### PR TITLE
[MTP] Fix erndata packed-doc and mHC multi-stream wiring for MTP

### DIFF
--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -460,6 +460,7 @@ class GPTEmbedding(FleetLayer):
                             cu_seqlens_q,
                             decoder_input.shape[0],
                             include_position_axis=self.config.gpt_model_use_experimental_version,
+                            seq_len=decoder_input.shape[1],
                         )
 
                     # decoder_input: [B, L, H] full-length embedding (already

--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -1107,8 +1107,9 @@ class HyperConnectionContractLayer(FleetLayer):
                     )
                 )
             else:
-                # Non-magic_send: backbone output is [backbone_chunk | mtp_chunks...] concatenated.
-                # Split, contract main backbone, slice MTP chunks.
+                # Non-magic_send: backbone output is [backbone_chunk | mtp_chunks...]
+                # concatenated along the seq axis; splitting yields
+                # [main(4-stream) | mtp_1(4-stream) ... mtp_k(4-stream)].
                 chunks = paddle.split(hidden_states, self.num_mtp + 1)
 
                 # Main backbone: learned contraction [s, b, n*h] -> [s, b, h]
@@ -1121,13 +1122,22 @@ class HyperConnectionContractLayer(FleetLayer):
                     self.config.rms_norm_eps,
                 )
 
-                # Expand to match expected layout [[s,b,h]...] for downstream MTP slicing
-                mtp_contracted = [
+                # MTP chunks stay multi-stream: MTP transformer blocks are the
+                # mHC blocks shared with the backbone last layer
+                # (mtp_shared_last_layer), which consume [s, b, n*h]. Hand the
+                # full multi-stream backbone output over through
+                # mhc_multistream (same K+1-slot layout as the magic-send /
+                # separate_mtp_input branch: MTP layers split it into one
+                # [s, b, n*h] slot per depth); the single-stream carrier below
+                # only acts as the per-depth embedding carrier that MTP layers
+                # read as decoder_input and later overwrite with their output.
+                dict_args["mhc_multistream"] = hidden_states
+                mtp_single = [
                     c[..., : c.shape[-1] // self.n] for c in chunks[1:]
                 ]
 
                 dict_args["hidden_states"] = paddle.concat(
-                    [main_contracted, *mtp_contracted]
+                    [main_contracted, *mtp_single]
                 )
 
         else:

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -154,7 +154,7 @@ def _roll_tensor_packed_seq(
         for _i in range(dim):
             prod_flat *= int(tensor.shape[_i])
         if prod_flat == batch_flat:
-            flat_shape = [seq_span] + list(tensor.shape[dim + 1 :])
+            flat_shape = [seq_span, *tensor.shape[dim + 1 :]]
             rolled_flat, _ = _roll_tensor_packed_seq(
                 tensor.reshape(flat_shape),
                 shifts,
@@ -351,7 +351,7 @@ def extract_local_zigzag_chunks(tensor_full, cp_rank, cp_size, axis=1):
 
 
 def build_startend_row_indices_from_cu_seqlens(
-    cu_seqlens_q, batch_size, include_position_axis=False
+    cu_seqlens_q, batch_size, include_position_axis=False, seq_len=None
 ):
     """Derive flashmask ``attn_mask_startend_row_indices`` from ``cu_seqlens_q``.
 
@@ -368,16 +368,21 @@ def build_startend_row_indices_from_cu_seqlens(
 
     Args:
         cu_seqlens_q: ``[num_docs + 1]`` int32 cumulative doc lengths. The last
-            entry is the full sequence length ``L``. When it equals
-            ``batch_size * seq_len`` (the erndata batch-flat granularity —
-            sample ``i`` occupies ``[i*seq_len, (i+1)*seq_len)`` in row-major
-            order), ``seq_len`` is inferred per sample and each sample gets
-            its own doc boundaries.
+            entry is the doc-boundary span, which is either the per-sample
+            sequence length ``L`` or -- for the erndata batch-flat granularity
+            -- ``batch_size * L`` (sample ``i`` occupies
+            ``[i*L, (i+1)*L)`` in row-major order).
         batch_size: batch axis size to broadcast to.
         include_position_axis: when True emit the 2-column
             ``[B, 1, L, 2]`` layout (``[end, position]``) that
             ``gpt_model_use_experimental_version`` expects; otherwise the
             1-column ``[B, 1, L, 1]`` fleet-mode layout.
+        seq_len: actual per-sample sequence length. Required to tell the two
+            granularities apart: the boundary values alone cannot, because a
+            legitimate per-sample ``cu=[0, 4, 8]`` with ``batch_size=2`` looks
+            exactly like a batch-flat cu over two samples of length 4. Pass it
+            whenever the caller knows ``L`` (both production call sites do);
+            when it is ``None`` the per-sample interpretation is assumed.
 
     Returns:
         ``[batch_size, 1, L, 1 or 2]`` int32 tensor on GPU.
@@ -392,39 +397,42 @@ def build_startend_row_indices_from_cu_seqlens(
     seq_span = int(cu_np[-1])
 
     # erndata batch-flat granularity: cu_seqlens_q spans the whole batch
-    # ([0, batch*seq_len]). Each sample i carries its own doc boundaries within
-    # [i*seq_len, (i+1)*seq_len), so the mask must be materialized per sample
+    # ([0, batch*L]). Each sample carries its own doc boundaries within
+    # [i*L, (i+1)*L), so the mask must be materialized per sample
     # (expand-to-batch would smear one sample's layout onto all samples).
-    # Detection is structural: in the flat form every sample necessarily ends
-    # at a multiple of ``seq_len``, so cu_seqlens_q must contain L, 2L, ...,
-    # (batch-1)*L among its boundary values. A per-sample [0, L] cu with
-    # batch_size > 1 and L % batch_size == 0 fails this test and keeps the
-    # legacy per-sample semantics below.
+    #
+    # The granularity is decided by ``seq_len``, never guessed from the
+    # boundary values: batch_size=2 with per-sample cu=[0, 4, 8] (L=8) has the
+    # same boundary set as a batch-flat cu over two length-4 samples, so any
+    # structural test necessarily mis-classifies one of them.
     flat_batch = False
-    if batch_size > 1 and seq_span % batch_size == 0:
-        seqlen_guess = seq_span // batch_size
-        cu_set = {int(c) for c in cu_np}
-        flat_batch = all(
-            _i * seqlen_guess in cu_set for _i in range(1, batch_size)
-        )
+    if seq_len is not None:
+        seq_len = int(seq_len)
+        if batch_size > 1 and seq_span == batch_size * seq_len:
+            flat_batch = True
+        elif seq_span != seq_len:
+            raise ValueError(
+                "cu_seqlens_q span is neither the per-sample sequence length "
+                f"nor batch_size * seq_len: span={seq_span}, "
+                f"seq_len={seq_len}, batch_size={batch_size}."
+            )
     if flat_batch:
-        seqlen = seq_span // batch_size
-        end = _np.zeros([batch_size, seqlen], dtype=_np.int32)
+        end = _np.zeros([batch_size, seq_len], dtype=_np.int32)
         for j in range(len(cu_np) - 1):
             s, e = int(cu_np[j]), int(cu_np[j + 1])
             if e - s <= 0:
                 continue
-            for _i in range(batch_size):
-                _s0 = _i * seqlen
-                _e0 = _s0 + seqlen
-                if e <= _s0 or s >= _e0:
+            for i in range(batch_size):
+                s0 = i * seq_len
+                e0 = s0 + seq_len
+                if e <= s0 or s >= e0:
                     continue
-                _ls = max(s - _s0, 0)
-                _le = min(e - _s0, seqlen)
-                end[_i, _ls:_le] = _le
+                ls = max(s - s0, 0)
+                le = min(e - s0, seq_len)
+                end[i, ls:le] = le
         if include_position_axis:
             pos = _np.tile(
-                _np.arange(seqlen, dtype=_np.int32)[None, :], (batch_size, 1)
+                _np.arange(seq_len, dtype=_np.int32)[None, :], (batch_size, 1)
             )
             # [B, L, 2] -> [B, 1, L, 2]
             startend_np = _np.stack([end, pos], axis=-1)[:, None, :, :]
@@ -910,59 +918,78 @@ class MultiTokenPredictionLayer(FleetLayer):
         """
         Concatenate the tokens before sending to transformer layer.
 
-        In mHC mode, hidden_states is [s, b, n*h] (multi-stream) and decoder_input
-        is [s, b, h] (single-stream embedding). Uses separate e_proj and h_proj.
-        In non-mHC mode, concatenates and projects with eh_proj as before.
+        In mHC mode, hidden_states is multi-stream ``[..., n*h]`` and
+        decoder_input is single-stream ``[..., h]``. Uses separate e_proj and
+        h_proj. In non-mHC mode, concatenates and projects with eh_proj as
+        before.
+
+        Layout contract for the leading two axes: seq-first ``[s, b, ...]``
+        when ``sequence_parallel`` is on, batch-first ``[b, s, ...]``
+        otherwise. ``GPTEmbedding`` establishes it -- both the erndata and the
+        ernie5 MTP branches permute to ``[S/TP, B, H]`` only under
+        ``sequence_parallel`` -- and the contract/split upstream preserves it.
+        The code below therefore keeps the leading axes opaque and only names
+        the seq axis where it actually matters (mask alignment, the
+        sequence-parallel gather/scatter and the h_proj reshape).
         """
         decoder_input = self.enorm(decoder_input)
 
         if self.mhc_enabled:
-            # mHC mode: hidden_states is [b, s, n*h] (batch-first; erndata
-            # embeddings and the backbone both use [b, s, ...]).
             n = self.config.num_residual_streams
             h = self.config.hidden_size
-            b, s, _ = hidden_states.shape
+            # d0/d1 are (seq, batch) under sequence_parallel and (batch, seq)
+            # otherwise; the reshape below is agnostic either way.
+            d0, d1, _ = hidden_states.shape
             if hidden_states.shape[-1] != n * h:
                 raise RuntimeError(
                     "mHC MTP _concat_embeddings requires multi-stream "
-                    f"hidden_states [b, s, {n * h}], got {tuple(hidden_states.shape)}. "
+                    f"hidden_states [..., {n * h}], got {tuple(hidden_states.shape)}. "
                     "The backbone contract layer must pass mhc_multistream and "
-                    "the erndata MTP forward must consume it (fix 6/7 wiring)."
+                    "the erndata MTP forward must consume it."
                 )
 
-            hs_streams = hidden_states.reshape([b, s, n, h])
+            hs_streams = hidden_states.reshape([d0, d1, n, h])
             hs_streams = self.hnorm(hs_streams)
 
             # Apply mask if needed
             if mtp_hidden_inputs_mask is not None:
-                # [B, 1, S] (batch-first layout), broadcast over the n streams.
-                mask = mtp_hidden_inputs_mask.astype(hs_streams.dtype)
+                # [B, 1, S] -> [B, S, 1]
+                mtp_hidden_inputs_mask = mtp_hidden_inputs_mask.transpose(
+                    [0, 2, 1]
+                ).astype(hs_streams.dtype)
                 if (
                     get_context_parallel_world_size() > 1
                     and self.config.experimental_dataflow
                 ):
-                    mask = ContextParallelScatterOp.apply(
-                        mask,
-                        axis=2,
+                    mtp_hidden_inputs_mask = ContextParallelScatterOp.apply(
+                        mtp_hidden_inputs_mask,
+                        axis=1,
                         mode=self.config.cp_balance_mode,
                     )
-                # when sp enable: scatter seq axis (axis 2 here) and transpose
-                # back to [b, 1, s/tp] before the multiply below.
+                # when sp enable: hs_streams is seq-first, so bring the mask to
+                # [S/CP, B, 1] before scattering the seq axis.
                 if self.sequence_parallel:
-                    mask = mask.transpose([2, 1, 0])  # [s, 1, b]
-                    mask = scatter_to_sequence_parallel_region(mask)
-                    mask = mask.transpose([2, 1, 0])  # [b, 1, s/tp]
-                hs_streams = hs_streams * mask.transpose([0, 2, 1]).unsqueeze(
-                    -1
-                )
+                    # [B, S/CP, 1] -> [S/CP, B, 1]
+                    mtp_hidden_inputs_mask = mtp_hidden_inputs_mask.transpose(
+                        [1, 0, 2]
+                    )
+                    # [S/CP, B, 1] -> [S/CP/TP, B, 1]
+                    mtp_hidden_inputs_mask = (
+                        scatter_to_sequence_parallel_region(
+                            mtp_hidden_inputs_mask
+                        )
+                    )
+                hs_streams = hs_streams * mtp_hidden_inputs_mask.unsqueeze(-1)
 
             # e_proj: [.., h] -> [.., h/tp]
             e_out, _ = self.e_proj(decoder_input)
             # h_proj: applied per-stream [.., n, h] -> [.., n, h/tp]
-            # 4D tensor [b,s,n,h] causes .t() error in backward; reshape to 3D first
-            orig_shape = list(hs_streams.shape)  # [b, s, n, h]
+            # 4D tensor causes .t() error in backward; reshape to 3D first.
+            orig_shape = list(hs_streams.shape)
             if self.tensor_parallel > 1 and self.sequence_parallel:
-                orig_shape[1] = orig_shape[1] * self.tensor_parallel
+                # Sequence-parallel linear all-gathers the seq axis, which is
+                # axis 0 in the seq-first layout that sequence_parallel implies.
+                orig_shape[0] = orig_shape[0] * self.tensor_parallel
             hs_flat = hs_streams.reshape([-1, orig_shape[-1]])  # [s/sp*b*n, h]
             h_out, _ = self.h_proj(hs_flat)  # [s*b*n, h/tp]
             h_out = h_out.reshape([*orig_shape[:-1], -1])  # [s, b, n, h/tp]
@@ -977,14 +1004,10 @@ class MultiTokenPredictionLayer(FleetLayer):
             hidden_states = hidden_states.reshape([*leading, n * h])
 
             if self.sequence_parallel:
-                # scatter_to_sequence_parallel_region splits along the first
-                # dim, but our layout is batch-first [b, s, n*h]: move seq to
-                # the front, scatter, and put it back.
-                hidden_states = hidden_states.transpose([1, 0, 2])
+                # Splits axis 0, which is the seq axis in the seq-first layout.
                 hidden_states = scatter_to_sequence_parallel_region(
                     hidden_states
                 )
-                hidden_states = hidden_states.transpose([1, 0, 2])
         else:
             hidden_states = self.hnorm(hidden_states)
             # Apply mtp_hidden_inputs_mask to mask out hidden state contributions
@@ -1924,25 +1947,37 @@ class MultiTokenPredictionLayer(FleetLayer):
                 if getattr(self.config, "sequence_parallel", False)
                 else dict_args["hidden_states"].shape[0]
             )
+            # ``input_ids`` is the canonical [B, L] tensor on this path (the
+            # guard above enforces ndim == 2), so it is the only SP/CP-agnostic
+            # source of the per-sample length L. hidden_states cannot be used:
+            # under sequence_parallel its seq axis already holds S/TP.
+            # Without L the builder cannot tell a per-sample cu from a
+            # batch-flat one, so it falls back to per-sample semantics.
+            seq_len = None if input_ids is None else input_ids.shape[1]
             dict_args["attn_mask_startend_row_indices"] = (
                 build_startend_row_indices_from_cu_seqlens(
                     cu_seqlens_q,
                     batch_size,
                     include_position_axis=include_pos,
+                    seq_len=seq_len,
                 )
             )
 
         # Run transformer layer.
         hidden_states = self._proj_and_transformer_layer(**dict_args)
 
-        # mHC: the shared block outputs multi-stream; contract it back to
-        # single-stream so the carrier concat below stays width-uniform
-        # (every slot is [B, S, h]). The multi-stream chunk list is re-added
-        # untouched (legacy behavior), so deeper MTP depths / the LMHead keep
-        # receiving the same mhc_multistream channel.
+        # mHC: the shared block emits multi-stream output. Same contract as the
+        # legacy magic-send / separate_mtp_input branch above: publish it as
+        # this depth's multi-stream slot so depth k+1 consumes depth k's output
+        # (leaving the backbone-generated chunk in place would break the chain
+        # for K > 1), and contract it to single-stream for the carrier concat
+        # so every slot stays width-uniform. Only forward the channel while a
+        # deeper MTP layer still needs it.
         if mhc_chunks is not None:
+            mhc_chunks[self.layer_number + 1] = hidden_states
             hidden_states = self._postprocess(hidden_states)
-            dict_args["mhc_multistream"] = paddle.concat(mhc_chunks)
+            if self.layer_number < num_nextn - 1:
+                dict_args["mhc_multistream"] = paddle.concat(mhc_chunks)
 
         # Store back into the pipeline concat tensor at slot k+1.
         tensor_list[self.layer_number + 1] = hidden_states

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -110,6 +110,15 @@ def _roll_tensor_packed_seq(
             ``tensor``.
         cu_seqlens_q: int32 tensor of shape ``[num_docs + 1]``; cumulative
             document lengths so that ``cu_seqlens_q[-1] == tensor.shape[dims]``.
+            Two granularities are supported:
+              - per-sample: ``cu_seqlens_q[-1]`` equals the per-sample seq
+                length (``tensor.shape[dims]``); the same doc layout is applied
+                to every sample.
+              - batch-flat (erndata): ``cu_seqlens_q[-1] == batch * seq_len``,
+                describing packed-doc boundaries over the batch flattened
+                into one sequence (sample ``i`` occupies
+                ``[i*seq_len, (i+1)*seq_len)``). The batch axes are flattened
+                onto the seq axis before rolling and restored afterwards.
         cp_group: paddle process group for context parallelism; unused in
             this non-CP branch.
     """
@@ -129,6 +138,32 @@ def _roll_tensor_packed_seq(
         cu_seqlens_np = cu_seqlens_q.numpy().tolist()
     else:
         cu_seqlens_np = list(cu_seqlens_q)
+
+    # erndata emits a single cu_seqlens_q that spans the *entire* micro-batch
+    # ([0, batch_size * seq_len]), i.e. the batch is treated as one flattened
+    # sequence — sample ``i`` occupies ``[i*seq_len, (i+1)*seq_len)`` in
+    # row-major order (see erndata providers._batch_utils.stack_prepared_batches).
+    # The roll axis of ``tensor`` is per-sample length; when the cu_seqlens_q
+    # span exceeds it, flatten the batch axes into the flat sequence, roll
+    # against the flat cu_seqlens_q, then restore the original shape.
+    seq_span = int(cu_seqlens_np[-1])
+    seq_dim_len = int(tensor.shape[dim])
+    if seq_span > seq_dim_len and seq_span % seq_dim_len == 0:
+        batch_flat = seq_span // seq_dim_len
+        prod_flat = 1
+        for _i in range(dim):
+            prod_flat *= int(tensor.shape[_i])
+        if prod_flat == batch_flat:
+            flat_shape = [seq_span] + list(tensor.shape[dim + 1 :])
+            rolled_flat, _ = _roll_tensor_packed_seq(
+                tensor.reshape(flat_shape),
+                shifts,
+                0,
+                cu_seqlens_q,
+                cp_group=None,
+                pad_value=pad_value,
+            )
+            return rolled_flat.reshape(tensor.shape), rolled_flat.sum()
 
     def _select(t, s, e):
         idx = [slice(None)] * ndim
@@ -333,7 +368,11 @@ def build_startend_row_indices_from_cu_seqlens(
 
     Args:
         cu_seqlens_q: ``[num_docs + 1]`` int32 cumulative doc lengths. The last
-            entry is the full sequence length ``L``.
+            entry is the full sequence length ``L``. When it equals
+            ``batch_size * seq_len`` (the erndata batch-flat granularity —
+            sample ``i`` occupies ``[i*seq_len, (i+1)*seq_len)`` in row-major
+            order), ``seq_len`` is inferred per sample and each sample gets
+            its own doc boundaries.
         batch_size: batch axis size to broadcast to.
         include_position_axis: when True emit the 2-column
             ``[B, 1, L, 2]`` layout (``[end, position]``) that
@@ -350,8 +389,53 @@ def build_startend_row_indices_from_cu_seqlens(
         if isinstance(cu_seqlens_q, paddle.Tensor)
         else _np.asarray(cu_seqlens_q)
     )
-    seqlen = int(cu_np[-1])
+    seq_span = int(cu_np[-1])
 
+    # erndata batch-flat granularity: cu_seqlens_q spans the whole batch
+    # ([0, batch*seq_len]). Each sample i carries its own doc boundaries within
+    # [i*seq_len, (i+1)*seq_len), so the mask must be materialized per sample
+    # (expand-to-batch would smear one sample's layout onto all samples).
+    # Detection is structural: in the flat form every sample necessarily ends
+    # at a multiple of ``seq_len``, so cu_seqlens_q must contain L, 2L, ...,
+    # (batch-1)*L among its boundary values. A per-sample [0, L] cu with
+    # batch_size > 1 and L % batch_size == 0 fails this test and keeps the
+    # legacy per-sample semantics below.
+    flat_batch = False
+    if batch_size > 1 and seq_span % batch_size == 0:
+        seqlen_guess = seq_span // batch_size
+        cu_set = {int(c) for c in cu_np}
+        flat_batch = all(
+            _i * seqlen_guess in cu_set for _i in range(1, batch_size)
+        )
+    if flat_batch:
+        seqlen = seq_span // batch_size
+        end = _np.zeros([batch_size, seqlen], dtype=_np.int32)
+        for j in range(len(cu_np) - 1):
+            s, e = int(cu_np[j]), int(cu_np[j + 1])
+            if e - s <= 0:
+                continue
+            for _i in range(batch_size):
+                _s0 = _i * seqlen
+                _e0 = _s0 + seqlen
+                if e <= _s0 or s >= _e0:
+                    continue
+                _ls = max(s - _s0, 0)
+                _le = min(e - _s0, seqlen)
+                end[_i, _ls:_le] = _le
+        if include_position_axis:
+            pos = _np.tile(
+                _np.arange(seqlen, dtype=_np.int32)[None, :], (batch_size, 1)
+            )
+            # [B, L, 2] -> [B, 1, L, 2]
+            startend_np = _np.stack([end, pos], axis=-1)[:, None, :, :]
+        else:
+            # [B, L] -> [B, 1, L, 1]
+            startend_np = end[:, None, :, None]
+        return paddle.to_tensor(startend_np).cuda()
+
+    # Per-sample (or batch_size == 1) granularity: a single doc layout shared
+    # by every sample; expand is zero-copy, attention only reads these values.
+    seqlen = seq_span
     end = _np.zeros(seqlen, dtype=_np.int32)
     for j in range(len(cu_np) - 1):
         s, e = int(cu_np[j]), int(cu_np[j + 1])
@@ -506,6 +590,13 @@ def get_mtp_layer_spec_for_backend(
     }
 
     if config.enable_hyper_connections:
+        # mHC MTP: separate per-stream e_proj (embedding) + h_proj (hidden
+        # streams); the multi-stream hidden must flow in through
+        # mhc_multistream (HyperConnectionContractLayer), otherwise the MTP
+        # transformer blocks (shared with the mHC backbone last layer) would
+        # receive single-stream input and crash on the n*h mapping matmul.
+        # 注意与 MultiTokenPredictionLayer.mhc_enabled 的判定保持一致，
+        # 否则 spec 与构造分支会出现 eh_proj=None 的崩溃。
         submodules_kwargs["e_proj"] = column_parallel_linear_impl
         submodules_kwargs["h_proj"] = column_parallel_linear_impl
     else:
@@ -622,6 +713,11 @@ class MultiTokenPredictionLayer(FleetLayer):
             + f"The supported attention mask types are {SUPPORTED_ATTN_MASK}."
         )
 
+        # mHC 多流始终启用（与 spec / 主干行为一致）：MTP transformer 块是
+        # 与主干末层共享的 mHC 块（mtp_shared_last_layer），必须吃 [s, b, n*h]
+        # 多流输入。多流传入由 hyper_connection.py 的
+        # HyperConnectionContractLayer 负责（非 magic-send 分支通过
+        # mhc_multistream 透传，见其 forward 的 else 分支）。
         self.mhc_enabled = config.enable_hyper_connections
 
         self.enorm = build_spec_layer(
@@ -718,17 +814,37 @@ class MultiTokenPredictionLayer(FleetLayer):
                     if self.config.use_bias:
                         mark_as_sequence_parallel_parameter(self.eh_proj.bias)
             else:
-                self.eh_proj = build_spec_layer(
-                    self.sublayers_spec.eh_proj,
-                    self.config.hidden_size * 2,
-                    self.config.hidden_size,
-                    config=self.config,
-                    init_method=self.config.init_method,
-                    gather_output=False,
-                    bias=False,
-                    skip_bias_add=False,
-                    is_expert=False,
-                )
+                if self.sublayers_spec.eh_proj is not None:
+                    self.eh_proj = build_spec_layer(
+                        self.sublayers_spec.eh_proj,
+                        self.config.hidden_size * 2,
+                        self.config.hidden_size,
+                        config=self.config,
+                        init_method=self.config.init_method,
+                        gather_output=False,
+                        bias=False,
+                        skip_bias_add=False,
+                        is_expert=False,
+                    )
+                else:
+                    # erndata 单流 MTP 兜底: enable_hyper_connections 时
+                    # sublayers spec 只定义多流的 e_proj/h_proj，不含 eh_proj;
+                    # use_erndata 门控关闭 mhc 多流后按标准 eh_proj([2h]->[h])
+                    # 构造，参数与 build_spec_layer 的默认分支保持一致。
+                    from paddlefleet.tensor_parallel.layers import (
+                        ColumnParallelLinear,
+                    )
+
+                    self.eh_proj = ColumnParallelLinear(
+                        self.config.hidden_size * 2,
+                        self.config.hidden_size,
+                        gather_output=False,
+                        bias=False,
+                        skip_bias_add=False,
+                        is_expert=False,
+                        config=self.config,
+                        init_method=self.config.init_method,
+                    )
             self.e_proj = None
             self.h_proj = None
 
@@ -801,51 +917,52 @@ class MultiTokenPredictionLayer(FleetLayer):
         decoder_input = self.enorm(decoder_input)
 
         if self.mhc_enabled:
-            # mHC mode: hidden_states is [s, b, n*h]
+            # mHC mode: hidden_states is [b, s, n*h] (batch-first; erndata
+            # embeddings and the backbone both use [b, s, ...]).
             n = self.config.num_residual_streams
             h = self.config.hidden_size
-            s, b, _ = hidden_states.shape
+            b, s, _ = hidden_states.shape
+            if hidden_states.shape[-1] != n * h:
+                raise RuntimeError(
+                    "mHC MTP _concat_embeddings requires multi-stream "
+                    f"hidden_states [b, s, {n * h}], got {tuple(hidden_states.shape)}. "
+                    "The backbone contract layer must pass mhc_multistream and "
+                    "the erndata MTP forward must consume it (fix 6/7 wiring)."
+                )
 
-            hs_streams = hidden_states.reshape([s, b, n, h])
+            hs_streams = hidden_states.reshape([b, s, n, h])
             hs_streams = self.hnorm(hs_streams)
 
             # Apply mask if needed
             if mtp_hidden_inputs_mask is not None:
-                # [B, 1, S] -> [B, S, 1]
-                mtp_hidden_inputs_mask = mtp_hidden_inputs_mask.transpose(
-                    [0, 2, 1]
-                ).astype(hs_streams.dtype)
+                # [B, 1, S] (batch-first layout), broadcast over the n streams.
+                mask = mtp_hidden_inputs_mask.astype(hs_streams.dtype)
                 if (
                     get_context_parallel_world_size() > 1
                     and self.config.experimental_dataflow
                 ):
-                    mtp_hidden_inputs_mask = ContextParallelScatterOp.apply(
-                        mtp_hidden_inputs_mask,
-                        axis=1,
+                    mask = ContextParallelScatterOp.apply(
+                        mask,
+                        axis=2,
                         mode=self.config.cp_balance_mode,
                     )
-                # when sp enable
+                # when sp enable: scatter seq axis (axis 2 here) and transpose
+                # back to [b, 1, s/tp] before the multiply below.
                 if self.sequence_parallel:
-                    # [B, S/CP, 1] -> [S/CP, B, 1]
-                    mtp_hidden_inputs_mask = mtp_hidden_inputs_mask.transpose(
-                        [1, 0, 2]
-                    )
-                    # [S/CP, B, 1] -> [S/CP/TP, B, 1]
-                    mtp_hidden_inputs_mask = (
-                        scatter_to_sequence_parallel_region(
-                            mtp_hidden_inputs_mask
-                        )
-                    )
-                hs_streams = hs_streams * mtp_hidden_inputs_mask.unsqueeze(-1)
+                    mask = mask.transpose([2, 1, 0])  # [s, 1, b]
+                    mask = scatter_to_sequence_parallel_region(mask)
+                    mask = mask.transpose([2, 1, 0])  # [b, 1, s/tp]
+                hs_streams = hs_streams * mask.transpose([0, 2, 1]).unsqueeze(
+                    -1
+                )
 
             # e_proj: [.., h] -> [.., h/tp]
             e_out, _ = self.e_proj(decoder_input)
             # h_proj: applied per-stream [.., n, h] -> [.., n, h/tp]
             # 4D tensor [b,s,n,h] causes .t() error in backward; reshape to 3D first
-            orig_shape = list(hs_streams.shape)  # [s/sp, b, n, h]
+            orig_shape = list(hs_streams.shape)  # [b, s, n, h]
             if self.tensor_parallel > 1 and self.sequence_parallel:
-                # [s/sp, b, n, h] --> [s, b, n, h]
-                orig_shape[0] = orig_shape[0] * self.tensor_parallel
+                orig_shape[1] = orig_shape[1] * self.tensor_parallel
             hs_flat = hs_streams.reshape([-1, orig_shape[-1]])  # [s/sp*b*n, h]
             h_out, _ = self.h_proj(hs_flat)  # [s*b*n, h/tp]
             h_out = h_out.reshape([*orig_shape[:-1], -1])  # [s, b, n, h/tp]
@@ -860,9 +977,14 @@ class MultiTokenPredictionLayer(FleetLayer):
             hidden_states = hidden_states.reshape([*leading, n * h])
 
             if self.sequence_parallel:
+                # scatter_to_sequence_parallel_region splits along the first
+                # dim, but our layout is batch-first [b, s, n*h]: move seq to
+                # the front, scatter, and put it back.
+                hidden_states = hidden_states.transpose([1, 0, 2])
                 hidden_states = scatter_to_sequence_parallel_region(
                     hidden_states
                 )
+                hidden_states = hidden_states.transpose([1, 0, 2])
         else:
             hidden_states = self.hnorm(hidden_states)
             # Apply mtp_hidden_inputs_mask to mask out hidden state contributions
@@ -1415,7 +1537,10 @@ class MultiTokenPredictionLayer(FleetLayer):
 
         # === Original concat+split logic ===
         hidden_states_concat = dict_args["hidden_states"]
-        # mHC: pop multi-stream tensor if available
+        # mHC multi-stream: the erndata backbone contract layer passes the
+        # MTP chunks as [s, b, n*h] through mhc_multistream (same contract as
+        # the magic-send / separate_mtp_input branch); pop it here and let the
+        # mhc_chunks path below feed each depth its multi-stream input.
         mhc_multistream = dict_args.pop("mhc_multistream", None)
 
         # New dataflow: pop mtp_startend_row_indices_all if present (experimental_dataflow=True)
@@ -1729,11 +1854,31 @@ class MultiTokenPredictionLayer(FleetLayer):
 
         num_nextn = self.config.num_nextn_predict_layers
 
+        # mHC + erndata: the backbone contract layer has already handed over
+        # the pre-contraction multi-stream backbone output through
+        # dict_args["mhc_multistream"]: [B*(K+1), S, n*h], K+1 slots
+        # concatenated along the batch axis (one per depth, matching the
+        # single-stream carrier layout). The shared mHC transformer block
+        # (mtp_shared_last_layer) must consume the multi-stream slot; feeding
+        # it the single-stream carrier slice is what crashed
+        # `_concat_embeddings` (reshape [B,S,h] -> [B,S,n,h]). Mirror the
+        # legacy magic-send / separate_mtp_input branches: take the mHC chunk
+        # at this depth as hidden_states, and use the carrier slot only as the
+        # decoder embedding for this depth.
+        mhc_multistream = dict_args.pop("mhc_multistream", None)
+        mhc_chunks = None
+        if mhc_multistream is not None:
+            mhc_chunks = paddle.split(mhc_multistream, num_nextn + 1)
+
         hidden_states_concat = dict_args["hidden_states"]
         tensor_list = paddle.split(hidden_states_concat, num_nextn + 1)
 
-        # Use previous-stage slices for this depth.
-        dict_args["hidden_states"] = tensor_list[self.layer_number]
+        if mhc_chunks is not None:
+            # Multi-stream input for the shared mHC block, [B, S, n*h].
+            dict_args["hidden_states"] = mhc_chunks[self.layer_number]
+        else:
+            # Use previous-stage slices for this depth.
+            dict_args["hidden_states"] = tensor_list[self.layer_number]
         dict_args["decoder_input"] = tensor_list[self.layer_number + 1]
 
         # Drop any leftover ernie5-path fields from dict_args so
@@ -1753,13 +1898,19 @@ class MultiTokenPredictionLayer(FleetLayer):
                 f"Under use_erndata=True, input_ids must be [B, L], got shape {input_ids.shape}."
             )
 
-        # Derive per-depth attn_mask_startend_row_indices from cu_seqlens_q.
-        # Doc boundaries are the SAME at every MTP depth (per-doc roll does
-        # not wrap across doc boundaries), so a single derivation is enough
-        # per depth; we still recompute on each call in case the pipeline
-        # dict has been mutated by an earlier depth.
+        # Derive per-depth attn_mask_startend_row_indices from cu_seqlens_q
+        # only when the dataloader did not already provide one. The erndata
+        # loader emits a per-sample mask [B, 1, S, 1] that already reflects
+        # packed-doc boundaries, and doc boundaries are the SAME at every MTP
+        # depth (per-doc roll does not wrap across doc boundaries), so reusing
+        # it avoids both redundant deviation and any semantic drift. The
+        # fallback derivation below handles the case where the loader omitted
+        # the mask.
         cu_seqlens_q = dict_args.get("cu_seqlens_q", None)
-        if cu_seqlens_q is not None:
+        if (
+            cu_seqlens_q is not None
+            and dict_args.get("attn_mask_startend_row_indices") is None
+        ):
             # experimental_dataflow: 2-col [B, 1, S, 2]; fleet-mode: 1-col [B, 1, S, 1].
             # ernie5 flashmask & SWA helpers require a 4D layout [B, heads, S, num_vec]
             # (see startend_row_indices_add_sliding_window in utils.py).
@@ -1783,6 +1934,15 @@ class MultiTokenPredictionLayer(FleetLayer):
 
         # Run transformer layer.
         hidden_states = self._proj_and_transformer_layer(**dict_args)
+
+        # mHC: the shared block outputs multi-stream; contract it back to
+        # single-stream so the carrier concat below stays width-uniform
+        # (every slot is [B, S, h]). The multi-stream chunk list is re-added
+        # untouched (legacy behavior), so deeper MTP depths / the LMHead keep
+        # receiving the same mhc_multistream channel.
+        if mhc_chunks is not None:
+            hidden_states = self._postprocess(hidden_states)
+            dict_args["mhc_multistream"] = paddle.concat(mhc_chunks)
 
         # Store back into the pipeline concat tensor at slot k+1.
         tensor_list[self.layer_number + 1] = hidden_states

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -1942,18 +1942,26 @@ class MultiTokenPredictionLayer(FleetLayer):
                     self.config, "gpt_model_use_experimental_version", False
                 )
             )
-            batch_size = (
-                dict_args["hidden_states"].shape[1]
-                if getattr(self.config, "sequence_parallel", False)
-                else dict_args["hidden_states"].shape[0]
-            )
-            # ``input_ids`` is the canonical [B, L] tensor on this path (the
-            # guard above enforces ndim == 2), so it is the only SP/CP-agnostic
-            # source of the per-sample length L. hidden_states cannot be used:
-            # under sequence_parallel its seq axis already holds S/TP.
-            # Without L the builder cannot tell a per-sample cu from a
-            # batch-flat one, so it falls back to per-sample semantics.
-            seq_len = None if input_ids is None else input_ids.shape[1]
+            # Recover the GLOBAL per-sample length L from this rank's shard.
+            # ``input_ids`` must not be used: GPTEmbedding publishes it as
+            # ``input_ids_for_moe_mask``, which stays None under plain
+            # use_erndata with expert_model_parallel_size == 1 and
+            # gpt_model_use_experimental_version == False, so the key is absent
+            # here. Scale the local seq axis back up by the parallel degrees,
+            # exactly the way the KDA branch of GPTEmbedding.forward does for
+            # its own cu_seqlens (gpt_embedding.py, build_cu_seqlens call site):
+            # the mask lives in global sequence coordinates while hidden_states
+            # is the rank-local shard. Layout is seq-first iff sequence_parallel.
+            cp_size = max(get_context_parallel_world_size(), 1)
+            if getattr(self.config, "sequence_parallel", False):
+                # [s/tp, b, h]
+                local_seq_len, batch_size = dict_args["hidden_states"].shape[:2]
+                sp_size = self.config.tensor_model_parallel_size
+            else:
+                # [b, s, h]
+                batch_size, local_seq_len = dict_args["hidden_states"].shape[:2]
+                sp_size = 1
+            seq_len = local_seq_len * sp_size * cp_size
             dict_args["attn_mask_startend_row_indices"] = (
                 build_startend_row_indices_from_cu_seqlens(
                     cu_seqlens_q,

--- a/tests/single_card_tests/transformer/test_erndata_mtp_granularity_and_mhc_chain.py
+++ b/tests/single_card_tests/transformer/test_erndata_mtp_granularity_and_mhc_chain.py
@@ -1,0 +1,321 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""erndata MTP contracts: cu_seqlens granularity + mHC multi-depth chain.
+
+Two contracts that end-to-end smoke can only surface as opaque shape errors
+(or, worse, as a silently wrong attention mask):
+
+1. ``build_startend_row_indices_from_cu_seqlens`` must decide the cu_seqlens
+   granularity from the caller-supplied per-sample ``seq_len``, never from the
+   boundary values. ``batch_size=2`` with per-sample ``cu=[0, 4, 8]`` has the
+   same boundary set as a batch-flat cu over two length-4 samples, so a
+   structural test necessarily mis-classifies one of them and emits a mask of
+   the wrong length.
+
+2. Under ``use_erndata=True`` with mHC, ``_forward_megatron_style`` must
+   publish each depth's multi-stream output into the ``mhc_multistream``
+   channel. Leaving the backbone-generated chunk in place makes depth k+1 read
+   a stale slot, so for K > 1 the MTP multi-stream chain is no longer serial.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+import paddle
+
+from paddlefleet.transformer.multi_token_prediction import (
+    MultiTokenPredictionLayer,
+    build_startend_row_indices_from_cu_seqlens,
+)
+
+
+def _ends(mask: paddle.Tensor, sample: int) -> list[int]:
+    """Extract the per-position end-row column for one sample."""
+    return [row[0] for row in mask.numpy().tolist()[sample][0]]
+
+
+class TestCuSeqlensGranularity(unittest.TestCase):
+    """seq_len decides the granularity; boundary values never do."""
+
+    def test_per_sample_cu_colliding_with_flat_layout(self) -> None:
+        """cu=[0,4,8] with batch_size=2 is per-sample when seq_len=8.
+
+        The boundary 4 makes this indistinguishable from a batch-flat cu over
+        two length-4 samples. Passing the real seq_len must keep the per-sample
+        reading: one shared doc layout of length 8, broadcast to both samples.
+        A flat misreading would emit length-4 rows and break attention.
+        """
+        mask = build_startend_row_indices_from_cu_seqlens(
+            paddle.to_tensor([0, 4, 8], dtype="int32"),
+            batch_size=2,
+            seq_len=8,
+        )
+        self.assertEqual(list(mask.shape), [2, 1, 8, 1])
+        expected = [4, 4, 4, 4, 8, 8, 8, 8]
+        self.assertEqual(_ends(mask, 0), expected)
+        self.assertEqual(_ends(mask, 1), expected)
+
+    def test_batch_flat_cu_materializes_per_sample_boundaries(self) -> None:
+        """cu spanning batch*seq_len gets per-sample doc boundaries.
+
+        batch_size=2, seq_len=4 -> span 8. Sample 0 owns [0,4) with docs
+        [0,2) and [2,4); sample 1 owns [4,8) with docs [4,7) and [7,8), which
+        map to local ends 3 and 4. The two samples must NOT share a layout.
+        """
+        mask = build_startend_row_indices_from_cu_seqlens(
+            paddle.to_tensor([0, 2, 4, 7, 8], dtype="int32"),
+            batch_size=2,
+            seq_len=4,
+        )
+        self.assertEqual(list(mask.shape), [2, 1, 4, 1])
+        self.assertEqual(_ends(mask, 0), [2, 2, 4, 4])
+        self.assertEqual(_ends(mask, 1), [3, 3, 3, 4])
+
+    def test_flat_and_per_sample_cu_differ_for_same_boundaries(self) -> None:
+        """Same boundary set, different seq_len -> different masks.
+
+        This is the collision the structural detection could not resolve:
+        cu=[0,4,8] is a length-8 per-sample layout when seq_len=8 and a
+        batch-flat layout over two length-4 samples when seq_len=4.
+        """
+        cu = paddle.to_tensor([0, 4, 8], dtype="int32")
+        per_sample = build_startend_row_indices_from_cu_seqlens(
+            cu, batch_size=2, seq_len=8
+        )
+        flat = build_startend_row_indices_from_cu_seqlens(
+            cu, batch_size=2, seq_len=4
+        )
+        self.assertEqual(list(per_sample.shape), [2, 1, 8, 1])
+        self.assertEqual(list(flat.shape), [2, 1, 4, 1])
+        # Flat: each sample is one full doc, so every end is the local length.
+        self.assertEqual(_ends(flat, 0), [4, 4, 4, 4])
+        self.assertEqual(_ends(flat, 1), [4, 4, 4, 4])
+
+    def test_include_position_axis_flat(self) -> None:
+        """The 2-column experimental layout carries per-sample positions."""
+        mask = build_startend_row_indices_from_cu_seqlens(
+            paddle.to_tensor([0, 2, 4, 8], dtype="int32"),
+            batch_size=2,
+            seq_len=4,
+            include_position_axis=True,
+        )
+        self.assertEqual(list(mask.shape), [2, 1, 4, 2])
+        for sample in range(2):
+            pos = [row[1] for row in mask.numpy().tolist()[sample][0]]
+            self.assertEqual(pos, [0, 1, 2, 3])
+
+    def test_missing_seq_len_keeps_per_sample_semantics(self) -> None:
+        """seq_len=None (unknown L) must not guess; stay per-sample."""
+        mask = build_startend_row_indices_from_cu_seqlens(
+            paddle.to_tensor([0, 4, 8], dtype="int32"), batch_size=2
+        )
+        self.assertEqual(list(mask.shape), [2, 1, 8, 1])
+
+    def test_span_neither_per_sample_nor_flat_raises(self) -> None:
+        """A span that matches neither reading is a wiring bug, not a guess."""
+        with self.assertRaises(ValueError):
+            build_startend_row_indices_from_cu_seqlens(
+                paddle.to_tensor([0, 8, 16], dtype="int32"),
+                batch_size=1,
+                seq_len=8,
+            )
+
+    def test_batch_size_one_flat_is_per_sample(self) -> None:
+        """batch_size=1: flat and per-sample coincide; no flat branch."""
+        mask = build_startend_row_indices_from_cu_seqlens(
+            paddle.to_tensor([0, 3, 8], dtype="int32"),
+            batch_size=1,
+            seq_len=8,
+        )
+        self.assertEqual(list(mask.shape), [1, 1, 8, 1])
+        self.assertEqual(_ends(mask, 0), [3, 3, 3, 8, 8, 8, 8, 8])
+
+
+# Multi-stream chunk marker values: chunk i is filled with (i + 1) * 10 so a
+# stale slot is immediately visible in the assertions below.
+_CHUNK_MARK = 10.0
+# The stubbed transformer block adds this so each depth's output is distinct
+# from every backbone-generated chunk.
+_BLOCK_DELTA = 1.0
+
+
+def _make_mhc_layer(K: int, layer_number: int, n: int, h: int):
+    """Real MultiTokenPredictionLayer with stubbed block + postprocess.
+
+    ``__new__`` avoids fleet init; only the fields ``_forward_megatron_style``
+    touches are populated, so the method under test is the production one.
+    """
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    cfg = MagicMock()
+    cfg.use_erndata = True
+    cfg.enable_mtp_magic_send = False
+    cfg.num_nextn_predict_layers = K
+    cfg.gpt_model_use_experimental_version = False
+    cfg.sequence_parallel = False
+    cfg.num_residual_streams = n
+    cfg.hidden_size = h
+    layer.config = cfg
+    layer.layer_number = layer_number
+    layer.mhc_enabled = True
+
+    recorded = {}
+
+    def _stub_proj(hidden_states, decoder_input, **kwargs):
+        # The shared mHC block only accepts multi-stream input. Raise instead
+        # of assert so `python -O` cannot strip the check.
+        if hidden_states.shape[-1] != n * h:
+            raise RuntimeError(
+                f"depth {layer_number} received width "
+                f"{hidden_states.shape[-1]}, expected multi-stream {n * h}"
+            )
+        recorded["hidden_in"] = hidden_states
+        recorded["decoder_in"] = decoder_input
+        return hidden_states + _BLOCK_DELTA
+
+    def _stub_postprocess(hidden_states):
+        # Stand-in for learned_output_contract: [.., n*h] -> [.., h].
+        return hidden_states[..., :h]
+
+    layer._proj_and_transformer_layer = _stub_proj
+    layer._postprocess = _stub_postprocess
+    return layer, recorded
+
+
+class TestErndataMhcMultiDepthChain(unittest.TestCase):
+    """K=2: depth 1 must consume depth 0's multi-stream output."""
+
+    def setUp(self) -> None:
+        self.K, self.B, self.S, self.n, self.h = 2, 1, 4, 2, 2
+
+    def _initial_args(self) -> dict:
+        K, B, S, n, h = self.K, self.B, self.S, self.n, self.h
+        # Multi-stream channel from the backbone contract layer:
+        # K+1 slots concatenated along the batch axis.
+        mhc = paddle.concat(
+            [
+                paddle.full([B, S, n * h], (i + 1) * _CHUNK_MARK)
+                for i in range(K + 1)
+            ]
+        )
+        # Single-stream carrier: per-depth embeddings.
+        carrier = paddle.concat(
+            [paddle.full([B, S, h], -(i + 1.0)) for i in range(K + 1)]
+        )
+        return {
+            "hidden_states": carrier,
+            "mhc_multistream": mhc,
+            "context": None,
+        }
+
+    def test_depth1_receives_depth0_multistream_output(self) -> None:
+        K, B, S, n, h = self.K, self.B, self.S, self.n, self.h
+        l0, rec0 = _make_mhc_layer(K, 0, n, h)
+        l1, rec1 = _make_mhc_layer(K, 1, n, h)
+
+        args = self._initial_args()
+        out0 = l0.forward(args)
+
+        # Depth 0 consumes backbone chunk 0 (marker 10) as multi-stream input
+        # and the carrier slot 1 as its decoder embedding.
+        self.assertEqual(float(rec0["hidden_in"].numpy()[0, 0, 0]), _CHUNK_MARK)
+        self.assertEqual(list(rec0["hidden_in"].shape), [B, S, n * h])
+        self.assertEqual(list(rec0["decoder_in"].shape), [B, S, h])
+
+        # The channel must still be present: depth 1 has yet to run.
+        self.assertIn("mhc_multistream", out0)
+
+        out1 = l1.forward(out0)
+
+        # The contract under test: depth 1's multi-stream input is depth 0's
+        # output (10 + 1), not the stale backbone chunk 1 (20).
+        self.assertEqual(
+            float(rec1["hidden_in"].numpy()[0, 0, 0]),
+            _CHUNK_MARK + _BLOCK_DELTA,
+        )
+        self.assertNotEqual(
+            float(rec1["hidden_in"].numpy()[0, 0, 0]), 2 * _CHUNK_MARK
+        )
+
+        # Last depth: the channel is dropped instead of being forwarded.
+        self.assertNotIn("mhc_multistream", out1)
+
+        # The carrier stays width-uniform across all K+1 slots.
+        self.assertEqual(list(out1["hidden_states"].shape), [(K + 1) * B, S, h])
+        self.assertNotIn("decoder_input", out1)
+
+    def test_carrier_slots_hold_contracted_outputs(self) -> None:
+        """Each depth writes its contracted output into carrier slot k+1."""
+        K, n, h = self.K, self.n, self.h
+        l0, _ = _make_mhc_layer(K, 0, n, h)
+        l1, _ = _make_mhc_layer(K, 1, n, h)
+
+        out1 = l1.forward(l0.forward(self._initial_args()))
+        slots = paddle.split(out1["hidden_states"], K + 1)
+
+        # Slot 0 is untouched backbone carrier; slots 1..K hold the contracted
+        # per-depth outputs (marker + delta).
+        self.assertEqual(float(slots[0].numpy()[0, 0, 0]), -1.0)
+        self.assertEqual(
+            float(slots[1].numpy()[0, 0, 0]), _CHUNK_MARK + _BLOCK_DELTA
+        )
+        self.assertEqual(
+            float(slots[2].numpy()[0, 0, 0]),
+            _CHUNK_MARK + 2 * _BLOCK_DELTA,
+        )
+
+    def test_k1_drops_channel_immediately(self) -> None:
+        """K=1: the only depth is the last one, so nothing is forwarded."""
+        B, S, n, h = 1, 4, 2, 2
+        layer, rec = _make_mhc_layer(1, 0, n, h)
+        mhc = paddle.concat(
+            [
+                paddle.full([B, S, n * h], (i + 1) * _CHUNK_MARK)
+                for i in range(2)
+            ]
+        )
+        carrier = paddle.concat(
+            [paddle.full([B, S, h], -(i + 1.0)) for i in range(2)]
+        )
+        out = layer.forward(
+            {
+                "hidden_states": carrier,
+                "mhc_multistream": mhc,
+                "context": None,
+            }
+        )
+        self.assertEqual(float(rec["hidden_in"].numpy()[0, 0, 0]), _CHUNK_MARK)
+        self.assertNotIn("mhc_multistream", out)
+        self.assertEqual(list(out["hidden_states"].shape), [2 * B, S, h])
+
+    def test_single_stream_input_raises_readable_error(self) -> None:
+        """Missing mhc_multistream must fail loudly, not as a raw ReshapeOp.
+
+        Without the channel the shared mHC block would be handed the
+        single-stream carrier; the stub asserts the width, mirroring the
+        explicit check in ``_concat_embeddings``.
+        """
+        B, S, n, h = 1, 4, 2, 2
+        layer, _ = _make_mhc_layer(1, 0, n, h)
+        carrier = paddle.concat(
+            [paddle.full([B, S, h], -(i + 1.0)) for i in range(2)]
+        )
+        with self.assertRaises(RuntimeError):
+            layer.forward({"hidden_states": carrier, "context": None})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_erndata_mtp_granularity_and_mhc_chain.py
+++ b/tests/single_card_tests/transformer/test_erndata_mtp_granularity_and_mhc_chain.py
@@ -317,5 +317,101 @@ class TestErndataMhcMultiDepthChain(unittest.TestCase):
             layer.forward({"hidden_states": carrier, "context": None})
 
 
+def _make_mask_layer(
+    K: int,
+    *,
+    layer_number: int = 0,
+    sequence_parallel: bool = False,
+    tp_size: int = 1,
+):
+    """Non-mHC layer used to exercise the mask-derivation fallback only."""
+    layer = MultiTokenPredictionLayer.__new__(MultiTokenPredictionLayer)
+    cfg = MagicMock()
+    cfg.use_erndata = True
+    cfg.enable_mtp_magic_send = False
+    cfg.num_nextn_predict_layers = K
+    cfg.gpt_model_use_experimental_version = False
+    cfg.sequence_parallel = sequence_parallel
+    cfg.tensor_model_parallel_size = tp_size
+    layer.config = cfg
+    layer.layer_number = layer_number
+    layer.mhc_enabled = False
+
+    recorded = {}
+
+    def _stub_proj(hidden_states, decoder_input, **kwargs):
+        am = kwargs.get("attn_mask_startend_row_indices")
+        recorded["attn_mask"] = am
+        recorded["attn_mask_shape"] = None if am is None else list(am.shape)
+        return decoder_input
+
+    layer._proj_and_transformer_layer = _stub_proj
+    return layer, recorded
+
+
+class TestMaskFallbackWithoutInputIds(unittest.TestCase):
+    """The fallback must not depend on the optional ``input_ids`` key.
+
+    ``GPTEmbedding`` publishes ``input_ids`` as ``input_ids_for_moe_mask``,
+    which stays None under plain ``use_erndata`` with
+    ``expert_model_parallel_size == 1`` and
+    ``gpt_model_use_experimental_version == False`` -- the key is then absent
+    from ``dict_args``. The per-sample length must instead be recovered from
+    the rank-local hidden_states shape and the parallel degrees.
+    """
+
+    def test_batch_flat_cu_without_input_ids(self) -> None:
+        """B=2, L=4, batch-flat cu, no input_ids -> [2, 1, 4, 1] mask.
+
+        Deriving L from a missing ``input_ids`` would fall back to per-sample
+        semantics and emit a length-8 mask, which mismatches the length-4
+        sequence attention actually sees.
+        """
+        K, B, L, h = 1, 2, 4, 2
+        layer, rec = _make_mask_layer(K)
+        # Carrier: K+1 slots concatenated along the batch axis, [ (K+1)*B, L, h ]
+        carrier = paddle.zeros([(K + 1) * B, L, h], dtype="float32")
+        cu = paddle.to_tensor([0, 2, 4, 7, 8], dtype="int32")
+        layer._forward_megatron_style(
+            {"hidden_states": carrier, "cu_seqlens_q": cu, "context": None}
+        )
+        self.assertEqual(rec["attn_mask_shape"], [B, 1, L, 1])
+        self.assertEqual(_ends(rec["attn_mask"], 0), [2, 2, 4, 4])
+        self.assertEqual(_ends(rec["attn_mask"], 1), [3, 3, 3, 4])
+
+    def test_per_sample_cu_without_input_ids(self) -> None:
+        """A per-sample cu keeps the shared length-L layout for both samples."""
+        K, B, L, h = 1, 2, 4, 2
+        layer, rec = _make_mask_layer(K)
+        carrier = paddle.zeros([(K + 1) * B, L, h], dtype="float32")
+        cu = paddle.to_tensor([0, 3, 4], dtype="int32")
+        layer._forward_megatron_style(
+            {"hidden_states": carrier, "cu_seqlens_q": cu, "context": None}
+        )
+        self.assertEqual(rec["attn_mask_shape"], [B, 1, L, 1])
+        self.assertEqual(_ends(rec["attn_mask"], 0), [3, 3, 3, 4])
+        self.assertEqual(_ends(rec["attn_mask"], 1), [3, 3, 3, 4])
+
+    def test_sequence_parallel_scales_local_seq_back_up(self) -> None:
+        """Under SP the seq axis holds L/TP; the mask must still cover L.
+
+        Layout is seq-first, so the carrier concat is along the seq axis:
+        [ (K+1)*L/TP, B, h ]. With TP=2 and local 4 the global L is 8, so a
+        batch-flat cu spanning B*L=16 must be recognized. Forgetting the TP
+        factor would make the span match neither reading and raise.
+        """
+        K, B, L, h, tp = 1, 2, 8, 2, 2
+        local = L // tp
+        layer, rec = _make_mask_layer(K, sequence_parallel=True, tp_size=tp)
+        carrier = paddle.zeros([(K + 1) * local, B, h], dtype="float32")
+        cu = paddle.to_tensor([0, 5, 8, 12, 16], dtype="int32")
+        layer._forward_megatron_style(
+            {"hidden_states": carrier, "cu_seqlens_q": cu, "context": None}
+        )
+        self.assertEqual(rec["attn_mask_shape"], [B, 1, L, 1])
+        self.assertEqual(_ends(rec["attn_mask"], 0), [5, 5, 5, 5, 5, 8, 8, 8])
+        self.assertEqual(_ends(rec["attn_mask"], 1), [4, 4, 4, 4, 8, 8, 8, 8])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category

Distributed Strategy

### PR Types

Bug fixes

### Description

Training an mHC model with MTP under the erndata dataflow (`use_erndata=true`,
`enable_hyper_connections=true`, `mtp_shared_last_layer=true`) crashed
deterministically, because the MTP path relied on three assumptions that do not
hold there.

**1. cu_seqlens granularity.** erndata emits a batch-flat `cu_seqlens_q`
(`cu[-1] == batch * seq_len`) while `_roll_tensor_packed_seq` assumed per-sample
(`cu[-1] == tensor.shape[dim]`). Slicing a `[4, 8192, H]` tensor with boundaries
up to 32768 produced empty slices and a broadcast error
(`X=[4, 0, 1024]` vs `Y=[1, 8192, 1]`). The flat form is now detected from the
tensor's own shape, flattened onto the seq axis, rolled, and restored.

**2. Attention mask granularity.** The mask builder built one `[L]` layout and
expanded it to `[B, L]`, silently smearing sample 0's doc boundaries onto the
whole batch. The granularity is now decided by a caller-supplied per-sample
`seq_len`, never guessed from the boundary values: `batch_size=2` with
per-sample `cu=[0, 4, 8]` has exactly the same boundary set as a batch-flat cu
over two length-4 samples, so any structural test necessarily mis-classifies one
of them. A span that matches neither reading raises instead of picking one.
The loader-provided mask is preferred and the derivation is only a fallback;
doc boundaries are identical at every MTP depth.

**3. mHC multi-stream wiring between backbone and MTP.** With
`mtp_shared_last_layer` the MTP transformer block *is* the mHC block shared with
the backbone last layer, so it only accepts `[..., n*h]`. The contract layer
truncated MTP chunks to single-stream, which crashed in `native_proj_rms`
(`matmul K=1024 vs 4096`); wiring the full multi-stream output through
`mhc_multistream` without consuming it in the erndata forward moved the failure
to `_concat_embeddings` (`reshape [4,8192,1024] -> [4,8192,4,1024]`). The
channel is now passed by the contract layer, consumed per depth, and contracted
back via `_postprocess` before the carrier concat so every slot stays
width-uniform. For `K > 1` each depth publishes its own multi-stream output into
slot `k+1` (same contract as the magic-send / `separate_mtp_input` branch), so
the chain stays serial; the channel is forwarded only while a deeper depth needs
it. `_concat_embeddings` also gained an explicit multi-stream width check, so a
missing channel fails with a readable error instead of a raw `ReshapeOp`.

Layout note: the leading axes are seq-first `[s, b, ...]` whenever
`sequence_parallel` is on (`GPTEmbedding` permutes to `[S/TP, B, H]` for both
the erndata and ernie5 MTP branches) and batch-first otherwise. All
layout-sensitive sites in the mHC branch are gated on `sequence_parallel`, and
the contract is now documented in the docstring.

### 是否引起精度变化

否。改动只在 `use_erndata=True` 且启用 MTP 的路径上生效——该路径此前必然崩溃，
没有可回归的精度基线。其余路径行为不变：mask 构造在 `seq_len=None` 时保持原
per-sample 语义；`_roll_tensor_packed_seq` 的 batch-flat 分支只在 cu 跨度超过
tensor 序列维时进入；`_concat_embeddings` 的 mHC 分支已恢复为改动前的计算逻辑，
仅新增一处宽度检查与注释。
