### PR TITLE
[cherry-pick] Fix single-node shrink for dsv4-style configs (#1907)

### DIFF
--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -70,6 +70,13 @@ ADAPTER_CONTROLLED_FIELDS = frozenset(
 )
 
 
+def _yaml_truthy(value):
+    """Loose YAML bool: accepts real bools plus "true"/"yes"/"1" spellings."""
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "yes", "on", "1"}
+    return bool(value)
+
+
 class ConfigAdapter:
     """Rewrites one training YAML (and its model_config.json) for a scale."""
 
@@ -240,6 +247,8 @@ class ConfigAdapter:
         )
         if err:
             return False, f"{input_path.name}: {err}"
+
+        self._drop_stale_checkpoint_refs(config, log, dims_before, dims_after)
 
         # Nothing has touched the filesystem up to this point: every rewrite
         # above happened in memory, so a validation failure leaves both source
@@ -506,9 +515,19 @@ class ConfigAdapter:
                 f"GBS 由框架按实际卡数反推"
             )
         else:
+            # The trainer asserts GBS == micro_bs * acc * dataset_world_size,
+            # so batch fields must scale with the data-parallel width, not
+            # the card count (the two differ whenever EP/PP/CP change).
+            orig_units = self._dataset_ways(orig_cards, dims_before)
+            new_units = self._dataset_ways(self.target_cards, dims_after)
+            if orig_units and new_units:
+                unit = "数据并行路数"
+            else:
+                orig_units, new_units = orig_cards, self.target_cards
+                unit = "卡数"
             strategy = BATCH_STRATEGIES[self.options.batch_strategy]
             batch_map, reason, err = strategy(
-                gbs, grad_accum, orig_cards, self.target_cards
+                gbs, grad_accum, orig_units, new_units, unit=unit
             )
             if err:
                 return err
@@ -551,6 +570,37 @@ class ConfigAdapter:
                 "数据并行度由 sharding 承担",
             )
 
+        # muon_sharding_optimizer asserts that comm_group_call_opt is only
+        # enabled when EP is a multiple of gpus_per_node, moe_sharding > 1
+        # and TP == 1, and PaddleFormers' TrainingArguments additionally
+        # asserts optim == muon whenever the switch is on; a shrunk EP (or a
+        # non-Muon optimizer) easily violates that, so drop the switch
+        # instead of shipping a config that dies on these asserts at startup.
+        if _yaml_truthy(config.get("sharding_comm_group_call_opt")):
+            moe_sharding = self.target_cards // (pp * ep)
+            optim = str(config.get("optim") or "").strip().lower()
+            group_call_ok = (
+                optim == "muon"
+                and self.cards_per_node > 1
+                and ep % self.cards_per_node == 0
+                and moe_sharding > 1
+                and tp == 1
+            )
+            if not group_call_ok:
+                log.record(
+                    "yaml",
+                    self.yaml_writer.apply_config_map(
+                        config,
+                        {"sharding_comm_group_call_opt": False},
+                        protected=self.yaml_overrides,
+                    ),
+                    f"框架断言 comm_group_call_opt 只能在优化器为 muon、"
+                    f"EP 是每节点卡数的整数倍、moe_sharding>1 且 TP=1 时"
+                    f"开启；当前 optim={optim or '未设置'}、EP={ep}、每节点 "
+                    f"{self.cards_per_node} 卡、moe_sharding={moe_sharding}、"
+                    f"TP={tp} 不满足，关闭该优化以免启动即断言失败",
+                )
+
         # C4 was validated above, so both divisions are exact.
         switches = plan_sharding_shrink_switches(
             config,
@@ -568,6 +618,47 @@ class ConfigAdapter:
                 reason,
             )
         return None
+
+    def _drop_stale_checkpoint_refs(self, config, log, dims_before, dims_after):
+        """Drop checkpoint references once the model structure has shrunk.
+
+        Shrinking EP rescales ``n_routed_experts`` and shrinking PP rescales
+        ``num_hidden_layers``, so a checkpoint produced by the full-scale run
+        no longer matches the adapted model.  Loading it anyway yields a
+        silently corrupted model: the forward pass still runs (loss even looks
+        plausible), but gradients blow up to NaN on the very first step.
+        Dropping the reference falls back to random init, which is the only
+        well-defined starting point for a shrunk smoke test.
+        """
+        tp_b, pp_b, ep_b, cp_b, sep_b = dims_before
+        tp_a, pp_a, ep_a, cp_a, sep_a = dims_after
+        if ep_a >= ep_b and pp_a >= pp_b:
+            return
+        shrunk = []
+        if ep_a < ep_b:
+            shrunk.append(f"EP {ep_b}->{ep_a}（专家数等比缩减）")
+        if pp_a < pp_b:
+            shrunk.append(f"PP {pp_b}->{pp_a}（层数等比缩减）")
+        reason = (
+            f"{'、'.join(shrunk)}后模型结构与原 checkpoint 不再匹配，"
+            f"加载会得到权重错乱的模型（首步梯度即 NaN）；"
+            f"摘除加载入口，改用随机初始化"
+        )
+        for key in ("resume_from_checkpoint",):
+            if key in config and key not in self.yaml_overrides:
+                log.record_removed("yaml", key, config.pop(key), reason)
+        if _yaml_truthy(config.get("load_from_hf")) and (
+            "load_from_hf" not in self.yaml_overrides
+        ):
+            log.record(
+                "yaml",
+                self.yaml_writer.apply_config_map(
+                    config,
+                    {"load_from_hf": False},
+                    protected=self.yaml_overrides,
+                ),
+                reason,
+            )
 
     @staticmethod
     def _dataset_ways(cards, dims):

--- a/src/paddlefleet/config_adapter/layer_fields.py
+++ b/src/paddlefleet/config_adapter/layer_fields.py
@@ -49,7 +49,13 @@ from collections import namedtuple
 LayerField = namedtuple("LayerField", ["aliases", "includes_mtp", "families"])
 
 LAYER_FIELDS = (
-    LayerField(("csa_compress_ratios",), includes_mtp=True, families=True),
+    # "compress_ratios" is the HF-style spelling: DeepseekV4ModelProvider
+    # transform_rules map it to csa_compress_ratios verbatim.
+    LayerField(
+        ("csa_compress_ratios", "compress_ratios"),
+        includes_mtp=True,
+        families=True,
+    ),
     LayerField(("window_attn_skip_freq",), includes_mtp=True, families=False),
     LayerField(("layer_types",), includes_mtp=False, families=False),
     LayerField(("moe_layer_freq",), includes_mtp=False, families=False),

--- a/src/paddlefleet/config_adapter/strategies.py
+++ b/src/paddlefleet/config_adapter/strategies.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""How batch settings follow the GPU count. One strategy per test profile.
+"""How batch settings follow the data-parallel width, one per test profile.
 
 * ``--test-performance`` -> :func:`scale_batch`: shrink ``global_batch_size``
   proportionally and keep ``gradient_accumulation_steps``, so per-step work
@@ -22,6 +22,13 @@
   factor, so the effective batch (and therefore the loss curve) matches the
   full-scale run.
 
+Scaling must follow ``dataset_world_size`` (= cards / (TP*SEP*PP*CP)), not
+the raw card count: the trainer asserts ``GBS == micro_bs * acc *
+dataset_world_size``, and when the adapter also shrinks EP/PP/CP the two
+ratios differ.  The caller passes the before/after data-parallel widths as
+``orig_units`` / ``target_units`` (falling back to card counts, with a
+matching ``unit`` label, only when a width cannot be derived).
+
 Neither strategy touches parallelism dimensions.  Both return
 ``(config_map, reason, error)``; a non-empty ``error`` aborts adaptation
 rather than silently rounding.
@@ -29,9 +36,11 @@ rather than silently rounding.
 
 from __future__ import annotations
 
+DEFAULT_UNIT = "数据并行路数"
 
-def scale_batch(gbs, grad_accum, orig_cards, target_cards):
-    """Shrink GBS proportionally to the card count, keep grad_accum."""
+
+def scale_batch(gbs, grad_accum, orig_units, target_units, unit=DEFAULT_UNIT):
+    """Shrink GBS proportionally to the DP width, keep grad_accum."""
     if gbs is None:
         return (
             {"gradient_accumulation_steps": grad_accum},
@@ -40,16 +49,16 @@ def scale_batch(gbs, grad_accum, orig_cards, target_cards):
             None,
         )
 
-    if gbs * target_cards % orig_cards != 0:
+    if gbs * target_units % orig_units != 0:
         return (
             None,
             "",
-            f"GBS 无法整除：{gbs} × {target_cards} / {orig_cards} = "
-            f"{gbs * target_cards / orig_cards}，"
+            f"GBS 无法整除：{gbs} × {target_units} / {orig_units} = "
+            f"{gbs * target_units / orig_units}，"
             f"请换一个能整除的目标机器规模",
         )
 
-    new_gbs = gbs * target_cards // orig_cards
+    new_gbs = gbs * target_units // orig_units
     if new_gbs <= 0:
         return None, "", f"缩放后 GBS={new_gbs} <= 0，目标机器规模太小"
 
@@ -58,13 +67,15 @@ def scale_batch(gbs, grad_accum, orig_cards, target_cards):
             "global_batch_size": new_gbs,
             "gradient_accumulation_steps": grad_accum,
         },
-        f"GBS 按卡数等比缩放 {gbs} × {target_cards} / "
-        f"{orig_cards} = {new_gbs}，acc 保持 {grad_accum} 不变",
+        f"GBS 按{unit}等比缩放 {gbs} × {target_units} / "
+        f"{orig_units} = {new_gbs}，acc 保持 {grad_accum} 不变",
         None,
     )
 
 
-def scale_accumulation(gbs, grad_accum, orig_cards, target_cards):
+def scale_accumulation(
+    gbs, grad_accum, orig_units, target_units, unit=DEFAULT_UNIT
+):
     """Keep GBS, raise grad_accum so the effective batch is unchanged."""
     if gbs is None:
         return (
@@ -73,16 +84,16 @@ def scale_accumulation(gbs, grad_accum, orig_cards, target_cards):
             None,
         )
 
-    if grad_accum * orig_cards % target_cards != 0:
+    if grad_accum * orig_units % target_units != 0:
         return (
             None,
             "",
-            f"acc 无法整除：{grad_accum} × {orig_cards} / {target_cards} = "
-            f"{grad_accum * orig_cards / target_cards}，"
+            f"acc 无法整除：{grad_accum} × {orig_units} / {target_units} = "
+            f"{grad_accum * orig_units / target_units}，"
             f"请换一个能整除的目标机器规模",
         )
 
-    new_grad_accum = grad_accum * orig_cards // target_cards
+    new_grad_accum = grad_accum * orig_units // target_units
     if new_grad_accum <= 0:
         return None, "", f"缩放后 acc={new_grad_accum} <= 0"
 
@@ -91,8 +102,8 @@ def scale_accumulation(gbs, grad_accum, orig_cards, target_cards):
             "global_batch_size": gbs,
             "gradient_accumulation_steps": new_grad_accum,
         },
-        f"保持等效 batch：GBS 保持 {gbs} 不变，acc 放大为 {grad_accum} × "
-        f"{orig_cards} / {target_cards} = {new_grad_accum}",
+        f"保持等效 batch：GBS 保持 {gbs} 不变，acc 按{unit}放大为 "
+        f"{grad_accum} × {orig_units} / {target_units} = {new_grad_accum}",
         None,
     )
 

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -985,6 +985,29 @@ class StandardMoERouter(nn.Layer):
             raise ValueError(
                 "tid2eid buffer is not registered; hash routing is not initialized."
             )
+        if not getattr(self, "_tid2eid_range_checked", False):
+            # A pretrained tid2eid loaded from a checkpoint may target a
+            # larger expert count than this model (e.g. a full-size HF
+            # checkpoint loaded into a shrunk config). Out-of-range ids would
+            # otherwise surface as an undebuggable device-side gather assert
+            # (CUDA error 719) on some later async op, so fail fast here with
+            # the actual root cause. A no-op when the table already matches.
+            max_eid = int(self.tid2eid.max().item())
+            min_eid = int(self.tid2eid.min().item())
+            if min_eid < 0 or max_eid >= self.num_experts:
+                raise ValueError(
+                    f"tid2eid contains expert ids in [{min_eid}, {max_eid}] "
+                    f"but this model only accepts [0, {self.num_experts - 1}]"
+                    f" ({self.num_experts} routed experts): the pretrained "
+                    f"hash-routing table does not match this model's "
+                    f"structure (e.g. it was built for a larger expert "
+                    f"count, or it carries negative sentinel values). Fix "
+                    f"the config/checkpoint pairing (do not load a "
+                    f"full-size checkpoint into a shrunk model) or drop "
+                    f"resume_from_checkpoint/load_from_hf to start from "
+                    f"random init."
+                )
+            self._tid2eid_range_checked = True
         score_function = self.scoring_func
         orig_dtype = logits.dtype
         logits_fp32 = logits.cast("float32")

--- a/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
+++ b/tests/single_card_tests/ai_edited_test/moe/test_ai_moe_router.py
@@ -802,6 +802,28 @@ class TestHashRouter(unittest.TestCase):
         with self.assertRaises(ValueError):
             router(hidden, input_ids=input_ids)
 
+    def test_tid2eid_out_of_range_fails_fast(self):
+        """A pretrained tid2eid built for a larger expert count must raise
+        up front instead of crashing later in a device-side gather."""
+        router, _ = self._make_router(n_routed_experts=4, num_experts_per_tok=2)
+        # Simulate a full-size checkpoint table loaded into a shrunk model:
+        # expert id 7 is out of range for 4 routed experts.
+        router.tid2eid = paddle.full_like(router.tid2eid, 7)
+        hidden = self._dummy_hidden(1, 2)
+        input_ids = paddle.to_tensor([[1, 2]], dtype="int64")
+        with self.assertRaisesRegex(ValueError, "routed experts"):
+            router(hidden, input_ids=input_ids)
+
+    def test_tid2eid_negative_ids_fail_fast(self):
+        """Negative expert ids (e.g. sentinel values) must be rejected too:
+        they would silently gather the wrong expert instead of asserting."""
+        router, _ = self._make_router(n_routed_experts=4, num_experts_per_tok=2)
+        router.tid2eid = paddle.full_like(router.tid2eid, -1)
+        hidden = self._dummy_hidden(1, 2)
+        input_ids = paddle.to_tensor([[1, 2]], dtype="int64")
+        with self.assertRaisesRegex(ValueError, r"\[0, 3\]"):
+            router(hidden, input_ids=input_ids)
+
     def test_noaux_tc_drops_bias_buffers(self):
         """Hash layer with noaux_tc topk_method should delete
         e_score_correction_bias and expert_usage buffers."""

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -1032,14 +1032,88 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
         self.assertEqual(config["sharding_parallel_size"], 2)
         self.assertEqual(model_config["n_routed_experts"], 8)
         self.assertEqual(model_config["num_hidden_layers"], 32)
-        # Default batch strategy shrinks GBS and leaves acc alone.
-        self.assertEqual(config["global_batch_size"], 2)
+        # Default batch strategy shrinks GBS and leaves acc alone.  GBS
+        # follows the data-parallel width (96 -> 2), not the card count:
+        # the trainer asserts GBS == micro_bs * acc * dataset_world_size,
+        # so 8 cards / PP 4 give width 2 and GBS = 1 * 2 * 2 = 4.
+        self.assertEqual(config["global_batch_size"], 4)
         self.assertEqual(config["gradient_accumulation_steps"], 2)
         # No determinism switches unless --test-accuracy is given.
         self.assertEqual(config["csa_sparse_attn_backend"], "cudnn")
         self.assertEqual(model_config["multimax_modules"], ["lm_head"])
         # Environment-specific pin is always dropped.
         self.assertNotIn("fa_version", config)
+
+    def test_stale_checkpoint_refs_are_dropped_when_structure_shrinks(self):
+        # Shrinking EP/PP rescales n_routed_experts / num_hidden_layers, so a
+        # full-scale checkpoint no longer matches; loading it anyway produces
+        # NaN gradients on step 1. The adapter must fall back to random init.
+        self.write_yaml(
+            SOURCE_YAML
+            + "resume_from_checkpoint: /ckpt/full_scale_base\n"
+            + "load_from_hf: true\n"
+        )
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        config = self.load_output_yaml(8)
+        self.assertNotIn("resume_from_checkpoint", config)
+        self.assertEqual(config["load_from_hf"], False)
+
+    def test_comm_group_call_opt_is_dropped_when_shrunk_ep_violates_it(self):
+        # muon_sharding_optimizer only allows the switch when EP is a multiple
+        # of gpus_per_node (8); EP shrinks to 2 here, so the adapter must turn
+        # it off instead of shipping a config that dies on the assert.  The
+        # quoted "True" also exercises the loose YAML bool parsing.
+        self.write_yaml(SOURCE_YAML + 'sharding_comm_group_call_opt: "True"\n')
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        config = self.load_output_yaml(8)
+        self.assertEqual(config["expert_model_parallel_size"], 2)
+        self.assertEqual(config["sharding_comm_group_call_opt"], False)
+
+    def test_comm_group_call_opt_requires_the_muon_optimizer(self):
+        # PaddleFormers' TrainingArguments asserts optim == muon whenever the
+        # switch is on, so satisfying the EP/moe_sharding/TP conditions is not
+        # enough: 128 nodes with the frozen source dims give EP 64 (a multiple
+        # of 8), moe_sharding 2 and TP 1, yet adamw must still drop the flag.
+        self.write_yaml(
+            SOURCE_YAML
+            + "optim: adamw\n"
+            + 'sharding_comm_group_call_opt: "True"\n'
+        )
+        ok, message = self.adapt(target_nodes=128, test_performance=True)
+        self.assertTrue(ok, message)
+        config = self.load_output_yaml(1024)
+        self.assertEqual(config["sharding_comm_group_call_opt"], False)
+
+    def test_comm_group_call_opt_survives_when_all_conditions_hold(self):
+        # Same scale as above but with the Muon optimizer: every condition of
+        # both framework asserts holds, so the switch must NOT be touched.
+        self.write_yaml(
+            SOURCE_YAML
+            + "optim: muon\n"
+            + "sharding_comm_group_call_opt: true\n"
+        )
+        ok, message = self.adapt(target_nodes=128, test_performance=True)
+        self.assertTrue(ok, message)
+        config = self.load_output_yaml(1024)
+        self.assertEqual(config["sharding_comm_group_call_opt"], True)
+
+    def test_checkpoint_refs_survive_when_structure_is_unchanged(self):
+        # --test-performance freezes the parallel dims, so the model structure
+        # (and therefore the checkpoint) still matches and must be kept.
+        self.write_yaml(
+            SOURCE_YAML
+            + "resume_from_checkpoint: /ckpt/full_scale_base\n"
+            + "load_from_hf: true\n"
+        )
+        ok, message = self.adapt(target_nodes=64, test_performance=True)
+        self.assertTrue(ok, message)
+        config = self.load_output_yaml(512)
+        self.assertEqual(
+            config["resume_from_checkpoint"], "/ckpt/full_scale_base"
+        )
+        self.assertEqual(config["load_from_hf"], True)
 
     def test_pp_is_shrunk_as_little_as_the_card_count_allows(self):
         # EP 64 -> 2 alone cannot reach 8 cards, but it lets PP stop at 4
@@ -1180,7 +1254,9 @@ class TestAccuracySwitch(ConfigAdapterTestBase):
         self.assertTrue(ok, message)
         config = self.load_output_yaml(8)
         self.assertEqual(config["global_batch_size"], 192)
-        self.assertEqual(config["gradient_accumulation_steps"], 192)
+        # acc follows the data-parallel width (96 -> 2): GBS must equal
+        # micro_bs * acc * dataset_world_size, so acc = 192 / (1 * 2) = 96.
+        self.assertEqual(config["gradient_accumulation_steps"], 96)
         self.assertEqual(config["csa_sparse_attn_backend"], "tilelang")
         # Written even though the source YAML never declared it: the field's
         # own default is the non-deterministic cuDNN backward.
@@ -1596,6 +1672,29 @@ class TestLayerFields(ConfigAdapterTestBase):
         self.assertIn(128, model_config["csa_compress_ratios"][:32])
         self.assertIn(-2, model_config["csa_compress_ratios"][:32])
         self.assertIn("逐层配置", message)
+
+    def test_hf_spelling_compress_ratios_is_truncated_too(self):
+        # dsv4-style HF configs spell the field "compress_ratios";
+        # DeepseekV4ModelProvider transform_rules map it to
+        # csa_compress_ratios verbatim, so the adapter must shrink it under
+        # its original key or the run dies on the length check at startup.
+        self.write_json(
+            {
+                **MODEL_CONFIG,
+                "compress_ratios": [128, 128, 128, -2] * 16 + [-2],
+            }
+        )
+        ok, message = self.adapt(target_nodes=1)
+        self.assertTrue(ok, message)
+        model_config = self.load_output_json(8)
+        self.assertEqual(model_config["num_hidden_layers"], 32)
+        # Written back under the HF spelling, 32 layers + 1 MTP tail entry.
+        self.assertNotIn("csa_compress_ratios", model_config)
+        self.assertEqual(len(model_config["compress_ratios"]), 33)
+        self.assertEqual(model_config["compress_ratios"][-1], -2)
+        # Both attention families of the source pattern survive.
+        self.assertIn(128, model_config["compress_ratios"][:32])
+        self.assertIn(-2, model_config["compress_ratios"][:32])
 
     def test_last_layer_is_realigned_with_the_shared_mtp_layer(self):
         # mtp_shared_last_layer aliases the MTP layer's attention onto the last


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Bug fixes

### Description
Cherry-pick of #1907 to release/0.4.

Merged in dev: #1907

Fixes five issues that prevented `config_adapter` from producing a runnable single-node config for DeepSeek-V4-style models (batch fields following DP width, HF `compress_ratios` per-layer registration, auto-disable `sharding_comm_group_call_opt` when shrunk EP makes it illegal, dropping checkpoint references after structural shrink, and fail-fast on out-of-range pretrained `tid2eid`). Clean cherry-pick, no conflicts.

### 是否引起精度变化
否