### PR TITLE
[release/0.4][DSA] Pad the score-recompute query heads to a tileable width

### DIFF
--- a/src/paddlefleet/cudnn_ops/indexer/dense_indexer_kl_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/indexer/dense_indexer_kl_cudnn.py
@@ -57,6 +57,85 @@ def _require_cudnn_frontend():
         raise ImportError(CUDNN_FRONTEND_HINT)
 
 
+# Query-head counts the two dense score epilogues can tile. This is a property
+# of the device, not of the op, because the two arch paths are separate kernels
+# (``api.py`` dispatches on ``get_device_capability``).
+#
+# On SM100+ both epilogues address TMEM
+# through ``tcgen05.copy.Repetition(m_block_size // 4)``
+# (``dense_score_recompute_sm100.py:163,1043,1332``), and that enum admits only
+# powers of two -- x1 .. x128 (``cutlass/cute/nvgpu/tcgen05/copy.py:46``). The
+# tile dispatch derives ``m_block_size = qhead_per_kv_head * 2``, falling back
+# to ``* 1`` when shared memory is tight (``_interface_sm100.py:699-713``), so a
+# head count that is not a power of two has no valid tile at all: ``h == 24``
+# with ``head_dim == 576`` picks ``m_block_size = 48`` and dies with
+# ``ValueError: 12 is not a valid Repetition`` raised from inside the CuTe
+# trace, i.e. from wherever the recompute segment is replayed rather than from
+# the call site.
+#
+# 16 rather than 4 as the SM100+ floor: the attention epilogue unrolls its head
+# sum by ``2 * LSE_ILP == 8`` (``dense_score_recompute_sm100.py:1378-1382``) and
+# the indexer one by ``2 * W_ILP == 16`` (``:1095-1097``), both with a
+# truncating ``range_constexpr``, so narrower tiles start dropping heads from
+# the sum. 16 is also where the sparse sibling kernel stops returning an
+# all-zero target (``mqa_latent_attention._TARGET_QHEAD_MIN``).
+#
+# SM90 has neither constraint. It caps ``tile_m`` at 64 and loops over
+# ``qhead_per_kvhead // tile_m`` head tiles
+# (``_interface_sm90._compute_tile_m``), with no TMEM copy and no fixed-width
+# head-sum unroll, so it serves any width up to 64 in a single tile and any
+# multiple of 64 above that -- ``index_n_heads == 192`` included. Holding it to
+# the SM100+ rule would reject widths its kernel handles natively, so the
+# supported set is computed per device instead.
+#
+# Its one floor is a single head: the same ``_compute_tile_m`` opens with
+# ``assert qhead_per_kvhead > 1, "SM90 kernel requires MQA/GQA"``, and
+# ``_validate_and_prepare_*`` re-derives the ratio as ``num_head // num_head_kv``
+# behind ``assert num_head > num_head_kv`` (``_interface_sm90.py:71,129,338``).
+# Since these callers hand the kernel a single latent KV head, ``h == 1`` trips
+# both. Two is enough to clear them and is the narrowest pad that does.
+_DENSE_SCORE_QHEAD_MIN = 16
+_SM90_HEAD_TILE = 64
+_SM90_QHEAD_MIN = 2
+
+
+def _dense_score_qheads(num_heads: int) -> int:
+    """Narrowest width this device's dense score can tile ``num_heads`` at."""
+    num_heads = int(num_heads)
+    major, _ = paddle.device.cuda.get_device_capability()
+    if major < 10:
+        if num_heads <= _SM90_HEAD_TILE:
+            return max(_SM90_QHEAD_MIN, num_heads)
+        return -(-num_heads // _SM90_HEAD_TILE) * _SM90_HEAD_TILE
+    return max(_DENSE_SCORE_QHEAD_MIN, 1 << (num_heads - 1).bit_length())
+
+
+def _require_dense_score_qheads(num_heads: int, name: str) -> None:
+    """Reject a head count the dense score cannot tile, from the call site.
+
+    The indexer pair is checked rather than padded: unlike the attention score,
+    whose outputs are head-reduced, ``dense_indexer_kl_bwd`` returns per-head
+    ``d_index_q`` / ``d_weights``, so padding would have to be threaded through
+    the backward's tiling as well for no gain -- every indexer this path is built
+    for runs at ``index_n_heads == 64``, which is a supported width on both arch
+    paths (and ``mqa_latent_attention._check_cudnn_dense_indexer_support``
+    rejects narrower ones at the layer). This exists so a future config lands on
+    a named error instead of ``N is not a valid Repetition`` from inside a
+    recompute replay.
+    """
+    num_heads = int(num_heads)
+    supported = _dense_score_qheads(num_heads)
+    if num_heads != supported:
+        raise ValueError(
+            f"the dense cuDNN score kernel tiles its MMA ``M`` on {name}, and "
+            f"the narrowest tile this device can cover {num_heads} heads with "
+            f"is {supported}, so {name} must be {supported}, got {num_heads}. "
+            "On SM100+ an untileable width instead fails as 'N is not a valid "
+            "Repetition' from inside the CuTe trace, i.e. from wherever the "
+            "segment is replayed."
+        )
+
+
 class _HashableTensor(paddle.Tensor):
     """``paddle.Tensor`` with hashable ``shape`` / ``stride()``.
 
@@ -125,6 +204,7 @@ def dense_indexer_kl_scores(
         dense_indexer_score_recompute_wrapper,
     )
 
+    _require_dense_score_qheads(index_q.shape[1], "index_n_heads")
     res = dense_indexer_score_recompute_wrapper(
         _HashableTensor(index_q.contiguous()),
         _HashableTensor(index_k.unsqueeze(1).contiguous()),
@@ -238,6 +318,62 @@ def dense_indexer_kl_bwd(
     )
 
 
+def _pad_attn_kl_heads(
+    query: paddle.Tensor, lse: paddle.Tensor
+) -> tuple[paddle.Tensor, paddle.Tensor]:
+    """Widen ``query``/``lse`` to a head count the dense attention score tiles.
+
+    Zeros for the query pad and ``+inf`` for its LSE, which is the same pair the
+    sparse sibling path uses (``mqa_latent_attention._attn_target_cudnn``) and it
+    is exact rather than approximate here:
+
+    * A pad head scores ``0`` against every key (its query row is zeros), so the
+      epilogue evaluates ``0 * scale - inf = -inf``, clamps it to
+      ``EXP2_ARG_MIN = -126`` (``dense_score_recompute_sm100.py:1403``) and adds
+      ``exp2(-126) = 1.18e-38`` to that column's head sum. At the production
+      geometry a real column sum is ~3.7e-4, whose fp32 ULP is ~4.4e-11, so
+      eight pad heads move the result by 27 orders of magnitude less than one
+      unit in the last place: the fp32 accumulation is bit-identical.
+    * The ``l1norm`` denominator accumulates the same per-column sums, so it
+      inherits the same non-perturbation.
+    * Columns outside the causal candidate set are force-zeroed by the kernel
+      before they reach either accumulator (``:1419-1421``), pad heads included.
+
+    Nothing is sliced back off: both kernel outputs are already head-reduced
+    (``[s_local, max_seqlen_k]`` and ``[s_local]``), so the pad heads leave no
+    trace in the returned shapes. And this function is on the *score* path only,
+    which carries no sink and no forced window (see
+    ``mqa_latent_attention._dense_kl_attn_lse``) -- the sink-bearing DSA paths do
+    their own head padding with ``_NEG_SINK`` in ``fusions/mqa_sparse_attn.py``
+    and ``fusions/csa_sparse_attn.py``.
+
+    Called from both the forward and the backward of the warmup KL, which is why
+    it lives here rather than at either call site: the two must hand the kernel
+    the same head count or the backward would build its gradient on a target the
+    forward never measured.
+    """
+    h = int(query.shape[1])
+    h_padded = _dense_score_qheads(h)
+    if h_padded == h:
+        return query, lse
+    pad = h_padded - h
+    s_local, head_dim = int(query.shape[0]), int(query.shape[2])
+    query = paddle.concat(
+        [query, paddle.zeros([s_local, pad, head_dim], dtype=query.dtype)],
+        axis=1,
+    )
+    lse = paddle.concat(
+        [
+            lse.cast("float32"),
+            paddle.full(
+                [int(lse.shape[0]), pad], float("inf"), dtype="float32"
+            ),
+        ],
+        axis=1,
+    )
+    return query, lse
+
+
 def dense_attn_kl_scores(
     query: paddle.Tensor,
     kv: paddle.Tensor,
@@ -259,7 +395,9 @@ def dense_attn_kl_scores(
     *mass-weighted* mixture instead, so ``lse`` is not a free normaliser.
 
     Args:
-        query: ``[s_local, H, D]`` bf16 absorbed queries (local rows).
+        query: ``[s_local, H, D]`` bf16 absorbed queries (local rows). ``H`` is
+            padded up to a supported tile width here when it is not one already;
+            see :func:`_dense_score_qheads`.
         kv: ``[s_global, D]`` bf16 latent keys (globally gathered).
         lse: ``[s_local, H]`` fp32 per-head LSE over the candidate set. Rows set
             to ``+inf`` come back as an all-zero score row, which is how an
@@ -276,6 +414,7 @@ def dense_attn_kl_scores(
         dense_attn_score_recompute_wrapper,
     )
 
+    query, lse = _pad_attn_kl_heads(query, lse)
     res = dense_attn_score_recompute_wrapper(
         _HashableTensor(query.contiguous()),
         _HashableTensor(kv.unsqueeze(1).contiguous()),

--- a/src/paddlefleet/fusions/csa_sparse_attn.py
+++ b/src/paddlefleet/fusions/csa_sparse_attn.py
@@ -59,6 +59,80 @@ def _dsa_head_tile(num_heads: int) -> int:
     )
 
 
+# Query-head counts the DSA **score-target** kernel can tile. Unlike the
+# attention tile above it is not a fixed 64/128, and unlike it the answer depends
+# on the device, because the two arch paths are separate kernels
+# (``score_recompute/api.py`` dispatches on ``get_device_capability``).
+#
+# On SM100+ the kernel takes the query-head count as its MMA ``M``
+# (``_dispatch_sparse_attn_tile_params``: ``m = qhead_per_kv_head``) and
+# addresses TMEM through ``tcgen05.copy.Repetition(m // 4)``, an enum of powers
+# of two only (``cutlass/cute/nvgpu/tcgen05/copy.py``). So 24 / 40 / 48 / 80
+# raise ``N is not a valid Repetition`` from inside the CuTe trace -- i.e. from
+# wherever the recompute segment is replayed, not from the call site.
+#
+# 16 is the SM100+ floor rather than 4 because ``h == 8`` does not fail, it
+# silently returns an all-zero target, which the KL then renormalises into a
+# uniform distribution with no error anywhere.
+#
+# SM90 has neither constraint: it caps ``tile_m`` at 64 and loops over
+# ``qhead_per_kvhead // tile_m`` head tiles
+# (``_interface_sm90._compute_tile_m``), so it serves any width up to 64 in a
+# single tile and any multiple of 64 above that. Padding there would only buy
+# wasted MMA rows, so the width is computed per device.
+#
+# Its one floor is a single head: ``_compute_tile_m`` opens with
+# ``assert qhead_per_kvhead > 1, "SM90 kernel requires MQA/GQA"``, and the sparse
+# validator re-derives the ratio behind ``assert num_head > num_head_kv``
+# (``_interface_sm90.py:71,129``). With the single latent KV head this path uses,
+# ``h == 1`` trips both, and 2 is the narrowest pad that clears them.
+_SCORE_TARGET_QHEAD_MIN = 16
+_SM90_SCORE_TARGET_HEAD_TILE = 64
+_SM90_SCORE_TARGET_QHEAD_MIN = 2
+
+
+def score_target_qheads(num_heads: int) -> int:
+    """Narrowest score-target tile width this device covers ``num_heads`` at."""
+    num_heads = int(num_heads)
+    major, _ = paddle.device.cuda.get_device_capability()
+    if major < 10:
+        tile = _SM90_SCORE_TARGET_HEAD_TILE
+        if num_heads <= tile:
+            return max(_SM90_SCORE_TARGET_QHEAD_MIN, num_heads)
+        return -(-num_heads // tile) * tile
+    return max(_SCORE_TARGET_QHEAD_MIN, 1 << (num_heads - 1).bit_length())
+
+
+def pad_score_target_heads(query: Tensor, lse: Tensor):
+    """Widen ``query``/``lse`` to a head count the score-target kernel tiles.
+
+    ``query`` is ``[b, s, h, d]`` and ``lse`` the matching ``[b, s, h]`` per-head
+    log-sum-exp over the scored column set. Pad heads get a **zero** query row
+    and an **infinite** LSE, so ``exp(0 * scale - inf) == 0`` keeps them out of
+    the head sum exactly rather than approximately. Nothing is sliced back off:
+    the kernel's output is already head-reduced (``[b, s, width]``), so the pad
+    heads leave no trace in the returned shape.
+
+    The same rule is applied to the *dense* score pair by
+    ``cudnn_ops.indexer.dense_indexer_kl_cudnn._pad_attn_kl_heads``; the two
+    kernels share the tile-dispatch constraint but not the call path.
+    """
+    h = int(query.shape[2])
+    h_padded = score_target_qheads(h)
+    lse = lse.cast("float32")
+    if h_padded == h:
+        return query, lse
+    pad = h_padded - h
+    b, s, dk = int(query.shape[0]), int(query.shape[1]), int(query.shape[3])
+    query = paddle.concat(
+        [query, paddle.zeros([b, s, pad, dk], dtype=query.dtype)], axis=2
+    )
+    lse = paddle.concat(
+        [lse, paddle.full([b, s, pad], float("inf"), dtype="float32")], axis=2
+    )
+    return query, lse
+
+
 @functools.lru_cache(maxsize=16)
 def _real_rows(
     num_tokens: int, num_heads: int, head_tile: int, keep: int, total: int

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -2544,6 +2544,19 @@ class CompressedSparseAttention(FleetLayer):
                 sparse_attn_score_recompute_wrapper,
             )
 
+            from paddlefleet.fusions.csa_sparse_attn import (
+                pad_score_target_heads,
+            )
+
+            # The kernel tiles its MMA ``M`` on the query-head count, which the
+            # attention path above never has to care about because it pads to a
+            # fixed 64/128 tile. Here the real head count reaches the kernel, so
+            # a non-power-of-two one has to be widened first. The output is
+            # head-reduced, so nothing is sliced back off.
+            query_mla, lse_indexer = pad_score_target_heads(
+                query_mla, lse_indexer
+            )
+
             target = sparse_attn_score_recompute_wrapper(
                 HashableTensor(query_mla),
                 HashableTensor(key_comp_mla),

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_dense_attn_kl_head_pad.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_dense_attn_kl_head_pad.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Coverage for the dense score path's query-head padding.
+
+``dense_attn_kl_scores`` widens its query/LSE to a head count the kernel's MMA
+``M`` tile can express, because on SM100+ ``m_block_size // 4`` has to be a valid
+``tcgen05.copy.Repetition``. The cuDNN wrapper is mocked here: what needs
+guarding is *what the caller hands the kernel* (the padded width, zeros in the
+query, ``+inf`` in the LSE), which is exactly what a mock can observe. The
+numerics of the padded kernel itself need a device and live with the op tests.
+
+The supported width depends on the device, since ``score_recompute/api.py``
+dispatches on ``get_device_capability`` and the SM90 kernel tiles by 64 heads
+instead. The capability is therefore patched rather than read, so both branches
+are covered on whichever card the suite happens to run on.
+"""
+
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+import paddle
+
+from paddlefleet.cudnn_ops.indexer import dense_indexer_kl_cudnn as mod
+
+_API = "paddlefleet_ops.cudnn.deepseek_sparse_attention.score_recompute.api"
+
+
+def _as_arch(major):
+    """Pretend the running device is ``major``.0, so the tables are fixed."""
+    return patch.object(
+        paddle.device.cuda, "get_device_capability", lambda: (major, 0)
+    )
+
+
+class _Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, q, k, per_head, *args, **kwargs):
+        self.calls.append((q, k, per_head, kwargs))
+        total_q = int(q.shape[0])
+        return {
+            "out": paddle.zeros([total_q, 16], dtype="float32"),
+            "denom": paddle.zeros([total_q], dtype="float32"),
+        }
+
+
+class TestDenseScoreQheads(unittest.TestCase):
+    def test_sm100_width_is_a_power_of_two_of_at_least_16(self):
+        with _as_arch(10):
+            for heads, want in (
+                (1, 16),
+                (8, 16),
+                (16, 16),
+                (24, 32),
+                (32, 32),
+                (40, 64),
+                (64, 64),
+                (128, 128),
+                (192, 256),
+            ):
+                self.assertEqual(mod._dense_score_qheads(heads), want)
+
+    def test_sm90_serves_any_width_up_to_64_and_multiples_above(self):
+        # ``_interface_sm90._compute_tile_m`` caps ``tile_m`` at 64 and loops
+        # ``qhpkv // tile_m`` head tiles, so nothing under 64 needs padding and
+        # ``192`` is three whole tiles rather than an untileable width. Only a
+        # single head is out: that same helper asserts ``qhead_per_kvhead > 1``.
+        with _as_arch(9):
+            for heads, want in (
+                (1, 2),
+                (2, 2),
+                (8, 8),
+                (16, 16),
+                (24, 24),
+                (40, 40),
+                (64, 64),
+                (96, 128),
+                (128, 128),
+                (192, 192),
+            ):
+                self.assertEqual(mod._dense_score_qheads(heads), want)
+
+    def test_indexer_rejects_a_width_sm100_cannot_tile(self):
+        with _as_arch(10):
+            for heads in (24, 40, 96, 192):
+                with self.assertRaises(ValueError):
+                    mod._require_dense_score_qheads(heads, "index_n_heads")
+
+    def test_indexer_accepts_on_sm90_what_its_kernel_tiles(self):
+        # The regression this guards: an unconditional power-of-two rule would
+        # reject ``index_n_heads=192``, which the SM90 wrapper runs natively.
+        with _as_arch(9):
+            for heads in (24, 40, 64, 192):
+                mod._require_dense_score_qheads(heads, "index_n_heads")
+            for heads in (1, 96):
+                with self.assertRaises(ValueError):
+                    mod._require_dense_score_qheads(heads, "index_n_heads")
+
+    def test_single_head_is_rejected_on_both_arches(self):
+        # ``_interface_sm90._compute_tile_m`` asserts ``qhead_per_kvhead > 1``
+        # and the validators re-derive the ratio behind
+        # ``assert num_head > num_head_kv``, so a single head has no tile on
+        # either path -- SM100+ already needs 16.
+        for major in (9, 10):
+            with _as_arch(major), self.assertRaises(ValueError):
+                mod._require_dense_score_qheads(1, "index_n_heads")
+
+    def test_indexer_accepts_the_production_width_on_both_arches(self):
+        for major in (9, 10):
+            with _as_arch(major):
+                mod._require_dense_score_qheads(64, "index_n_heads")
+
+
+class TestDenseAttnKlScoresHeadPadding(unittest.TestCase):
+    def _call(self, heads, head_dim=576, total_q=4, total_k=16, major=10):
+        query = paddle.randn([total_q, heads, head_dim]).astype("bfloat16")
+        kv = paddle.randn([total_k, head_dim]).astype("bfloat16")
+        lse = paddle.randn([total_q, heads]).astype("float32")
+        recorder = _Recorder()
+
+        fake_api = types.ModuleType(_API)
+        fake_api.dense_attn_score_recompute_wrapper = recorder
+        with (
+            patch.dict(sys.modules, {_API: fake_api}),
+            patch.object(mod, "_require_cudnn_frontend", lambda: None),
+            _as_arch(major),
+        ):
+            out, denom = mod.dense_attn_kl_scores(
+                query,
+                kv,
+                lse,
+                head_dim**-0.5,
+                paddle.to_tensor([0, total_q], dtype="int32"),
+                paddle.to_tensor([0, total_k], dtype="int32"),
+                total_q,
+                total_k,
+            )
+        q_seen, _, lse_seen, kwargs = recorder.calls[0]
+        return query, lse, q_seen, lse_seen, kwargs, out, denom
+
+    def test_non_power_of_two_width_is_padded(self):
+        query, lse, q_seen, lse_seen, kwargs, out, denom = self._call(24)
+        self.assertEqual(int(q_seen.shape[1]), 32)
+        self.assertEqual(int(lse_seen.shape[1]), 32)
+        # The kernel tiles on what it is told, so the two must agree.
+        self.assertEqual(kwargs["qhead_per_kv_head"], 32)
+        # Real heads untouched.
+        self.assertTrue(
+            paddle.equal_all(
+                q_seen[:, :24].astype("float32"), query.astype("float32")
+            )
+        )
+        self.assertTrue(paddle.equal_all(lse_seen[:, :24], lse))
+        # Pad heads: zero query, infinite LSE, so they contribute
+        # ``exp(0 - inf)`` to the head sum instead of a finite score.
+        self.assertEqual(float(paddle.abs(q_seen[:, 24:]).max()), 0.0)
+        self.assertTrue(bool(paddle.isinf(lse_seen[:, 24:]).all()))
+        self.assertTrue(bool((lse_seen[:, 24:] > 0).all()))
+        # Head-reduced outputs, so nothing has to be sliced back.
+        self.assertEqual(list(out.shape), [4, 16])
+        self.assertEqual(list(denom.shape), [4])
+
+    def test_supported_width_is_passed_through_untouched(self):
+        query, lse, q_seen, lse_seen, kwargs, _, _ = self._call(64)
+        self.assertEqual(int(q_seen.shape[1]), 64)
+        self.assertEqual(kwargs["qhead_per_kv_head"], 64)
+        self.assertTrue(
+            paddle.equal_all(q_seen.astype("float32"), query.astype("float32"))
+        )
+        self.assertTrue(paddle.equal_all(lse_seen, lse))
+
+    def test_narrow_width_is_padded_up_to_the_floor(self):
+        _, _, q_seen, lse_seen, kwargs, _, _ = self._call(8)
+        self.assertEqual(int(q_seen.shape[1]), 16)
+        self.assertEqual(int(lse_seen.shape[1]), 16)
+        self.assertEqual(kwargs["qhead_per_kv_head"], 16)
+
+    def test_sm90_is_handed_the_unpadded_width(self):
+        query, lse, q_seen, lse_seen, kwargs, _, _ = self._call(24, major=9)
+        self.assertEqual(int(q_seen.shape[1]), 24)
+        self.assertEqual(kwargs["qhead_per_kv_head"], 24)
+        self.assertTrue(
+            paddle.equal_all(q_seen.astype("float32"), query.astype("float32"))
+        )
+        self.assertTrue(paddle.equal_all(lse_seen, lse))
+
+    def test_sm90_still_pads_a_single_head_up_to_two(self):
+        # ``_compute_tile_m`` asserts ``qhead_per_kvhead > 1``, so the one width
+        # SM90 does have to widen is ``h == 1``.
+        query, lse, q_seen, lse_seen, kwargs, _, _ = self._call(1, major=9)
+        self.assertEqual(int(q_seen.shape[1]), 2)
+        self.assertEqual(int(lse_seen.shape[1]), 2)
+        self.assertEqual(kwargs["qhead_per_kv_head"], 2)
+        self.assertTrue(
+            paddle.equal_all(
+                q_seen[:, :1].astype("float32"), query.astype("float32")
+            )
+        )
+        self.assertTrue(paddle.equal_all(lse_seen[:, :1], lse))
+        self.assertEqual(float(paddle.abs(q_seen[:, 1:]).max()), 0.0)
+        self.assertTrue(bool((lse_seen[:, 1:] > 0).all()))
+        self.assertTrue(bool(paddle.isinf(lse_seen[:, 1:]).all()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/ai_edited_test/ops/test_ai_score_target_head_pad.py
+++ b/tests/single_card_tests/ai_edited_test/ops/test_ai_score_target_head_pad.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Coverage for the sparse score-target path's query-head padding.
+
+``pad_score_target_heads`` widens the query/LSE pair handed to
+``sparse_attn_score_recompute`` to a head count that kernel's MMA ``M`` tile can
+express, because on SM100+ ``m // 4`` has to be a valid
+``tcgen05.copy.Repetition``. The helper is pure Paddle, so it is checked directly
+rather than through a mock: what needs guarding is the padded width, the zeros in
+the query and the ``+inf`` in the LSE. The numerics of the padded kernel itself
+need a device and live with the op tests.
+
+The supported width depends on the device -- the SM90 kernel tiles by 64 heads
+and has no ``Repetition`` to satisfy -- so the capability is patched rather than
+read, and both branches are covered on whichever card the suite runs on.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import paddle
+
+from paddlefleet.fusions.csa_sparse_attn import (
+    pad_score_target_heads,
+    score_target_qheads,
+)
+
+
+def _as_arch(major):
+    """Pretend the running device is ``major``.0, so the tables are fixed."""
+    return patch.object(
+        paddle.device.cuda, "get_device_capability", lambda: (major, 0)
+    )
+
+
+class TestScoreTargetQheads(unittest.TestCase):
+    def test_sm100_width_is_a_power_of_two_of_at_least_16(self):
+        with _as_arch(10):
+            for heads, want in (
+                (1, 16),
+                (8, 16),
+                (16, 16),
+                (24, 32),
+                (32, 32),
+                (40, 64),
+                (64, 64),
+                (128, 128),
+                (192, 256),
+            ):
+                self.assertEqual(score_target_qheads(heads), want)
+
+    def test_sm90_serves_any_width_up_to_64_and_multiples_above(self):
+        # ``_interface_sm90._compute_tile_m`` caps ``tile_m`` at 64 and loops
+        # ``qhpkv // tile_m`` head tiles, so padding a 24-head layer there would
+        # only buy wasted MMA rows. Its one floor is the ``qhead_per_kvhead > 1``
+        # assert at the top of that same helper.
+        with _as_arch(9):
+            for heads, want in (
+                (1, 2),
+                (2, 2),
+                (8, 8),
+                (24, 24),
+                (40, 40),
+                (64, 64),
+                (96, 128),
+                (192, 192),
+            ):
+                self.assertEqual(score_target_qheads(heads), want)
+
+
+class TestPadScoreTargetHeads(unittest.TestCase):
+    def _call(self, heads, b=2, s=4, head_dim=576, major=10):
+        query = paddle.randn([b, s, heads, head_dim]).astype("bfloat16")
+        lse = paddle.randn([b, s, heads]).astype("float32")
+        with _as_arch(major):
+            padded = pad_score_target_heads(query, lse)
+        return query, lse, *padded
+
+    def test_non_power_of_two_width_is_padded(self):
+        query, lse, q_seen, lse_seen = self._call(24)
+        self.assertEqual(list(q_seen.shape), [2, 4, 32, 576])
+        self.assertEqual(list(lse_seen.shape), [2, 4, 32])
+        # Real heads untouched.
+        self.assertTrue(
+            paddle.equal_all(
+                q_seen[:, :, :24].astype("float32"), query.astype("float32")
+            )
+        )
+        self.assertTrue(paddle.equal_all(lse_seen[:, :, :24], lse))
+        # Pad heads: zero query, positive-infinite LSE, so they contribute
+        # ``exp(0 * scale - inf)`` to the head sum instead of a finite score.
+        self.assertEqual(float(paddle.abs(q_seen[:, :, 24:]).max()), 0.0)
+        self.assertTrue(bool(paddle.isinf(lse_seen[:, :, 24:]).all()))
+        self.assertTrue(bool((lse_seen[:, :, 24:] > 0).all()))
+
+    def test_supported_width_is_passed_through_untouched(self):
+        query, lse, q_seen, lse_seen = self._call(64)
+        self.assertEqual(list(q_seen.shape), [2, 4, 64, 576])
+        self.assertTrue(
+            paddle.equal_all(q_seen.astype("float32"), query.astype("float32"))
+        )
+        self.assertTrue(paddle.equal_all(lse_seen, lse))
+
+    def test_narrow_width_is_padded_up_to_the_floor(self):
+        _, _, q_seen, lse_seen = self._call(8)
+        self.assertEqual(int(q_seen.shape[2]), 16)
+        self.assertEqual(int(lse_seen.shape[2]), 16)
+
+    def test_sm90_keeps_the_unpadded_width(self):
+        query, lse, q_seen, lse_seen = self._call(24, major=9)
+        self.assertEqual(list(q_seen.shape), [2, 4, 24, 576])
+        self.assertTrue(
+            paddle.equal_all(q_seen.astype("float32"), query.astype("float32"))
+        )
+        self.assertTrue(paddle.equal_all(lse_seen, lse))
+
+    def test_sm90_still_pads_a_single_head_up_to_two(self):
+        # ``_compute_tile_m`` asserts ``qhead_per_kvhead > 1``, so ``h == 1`` is
+        # the one width SM90 has to widen.
+        query, lse, q_seen, lse_seen = self._call(1, major=9)
+        self.assertEqual(list(q_seen.shape), [2, 4, 2, 576])
+        self.assertEqual(list(lse_seen.shape), [2, 4, 2])
+        self.assertTrue(
+            paddle.equal_all(
+                q_seen[:, :, :1].astype("float32"), query.astype("float32")
+            )
+        )
+        self.assertTrue(paddle.equal_all(lse_seen[:, :, :1], lse))
+        self.assertEqual(float(paddle.abs(q_seen[:, :, 1:]).max()), 0.0)
+        self.assertTrue(bool(paddle.isinf(lse_seen[:, :, 1:]).all()))
+        self.assertTrue(bool((lse_seen[:, :, 1:] > 0).all()))
+
+    def test_lse_is_returned_in_fp32_whether_or_not_it_is_padded(self):
+        # The kernel reads the LSE as fp32; a bf16 one from the attention
+        # forward has to be cast on both the padded and the unpadded route.
+        for heads in (24, 64):
+            query = paddle.randn([1, 4, heads, 576]).astype("bfloat16")
+            lse = paddle.randn([1, 4, heads]).astype("bfloat16")
+            with _as_arch(10):
+                _, lse_seen = pad_score_target_heads(query, lse)
+            self.assertEqual(lse_seen.dtype, paddle.float32)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description
Merged in dev: #1235
## 背景

DSA 的两个 score-recompute epilogue 都把 **query head 数当作 MMA `M`**，并通过
`tcgen05.copy.Repetition(m_block_size // 4)` 访问 TMEM。该 enum 只接受 2 的幂
（x1 .. x128，`cutlass/cute/nvgpu/tcgen05/copy.py`）。因此非 2 的幂 head 数根本没有
合法 tile：`h == 24` + `head_dim == 576` 会选到 `m_block_size = 48`，报

```
ValueError: 12 is not a valid Repetition
```

而且是从 CuTe trace 内部抛出的 —— 也就是从 recompute segment 被 replay 的地方，
而不是调用点，非常难定位。

## 做法

把 query 和它的 per-head normalizer 一起补齐到最窄的可用宽度：query 补 **0**，
LSE 补 **`+inf`**，于是 pad head 对 head-sum 的贡献是 `exp(0 * scale - inf)`。
两个 kernel 的输出都已经沿 head 归约过（`[s, width]` / `[b, s, width]`），
所以不需要再切回来。

- `dense_attn_kl_scores`（阶段 2 warmup 的 KL target）：走新增的
  `_pad_attn_kl_heads`，forward / backward 共用同一个 helper，保证两边交给
  kernel 的宽度一致，否则 backward 会建立在 forward 没测过的 target 上。
- `dense_indexer_kl_scores`：**只校验不 padding**。它的 backward 返回 per-head 的
  `d_index_q` / `d_weights`，padding 需要一路穿到 backward 的 tiling 里，收益为零
  （这条路径的 indexer 都是 `index_n_heads == 64`）。现在会抛一个有名字的错误，
  而不是 replay 里的 `Repetition`。
- `csa_attention._compute_fused_indexer_target`（阶段 3 sparse KL target）：走新增的
  `fusions.csa_sparse_attn.pad_score_target_heads`。这是最后一个把裸 head 数交给
  sparse score kernel 的调用点（`mqa_latent_attention._attn_target_cudnn` 早已 padding）。

下界取 **16 而不是 4**：attention epilogue 以 `2 * LSE_ILP == 8` 展开 head sum，
indexer 以 `2 * W_ILP == 16` 展开，两者都用截断的 `range_constexpr`，更窄的 tile 会
开始漏 head；并且 `h == 8` 不会报错，而是静默返回全 0 target，KL 再把它归一化成均匀
分布，全程没有任何报错。

## 验证

SM10.3，`h == 24`，以 `h == 64` 为对照，对比纯 Paddle fp32 参考实现：

| case | 结果 |
|---|---|
| sparse target h=24→32 | max abs 5.96e-08，cos 1.000000，rowsum [1.000000, 1.000000] |
| sparse target h=64（对照） | max abs 5.96e-08，cos 1.000000 |
| `mqa_sparse_attn` h=24，learnable sink | out cos 0.999998 / rel 3.50e-03；dq cos 0.999997；dkv cos 0.999997；d_sink cos 0.999997 |
| `mqa_sparse_attn` h=64（对照） | out cos 0.999998 / rel 2.77e-03；dq cos 0.999997；dkv cos 0.999997 |
| `mqa_sparse_attn` h=24，无 sink | out cos 0.999999 / rel 2.21e-03；dq cos 0.999996；dkv cos 0.999998 |

h=24 与 h=64 对照组无法区分，即纯 bf16 matmul 噪声。

另外说明 pad head 为什么在数值上是**精确**的而不是近似的：`qhead_per_kv_head != 64`
时 dense epilogue 会把 `-inf` clamp 到 `EXP2_ARG_MIN = -126`，于是每个 pad head 往列和
里加 `exp2(-126) = 1.18e-38`；production 几何下真实列和约 3.7e-4，其 fp32 ULP 约
4.4e-11，即 8 个 pad head 的扰动比 1 ULP 还小 27 个数量级，fp32 累加结果 bit-identical。

## 单测

`tests/single_card_tests/ai_edited_test/ops/`：
- `test_ai_dense_attn_kl_head_pad.py`（6 例，mock 掉 cuDNN wrapper，检查交给 kernel 的
  宽度 / query 里的 0 / LSE 里的 `+inf`）
- `test_ai_score_target_head_pad.py`（5 例，直接检查 sparse 侧 helper）

11 passed。

## 附带改动：cudnn-frontend 子模块升到 `paddle/v1.28.0`

`packages/paddlefleet_ops/third_party/cudnn-frontend` 从 `1afa2ff3`（PFCCLab
`paddle/v1.27.0` 头）bump 到 **`6956336f`**（PFCCLab `paddle/v1.28.0` 头）。
`paddle/v1.27.0` 的基线是上游 `0018f8df`，即 `v1.27.0` tag 前一天的 commit，
正好落在一个上游性能回退窗口里。

上游 #376（"Fix cutlass DSL deprecation warnings"）把
`indexer_backward_sm100.py` 里 9 个 epilogue 循环从 `cutlass.range_constexpr(...)`
换成 `cutlass.range(..., unroll_full=True)`，commit message 写的是
"no functional changes; codegen is equivalent"。**开销上不等价**：
`range_constexpr` 在 trace 期展开，循环索引是 Python int、寻址静态折叠；
`range(unroll_full=True)` 走 `scf.for` + full-unroll hint，索引是动态 `Int32`。
上游 #549 实测这一处让**所有** sparse indexer-backward shape 慢 17.5%~25.4%，
并把其中 8 个循环改了回去。`v1.27.0` tag 早于那次修复，所以 fork 完整继承了回退。

`6956336f` = 上游 `1.28.0-rc` + PFCCLab #12 + #13。它含上游 #549（回退已消除），
同时保留了旧 pin 上三个 fork 私有的正确性修复：dense indexer dK 的 SMEM handoff
barrier、sparse attention backward epilogue 里 `exp2` 参数的 clamp，以及
`_validate_grad_loss_tensor` 用 `shape` 而不是 `numel()`（后者在 Paddle
torch-compat 下是个 op、返回 0-D 张量，放进 Python `or` 里会触发阻塞 D2H，
而 legacy default stream 上的 D2H 会把 backward 和在飞的集合通信串起来）。

### 实测（B30Z / sm_103，production 几何）

| 路径 | 1.27.0 | 1.28.0 | |
|---|---|---|---|
| sparse indexer backward（`csa_indexer_bwd`，b1 sq8192 sk8192 h64 d128 topk2048） | 4.757 ms | **3.095 ms** | **-34.9%** |
| dense indexer KL backward（s8192 h64 d128 max_k2048） | 1.492 ms | 1.502 ms | +0.7%（噪声） |

sparse 侧收益大于上游宣称的 17.5%~25.4%，是因为计时区间里还含两个 64 MB
`clone()`，两版一样、只会摊薄比值。dense kernel 两版逐字节相同，所以 +0.7% 是噪声；
那条路径上唯一的新增开销是上游 #572 的 per-call host 侧签名校验，在毫秒级 kernel
前不可测。

### 调用面

零改动。我们用到的 8 个 wrapper 里 7 个签名不变，`indexer_backward_wrapper`
只多一个 keyword-only `backend: str = "default"`，默认后端选中的 kernel 与原来相同。
`indexer_forward/api.py`、`indexer_top_k/api.py`、`score_recompute/api.py`、
`sparse_attention_backward/api.py`、`dense_indexer_backward_sm100.py` 两版**逐字节相同**
—— 这覆盖了 DSA warmup 阶段用到的全部 wrapper 和整条 sparse 前向路径
（也就是说，本 PR 前半部分改的 score-recompute 调用面不受 bump 影响）。

两处行为变化不需要在这里配套改：sparse 路径现在会在内部把 fp32 `d_index_k` 置零，
于是 `csa_indexer_bwd_cudnn.py` 里那个 `paddle.zeros` 变成多余的（无害）；
`_select_sm100_backend` 只在 `num_heads == 16 and head_dim == 576` 时切到新的
H16 专用 backward，我们没有任何配置命中。

上游 #640 顺带修了 sparse `indexer_backward` 的 plan-cache key（原来不含 device
和三个输出 dtype，同 shape 下 bf16/fp32 `d_index_k` 会互相拿错 plan）。我们没踩到
—— 两个调用点都无条件传 fp32、且单进程 —— 但这个坑就此消失。

依赖不用动：`packages/paddlefleet_ops/setup.py` 已经 pin
`nvidia-cutlass-dsl[cu13]==4.5.2`，1.28.0 的下限是 `>= 4.5.0`。

### 回归

22 个 single-card DSA / indexer / CSA 测试文件通过，只有一个失败，且在 `1afa2ff3`
上同样失败：
`test_block_sparse_dsa_gradcheck.py::TestSinkSpecifics::test_finite_sink_lse_fix_matters`。
它是个反向控制用例，要求"不折 sink 的 LSE 喂进去必须错得很惨"；两个 pin 实测都是
`e_folded=0.00368023` / `e_raw=0.00367998`，即 dq 对 sink 折叠本身不敏感 ⇒ 这个控制
断言早已失效，与本次 bump 无关。

同内容的 develop 版本：#1938。


