### PR TITLE
[CI] Drop host /dev/shm mount for H20 multi-card job

### DIFF
--- a/.github/workflows/Test-release.yml
+++ b/.github/workflows/Test-release.yml
@@ -739,7 +739,6 @@ jobs:
             sleep $((i * 15))
           done
           docker run -d -t --name ${container_name} --gpus all --shm-size=32G \
-            -v "/dev/shm:/dev/shm"  \
             -v ${{ github.workspace }}/../../..:${{ github.workspace }}/../../.. \
             -v ${{ github.workspace }}/../../..:/root \
             -v /ssd1/paddle-1/action_cache:/home/.cache \


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Devs

### Description
删除 `integration-test-H20-multi-card` job 的 `-v "/dev/shm:/dev/shm"` 挂载，解决 CI 报错：

```
RuntimeError: (Unavailable) File descriptor /paddle_2708_1_811023067 open failed,
unable in read-write mode
  [Hint: Expected fd != -1, but received fd:-1 == -1:-1.]
  (at .../memory/allocation/mmap_allocator.cc:78)
```

该 `docker run` 已带 `--shm-size=32G`，宿主机 bind mount 会覆盖容器自己的 tmpfs，导致 Paddle mmap allocator 打开共享内存 fd 失败。去掉挂载后由 `--shm-size` 提供 32G 共享内存。

仅改动这一处，其他 job 的 `/dev/shm` 挂载保持不变。

### 是否引起精度变化
否