### PR TITLE
[Deps] Bump Paddle to `e4e12582077`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260901+160041a4134",
+    "paddlepaddle-gpu==3.4.0.post20260903+e4e12582077",
     "ruamel.yaml>=0.17",
     "tilelang-paddle==0.1.12",
 ]


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Others

### Description
Bump the pinned CUDA 12.9 Paddle dependency to `paddlepaddle-gpu==3.4.0.post20260903+e4e12582077`.

Target Paddle release: `release/3.4`.
Target Paddle commit: [`e4e12582077cffa5250218d13f185758fca88cbc`](https://github.com/PaddlePaddle/Paddle/commit/e4e12582077cffa5250218d13f185758fca88cbc).

The official self-hosted cu129 nightly index contains the exact target package:

- [CPython 3.12 Linux x86_64 wheel](https://paddle-whl.cdn.bcebos.com/nightly/cu129/paddlepaddle-gpu/paddlepaddle_gpu-3.4.0.post20260903%2Be4e12582077-cp312-cp312-linux_x86_64.whl)

Artifact checks: exact index match, HTTP HEAD 200, and HTTP Range 206.

Validation: TOML and PEP 508 parsing, `git diff --check`, exact one-file/one-line delta, and `pre-commit run --files pyproject.toml` pass.

### 是否引起精度变化
否