### PR TITLE
[New features] Add DSV4 IndexCache training support

### DIFF
--- a/src/paddlefleet/pipeline_parallel/__init__.py
+++ b/src/paddlefleet/pipeline_parallel/__init__.py
@@ -16,6 +16,7 @@ from paddle.distributed.fleet.meta_parallel.parallel_layers.pp_layers import (
     PipelineLayer,
 )
 
+from .indexcache_adapter import register_indexcache_pipeline_adapter
 from .pp_utils.forward_backward_overlap_utils import (
     ScheduleChunk,
     ScheduleNode,
@@ -25,4 +26,5 @@ __all__ = [
     "PipelineLayer",
     "ScheduleNode",
     "ScheduleChunk",
+    "register_indexcache_pipeline_adapter",
 ]

--- a/src/paddlefleet/pipeline_parallel/indexcache_adapter.py
+++ b/src/paddlefleet/pipeline_parallel/indexcache_adapter.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 import functools
-import os
 
 import paddle
 
@@ -25,10 +24,13 @@ _PIPELINE_KEY_ATTR = "_paddlefleet_pipeline_key"
 _PIPELINE_SHAPE_ATTR = "_paddlefleet_pipeline_shape"
 _PIPELINE_DTYPE_ATTR = "_paddlefleet_pipeline_dtype"
 _INDEXCACHE_PRODUCER_LAYER_ATTR = "_paddlefleet_indexcache_producer_layer"
+_INDEXCACHE_CONFIG = None
 
 
 def _debug_enabled() -> bool:
-    return os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1"
+    return bool(
+        getattr(_INDEXCACHE_CONFIG, "indexcache_train_debug", False)
+    )
 
 
 def _is_indexcache_key(key) -> bool:
@@ -491,21 +493,25 @@ def _schedule_node_backward(self, output_grad=None, scaler=None):
     return grad
 
 
-def register_indexcache_pipeline_adapter(
-    index_topk_pattern: str | list[str] | None,
-) -> bool:
+def register_indexcache_pipeline_adapter(config) -> bool:
     """Register Paddle Pipeline compatibility only for IndexCache runs.
 
     The adapter is process-global because Paddle exposes the relevant Pipeline
     hooks as module functions and class methods. Registration is nevertheless
-    explicit, conditional, and idempotent: an empty pattern is a no-op and a
-    second registration does not wrap methods again.
+    explicit, conditional, and idempotent: a config with an empty
+    ``index_topk_pattern`` is a no-op and a second registration does not wrap
+    methods again. Pipeline diagnostics read ``indexcache_train_debug`` from
+    this normalized TransformerConfig instead of process environment state.
 
     Returns:
         ``True`` only when this call installs the adapter.
     """
+    index_topk_pattern = getattr(config, "index_topk_pattern", None)
     if not index_topk_pattern:
         return False
+
+    global _INDEXCACHE_CONFIG
+    _INDEXCACHE_CONFIG = config
 
     import paddle.distributed.fleet.meta_parallel.pp_utils.forward_backward_overlap_utils as fbo
     import paddle.distributed.fleet.meta_parallel.pp_utils.utils as pp_utils

--- a/src/paddlefleet/pipeline_parallel/indexcache_adapter.py
+++ b/src/paddlefleet/pipeline_parallel/indexcache_adapter.py
@@ -1,0 +1,545 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import functools
+import os
+
+import paddle
+
+_PATCH_FLAG = "_indexcache_pipeline_adapter_registered"
+_INDEXCACHE_STATE_KEY = "indexcache_state"
+_PIPELINE_KEY_ATTR = "_paddlefleet_pipeline_key"
+_PIPELINE_SHAPE_ATTR = "_paddlefleet_pipeline_shape"
+_PIPELINE_DTYPE_ATTR = "_paddlefleet_pipeline_dtype"
+_INDEXCACHE_PRODUCER_LAYER_ATTR = "_paddlefleet_indexcache_producer_layer"
+
+
+def _debug_enabled() -> bool:
+    return os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1"
+
+
+def _is_indexcache_key(key) -> bool:
+    return isinstance(key, str) and key.startswith(_INDEXCACHE_STATE_KEY)
+
+
+def _get_pipeline_key(tensor):
+    key = getattr(tensor, "key", None)
+    if key is None:
+        key = getattr(tensor, _PIPELINE_KEY_ATTR, None)
+    return key
+
+
+def _save_pipeline_metadata(tensor, key):
+    setattr(tensor, _PIPELINE_KEY_ATTR, key)
+    setattr(tensor, _PIPELINE_SHAPE_ATTR, tuple(tensor.shape))
+    setattr(tensor, _PIPELINE_DTYPE_ATTR, tensor.dtype)
+
+
+def _has_indexcache_key(tensors) -> bool:
+    if not isinstance(tensors, (tuple, list)):
+        tensors = (tensors,)
+    return any(
+        _is_indexcache_key(_get_pipeline_key(tensor)) for tensor in tensors
+    )
+
+
+def _copy_indexcache_producer_layer(source, target) -> None:
+    producer_layer = getattr(source, _INDEXCACHE_PRODUCER_LAYER_ATTR, None)
+    if producer_layer is not None:
+        setattr(target, _INDEXCACHE_PRODUCER_LAYER_ATTR, int(producer_layer))
+
+
+def _annotate_indexcache_producer_layer(value):
+    if not _debug_enabled() or not isinstance(value, (tuple, list)):
+        return value
+
+    from paddlefleet.transformer.indexcache_state import (
+        INDEXCACHE_DISTILL_STATE_LEN,
+        INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER,
+        INDEXCACHE_DISTILL_STATE_TOPK_PROBS,
+    )
+
+    if len(value) != INDEXCACHE_DISTILL_STATE_LEN:
+        return value
+    gradient_tensor = value[INDEXCACHE_DISTILL_STATE_TOPK_PROBS]
+    producer_tensor = value[INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER]
+    if not isinstance(gradient_tensor, paddle.Tensor) or not isinstance(
+        producer_tensor, paddle.Tensor
+    ):
+        return value
+    if (
+        getattr(gradient_tensor, _INDEXCACHE_PRODUCER_LAYER_ATTR, None)
+        is not None
+    ):
+        return value
+    if not producer_tensor._is_initialized():
+        return value
+    setattr(
+        gradient_tensor,
+        _INDEXCACHE_PRODUCER_LAYER_ATTR,
+        int(producer_tensor.item()),
+    )
+    return value
+
+
+def _mark_indexcache_state_stop_gradient(value):
+    from paddlefleet.transformer.indexcache_state import (
+        apply_stop_gradient_mask,
+    )
+
+    if value is None:
+        return value
+    if not isinstance(value, (tuple, list)):
+        value = (value,)
+    return _annotate_indexcache_producer_layer(apply_stop_gradient_mask(value))
+
+
+def _describe_tensor_keys(tensors):
+    if not isinstance(tensors, (tuple, list)):
+        tensors = (tensors,)
+    desc = []
+    for tensor in tensors:
+        if not isinstance(tensor, paddle.Tensor):
+            desc.append(type(tensor).__name__)
+            continue
+        desc.append(
+            {
+                "key": _get_pipeline_key(tensor),
+                "shape": list(tensor.shape),
+                "dtype": str(tensor.dtype),
+                "stop_gradient": bool(tensor.stop_gradient),
+            }
+        )
+    return desc
+
+
+def _indexcache_producer_layer(tensors):
+    if not _debug_enabled():
+        return None
+    for tensor in tensors:
+        if not isinstance(tensor, paddle.Tensor):
+            continue
+        producer_layer = getattr(
+            tensor,
+            _INDEXCACHE_PRODUCER_LAYER_ATTR,
+            None,
+        )
+        if producer_layer is not None:
+            return int(producer_layer)
+    return None
+
+
+def _debug_state5_gradient(key, grad, source, producer_layer):
+    if not _debug_enabled() or key != f"{_INDEXCACHE_STATE_KEY} 5":
+        return
+    from paddlefleet.transformer.indexcache_state import (
+        format_indexcache_gradient_summary,
+        summarize_indexcache_gradients,
+    )
+
+    summary = summarize_indexcache_gradients([("grad", grad)])["grad"]
+    print(
+        "[INDEXCACHE_PP_GRAD] boundary=state5_grad_present "
+        f"source={source} "
+        f"producer_layer={producer_layer} "
+        f"{format_indexcache_gradient_summary('grad', summary)}",
+        flush=True,
+    )
+
+
+def _detach_and_requires_grad(value):
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        if _INDEXCACHE_STATE_KEY in value:
+            _annotate_indexcache_producer_layer(value[_INDEXCACHE_STATE_KEY])
+        return {
+            key: _detach_and_requires_grad(item)
+            for key, item in value.items()
+            if item is not None
+        }
+    if isinstance(value, (tuple, list)):
+        detached = [_detach_and_requires_grad(item) for item in value]
+        return tuple(detached) if isinstance(value, tuple) else detached
+    if isinstance(value, paddle.Tensor):
+        detached = value.detach()
+        detached.stop_gradient = value.stop_gradient
+        _copy_indexcache_producer_layer(value, detached)
+        return detached
+    return value
+
+
+class _IndexCacheAliasClone(paddle.autograd.PyLayer):
+    """Preserve the gradient edge without allocating an output-sized buffer."""
+
+    @staticmethod
+    def forward(ctx, value):
+        return value.view(value.shape)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return grad_output
+
+
+def _clone_and_clear_dataptr(value, fake_clone, clear_dataptr=False):
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        if _INDEXCACHE_STATE_KEY in value:
+            _annotate_indexcache_producer_layer(value[_INDEXCACHE_STATE_KEY])
+        cloned = {
+            key: _clone_and_clear_dataptr(item, fake_clone, clear_dataptr)
+            for key, item in value.items()
+            if item is not None
+        }
+        return cloned
+    if isinstance(value, (tuple, list)):
+        cloned = [
+            _clone_and_clear_dataptr(item, fake_clone, clear_dataptr)
+            for item in value
+            if item is not None
+        ]
+        return tuple(cloned) if isinstance(value, tuple) else cloned
+    if isinstance(value, paddle.Tensor):
+        # Paddle's FakeClone creates an empty_like allocation before the
+        # caller clears its dataptr. At 32K, that transient hidden-state-sized
+        # allocation can exceed the remaining memory once IndexCache state is
+        # present. A view keeps the same one-to-one gradient edge and lets the
+        # cloned tensor drop its holder without allocating a second buffer.
+        clone = _IndexCacheAliasClone if clear_dataptr else fake_clone
+        cloned = clone.apply(value)
+        cloned.stop_gradient = value.stop_gradient
+        _copy_indexcache_producer_layer(value, cloned)
+        if clear_dataptr:
+            cloned._clear_dataptr()
+        return cloned
+    return value
+
+
+def _convert_tensor_dict_to_tuple(output_tensor_dict):
+    output_tensor = []
+    for key, tensor in output_tensor_dict.items():
+        if tensor is None:
+            continue
+        if isinstance(tensor, (list, tuple)):
+            if key == _INDEXCACHE_STATE_KEY:
+                tensor = _mark_indexcache_state_stop_gradient(tensor)
+            for idx, item in enumerate(tensor):
+                if item is None:
+                    continue
+                if not isinstance(item, paddle.Tensor):
+                    raise TypeError(
+                        "Pipeline dict tuple values must be paddle.Tensor "
+                        f"or None, but {key}[{idx}] is {type(item).__name__}."
+                    )
+                item.key = f"{key} {idx}"
+                _save_pipeline_metadata(item, item.key)
+                output_tensor.append(item)
+        else:
+            if not isinstance(tensor, paddle.Tensor):
+                raise TypeError(
+                    "Pipeline dict values must be paddle.Tensor or tensor "
+                    f"tuple/list, but {key} is {type(tensor).__name__}."
+                )
+            tensor.key = key
+            _save_pipeline_metadata(tensor, key)
+            output_tensor.append(tensor)
+
+    output_tensor = tuple(output_tensor)
+    if _debug_enabled() and _has_indexcache_key(output_tensor):
+        print(
+            "[INDEXCACHE_PP_FLOW] dict_to_tuple "
+            f"tensors={_describe_tensor_keys(output_tensor)}",
+            flush=True,
+        )
+    return output_tensor
+
+
+def _convert_tensor_tuple_to_dict(input_tensor_tuple):
+    input_tensor_dict = {}
+    if not isinstance(input_tensor_tuple, tuple):
+        input_tensor_tuple = (input_tensor_tuple,)
+    for tensor in input_tensor_tuple:
+        key = tensor.key
+        _save_pipeline_metadata(tensor, key)
+        if " " in key:
+            real_key, suffix = key.rsplit(" ", 1)
+            if suffix.isdigit():
+                input_tensor_dict.setdefault(real_key, []).append(tensor)
+            else:
+                input_tensor_dict[key] = tensor
+        else:
+            input_tensor_dict[key] = tensor
+        delattr(tensor, "key")
+    if isinstance(input_tensor_dict.get(_INDEXCACHE_STATE_KEY), list):
+        input_tensor_dict[_INDEXCACHE_STATE_KEY] = tuple(
+            input_tensor_dict[_INDEXCACHE_STATE_KEY]
+        )
+    if _INDEXCACHE_STATE_KEY in input_tensor_dict:
+        input_tensor_dict[_INDEXCACHE_STATE_KEY] = (
+            _mark_indexcache_state_stop_gradient(
+                input_tensor_dict[_INDEXCACHE_STATE_KEY]
+            )
+        )
+    if _debug_enabled() and _INDEXCACHE_STATE_KEY in input_tensor_dict:
+        state = input_tensor_dict[_INDEXCACHE_STATE_KEY]
+        print(
+            "[INDEXCACHE_PP_FLOW] tuple_to_dict "
+            f"keys={list(input_tensor_dict.keys())} "
+            f"state_type={type(state).__name__} "
+            f"state={_describe_tensor_keys(state)}",
+            flush=True,
+        )
+    return input_tensor_dict
+
+
+def _tuple_to_dict_helper(input_tensor):
+    use_dict = False
+    if isinstance(input_tensor, tuple):
+        use_dict = len(input_tensor) > 0 and hasattr(input_tensor[0], "key")
+    else:
+        use_dict = hasattr(input_tensor, "key")
+    if use_dict:
+        input_tensor = _convert_tensor_tuple_to_dict(input_tensor)
+    return input_tensor, use_dict
+
+
+def _dict_to_tuple_helper(output_tensor):
+    if isinstance(output_tensor, dict):
+        return _convert_tensor_dict_to_tuple(output_tensor)
+    return output_tensor
+
+
+def _collect_input_gradients(inputs):
+    gradients = []
+    zero_filled_keys = []
+    producer_layer = _indexcache_producer_layer(inputs)
+    for tensor in inputs:
+        if not isinstance(tensor, paddle.Tensor) or tensor.stop_gradient:
+            continue
+        grad = tensor.grad
+        key = _get_pipeline_key(tensor)
+        _debug_state5_gradient(key, grad, "schedule_node", producer_layer)
+        if grad is None:
+            if not _is_indexcache_key(key):
+                raise RuntimeError(
+                    "Pipeline input is missing a gradient outside IndexCache "
+                    f"state: key={key!r}, shape={list(tensor.shape)}, "
+                    f"dtype={tensor.dtype}."
+                )
+            grad = paddle.zeros_like(tensor)
+            grad.stop_gradient = False
+            zero_filled_keys.append(key)
+        gradients.append(grad)
+    if _debug_enabled() and zero_filled_keys:
+        print(
+            f"[INDEXCACHE_PP_GRAD] zero_filled_keys={zero_filled_keys}",
+            flush=True,
+        )
+    return tuple(gradients)
+
+
+def _zeros_from_tensor_metadata(tensor):
+    shape = getattr(tensor, _PIPELINE_SHAPE_ATTR, None)
+    dtype = getattr(tensor, _PIPELINE_DTYPE_ATTR, None)
+    if shape is None or dtype is None:
+        raise RuntimeError(
+            "IndexCache pipeline tensor lacks preserved shape/dtype metadata: "
+            f"key={_get_pipeline_key(tensor)!r}."
+        )
+    grad = paddle.zeros(
+        shape=list(shape),
+        dtype=dtype,
+    )
+    grad.stop_gradient = False
+    return grad
+
+
+def _normalize_pipeline_input_gradients(input_tensor, input_tensor_grad):
+    if input_tensor is None:
+        return input_tensor_grad
+
+    is_tuple_input = isinstance(input_tensor, tuple)
+    inputs = input_tensor if is_tuple_input else (input_tensor,)
+    if not _has_indexcache_key(inputs):
+        return input_tensor_grad
+
+    differentiable_inputs = [
+        tensor
+        for tensor in inputs
+        if isinstance(tensor, paddle.Tensor) and not tensor.stop_gradient
+    ]
+    producer_layer = _indexcache_producer_layer(inputs)
+    if is_tuple_input:
+        if not isinstance(input_tensor_grad, (tuple, list)):
+            raise RuntimeError(
+                "IndexCache pipeline input gradients must preserve tuple "
+                f"structure, but got {type(input_tensor_grad).__name__}."
+            )
+        gradients = list(input_tensor_grad)
+    else:
+        gradients = [input_tensor_grad]
+
+    if len(gradients) != len(differentiable_inputs):
+        raise RuntimeError(
+            "IndexCache pipeline input gradient arity mismatch: "
+            f"inputs={len(differentiable_inputs)}, gradients={len(gradients)}."
+        )
+
+    zero_filled_keys = []
+    for idx, (tensor, grad) in enumerate(zip(differentiable_inputs, gradients)):
+        key = _get_pipeline_key(tensor)
+        _debug_state5_gradient(key, grad, "pipeline", producer_layer)
+        if grad is None:
+            if not _is_indexcache_key(key):
+                raise RuntimeError(
+                    "Pipeline input is missing a gradient outside IndexCache "
+                    f"state: key={key!r}, shape={list(tensor.shape)}, "
+                    f"dtype={tensor.dtype}."
+                )
+            grad = _zeros_from_tensor_metadata(tensor)
+            gradients[idx] = grad
+            zero_filled_keys.append(key)
+        elif not isinstance(grad, paddle.Tensor):
+            raise TypeError(
+                "Pipeline input gradients must be paddle.Tensor or None, "
+                f"but key={key!r} has {type(grad).__name__}."
+            )
+
+    if _debug_enabled() and zero_filled_keys:
+        print(
+            "[INDEXCACHE_PP_GRAD] boundary=pipeline zero_filled_keys="
+            f"{zero_filled_keys}",
+            flush=True,
+        )
+    return tuple(gradients) if is_tuple_input else gradients[0]
+
+
+def _wrap_pipeline_backward_step(original_backward_step):
+    @functools.wraps(original_backward_step)
+    def backward_step(self, input_tensor, *args, **kwargs):
+        input_tensor_grad = original_backward_step(
+            self,
+            input_tensor,
+            *args,
+            **kwargs,
+        )
+        return _normalize_pipeline_input_gradients(
+            input_tensor,
+            input_tensor_grad,
+        )
+
+    return backward_step
+
+
+def _schedule_node_backward(self, output_grad=None, scaler=None):
+    if output_grad is None:
+        if isinstance(self.outputs, (tuple, list)):
+            assert len(self.outputs) == 1
+            outputs = self.outputs[0]
+        else:
+            outputs = self.outputs
+        assert isinstance(outputs, paddle.Tensor)
+        if scaler is not None:
+            paddle.autograd.backward(scaler.scale(outputs))
+        else:
+            paddle.autograd.backward(outputs)
+    else:
+        is_output_grad_tuple = isinstance(output_grad, tuple)
+        if not isinstance(output_grad, (tuple, list)):
+            is_output_grad_tuple = True
+            output_grad = (output_grad,)
+
+        outputs = _dict_to_tuple_helper(self.outputs)
+        if not isinstance(outputs, (tuple, list)):
+            outputs = (outputs,)
+        outputs = [
+            tensor
+            for tensor in outputs
+            if isinstance(tensor, paddle.Tensor) and not tensor.stop_gradient
+        ]
+
+        output_grad = [grad for grad in output_grad if grad is not None]
+        output_grad = (
+            tuple(output_grad) if is_output_grad_tuple else list(output_grad)
+        )
+
+        assert len(outputs) == len(output_grad), (
+            f"{len(outputs)} of {type(outputs[0])} vs "
+            f"{len(output_grad)} of {type(output_grad[0])}"
+        )
+        paddle.autograd.backward(outputs, output_grad)
+
+    inputs = _dict_to_tuple_helper(self.inputs)
+    if not isinstance(inputs, (tuple, list)):
+        inputs = (inputs,)
+    grad = _collect_input_gradients(inputs)
+    self._reset_states()
+    return grad
+
+
+def register_indexcache_pipeline_adapter(
+    index_topk_pattern: str | list[str] | None,
+) -> bool:
+    """Register Paddle Pipeline compatibility only for IndexCache runs.
+
+    The adapter is process-global because Paddle exposes the relevant Pipeline
+    hooks as module functions and class methods. Registration is nevertheless
+    explicit, conditional, and idempotent: an empty pattern is a no-op and a
+    second registration does not wrap methods again.
+
+    Returns:
+        ``True`` only when this call installs the adapter.
+    """
+    if not index_topk_pattern:
+        return False
+
+    import paddle.distributed.fleet.meta_parallel.pp_utils.forward_backward_overlap_utils as fbo
+    import paddle.distributed.fleet.meta_parallel.pp_utils.utils as pp_utils
+    from paddle.distributed.fleet import meta_parallel
+    from paddle.distributed.fleet.meta_parallel import pipeline_parallel
+
+    if getattr(pp_utils, _PATCH_FLAG, False):
+        return False
+
+    def clone_and_clear_dataptr(outputs, clear_dataptr=False):
+        return _clone_and_clear_dataptr(
+            outputs,
+            fbo.FakeClone,
+            clear_dataptr=clear_dataptr,
+        )
+
+    pp_utils.convert_tensor_dict_to_tuple = _convert_tensor_dict_to_tuple
+    pp_utils.convert_tensor_tuple_to_dict = _convert_tensor_tuple_to_dict
+    pp_utils.tuple_to_dict_helper = _tuple_to_dict_helper
+    pp_utils.dict_to_tuple_helper = _dict_to_tuple_helper
+    setattr(pp_utils, _PATCH_FLAG, True)
+
+    meta_parallel.dict_to_tuple_helper = _dict_to_tuple_helper
+    meta_parallel.tuple_to_dict_helper = _tuple_to_dict_helper
+
+    fbo.detach_and_requires_grad = _detach_and_requires_grad
+    fbo.clone_and_clear_dataptr = clone_and_clear_dataptr
+    fbo.ScheduleNode.backward = _schedule_node_backward
+    setattr(fbo, _PATCH_FLAG, True)
+
+    pipeline_parallel.PipelineParallel._backward_step = (
+        _wrap_pipeline_backward_step(
+            pipeline_parallel.PipelineParallel._backward_step
+        )
+    )
+    setattr(pipeline_parallel, _PATCH_FLAG, True)
+    return True

--- a/src/paddlefleet/pipeline_parallel/indexcache_adapter.py
+++ b/src/paddlefleet/pipeline_parallel/indexcache_adapter.py
@@ -536,6 +536,8 @@ def register_indexcache_pipeline_adapter(config) -> bool:
 
     meta_parallel.dict_to_tuple_helper = _dict_to_tuple_helper
     meta_parallel.tuple_to_dict_helper = _tuple_to_dict_helper
+    pipeline_parallel.dict_to_tuple_helper = _dict_to_tuple_helper
+    pipeline_parallel.tuple_to_dict_helper = _tuple_to_dict_helper
 
     fbo.detach_and_requires_grad = _detach_and_requires_grad
     fbo.clone_and_clear_dataptr = clone_and_clear_dataptr

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1519,6 +1519,7 @@ class TileLangCSAIndexerDistillBridge(paddle.autograd.PyLayer):
         producer_loss_coeff: float = 0.0,
         producer_num_rows_override: float | None = None,
         producer_layer: int = -1,
+        debug_enabled: bool = False,
     ) -> Tensor:
         ctx.input_stop_gradients = (
             bool(index_q.stop_gradient),
@@ -1533,7 +1534,8 @@ class TileLangCSAIndexerDistillBridge(paddle.autograd.PyLayer):
         ]
         ctx.has_producer_score_delta = producer_score_delta is not None
         ctx.producer_layer = int(producer_layer)
-        if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
+        ctx.debug_enabled = bool(debug_enabled)
+        if ctx.debug_enabled:
             print(
                 "[INDEXCACHE_DISTILL_GRAD] "
                 "boundary=producer_bridge_apply "
@@ -1578,7 +1580,7 @@ class TileLangCSAIndexerDistillBridge(paddle.autograd.PyLayer):
                     grad_index_scores.cast("float32") + producer_grad
                 )
 
-        debug_enabled = os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1"
+        debug_enabled = getattr(ctx, "debug_enabled", False)
         if debug_enabled:
             score_summary = summarize_indexcache_gradients(
                 [("score", grad_index_scores)]
@@ -1662,10 +1664,12 @@ class IndexCacheServedDistillLossAutoScaler(paddle.autograd.PyLayer):
         loss_mask: Tensor | None = None,
         served_layer: int = -1,
         producer_layer: int = -1,
+        debug_enabled: bool = False,
     ) -> Tensor:
         ctx.topk_probs_stop_gradient = bool(topk_probs.stop_gradient)
         ctx.served_layer = int(served_layer)
         ctx.producer_layer = int(producer_layer)
+        ctx.debug_enabled = bool(debug_enabled)
         score_delta = topk_probs.detach() - target.detach()
         ctx.has_loss_mask = loss_mask is not None
         if loss_mask is not None:
@@ -1704,7 +1708,7 @@ class IndexCacheServedDistillLossAutoScaler(paddle.autograd.PyLayer):
         if ctx.topk_probs_stop_gradient:
             grad_index_scores = None
 
-        if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
+        if getattr(ctx, "debug_enabled", False):
             score_summary = summarize_indexcache_gradients(
                 [("score", grad_index_scores)]
             )["score"]
@@ -2797,6 +2801,9 @@ class CompressedSparseAttention(FleetLayer):
             raise ValueError("index_topk_pattern must start with 'F'.")
         return pattern
 
+    def _indexcache_train_debug_enabled(self) -> bool:
+        return bool(getattr(self.config, "indexcache_train_debug", False))
+
     def _indexcache_recompute_enabled(self) -> bool:
         return bool(getattr(self.config, "recompute_granularity", None))
 
@@ -2862,7 +2869,7 @@ class CompressedSparseAttention(FleetLayer):
         return state_kind
 
     def _indexcache_debug(self, msg: str) -> None:
-        if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
+        if self._indexcache_train_debug_enabled():
             cp_msg = (
                 f" cp_rank={self.cp_rank} cp_size={self.cp_size}"
                 if self.cp_enabled
@@ -2883,7 +2890,7 @@ class CompressedSparseAttention(FleetLayer):
             )
 
     def _indexcache_distill_debug(self, msg: str) -> None:
-        if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
+        if self._indexcache_train_debug_enabled():
             cp_msg = (
                 f" cp_rank={self.cp_rank} cp_size={self.cp_size}"
                 if self.cp_enabled
@@ -3071,7 +3078,7 @@ class CompressedSparseAttention(FleetLayer):
                     # gradients to one bridge/backward kernel. Saving one
                     # FP16 delta preserves the producer loss without retaining
                     # a second full TileLang backward context.
-                    if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
+                    if self._indexcache_train_debug_enabled():
                         print(
                             "[INDEXCACHE_DISTILL_GRAD] "
                             "boundary=producer_bridge_forward "
@@ -3089,6 +3096,7 @@ class CompressedSparseAttention(FleetLayer):
                         producer_loss_coeff,
                         producer_num_rows,
                         self.layer_number,
+                        self._indexcache_train_debug_enabled(),
                     )
                 else:
                     distill_topk_probs = TileLangCSAIndexerDistillBridge.apply(
@@ -3101,6 +3109,7 @@ class CompressedSparseAttention(FleetLayer):
                         0.0,
                         None,
                         self.layer_number,
+                        self._indexcache_train_debug_enabled(),
                     )
             else:
                 distill_topk_probs = topk_probs.detach()
@@ -3463,6 +3472,7 @@ class CompressedSparseAttention(FleetLayer):
             loss_mask,
             self.layer_number,
             int(producer_layer if producer_layer is not None else -1),
+            self._indexcache_train_debug_enabled(),
         )
 
     def _postprocess_indexer_replay(

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -54,6 +54,23 @@ from paddlefleet.transformer.dsa_attention import (
     fused_qk_topk_naive,
     rotate_activation,
 )
+from paddlefleet.transformer.indexcache_state import (
+    INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER,
+    INDEXCACHE_DISTILL_STATE_SERVED_COUNT,
+    INDEXCACHE_DISTILL_STATE_TOPK_INDICES,
+    INDEXCACHE_DISTILL_STATE_TOPK_PROBS,
+    INDEXCACHE_STATE_KIND_DISTILL,
+    INDEXCACHE_STATE_KIND_INVALID,
+    INDEXCACHE_STATE_KIND_TOPK_ONLY,
+    INDEXCACHE_STATE_TOPK_IDXS,
+    INDEXCACHE_TOPK_ONLY_STATE_LEN,
+    INDEXCACHE_TOPK_ONLY_STATE_PRODUCER_LAYER,
+    apply_stop_gradient_mask,
+    detach_stop_gradient_tensor,
+    format_indexcache_gradient_summary,
+    state_kind,
+    summarize_indexcache_gradients,
+)
 
 if TYPE_CHECKING:
     from paddlefleet.process_groups_config import ProcessGroupCollection
@@ -1228,6 +1245,36 @@ def _map_compressed_topk_to_kv_full(
     )
 
 
+_INDEXCACHE_PIPELINE_PAIR_BASE = (1 << 15) + 1
+
+
+def _pack_indexcache_pipeline_topk(topk_indices_compressed: Tensor) -> Tensor:
+    """Losslessly pack two signed block ids into one NCCL-safe int32."""
+    shifted = topk_indices_compressed.cast("int32") + 1
+    low = shifted[..., 0::2]
+    high = shifted[..., 1::2]
+    return low + high * _INDEXCACHE_PIPELINE_PAIR_BASE
+
+
+def _unpack_indexcache_pipeline_topk(
+    packed_topk_indices: Tensor, original_width: int
+) -> Tensor:
+    """Restore pair-packed pipeline block ids to their int32 shape."""
+    packed_shape = list(packed_topk_indices.shape)
+    if (
+        original_width <= 0
+        or original_width % 2 != 0
+        or not packed_shape
+        or packed_shape[-1] * 2 != original_width
+    ):
+        return packed_topk_indices.cast("int32")
+    packed = packed_topk_indices.cast("int32")
+    low = packed % _INDEXCACHE_PIPELINE_PAIR_BASE - 1
+    high = packed // _INDEXCACHE_PIPELINE_PAIR_BASE - 1
+    restored_shape = [*packed_shape[:-1], original_width]
+    return paddle.stack([low, high], axis=-1).reshape(restored_shape)
+
+
 def _compute_attn_target_on_selected_set(
     query_mla: Tensor,  # [b, sq, np, hn]  DETACHED
     key_comp_mla: Tensor,  # [b, sk, hn] shared compressed KV, or legacy [b, sk, np, hn]
@@ -1408,6 +1455,278 @@ def compute_csa_indexer_grads(
     return grad_q, grad_weights, grad_k
 
 
+def _compute_csa_selected_set_kl_loss(
+    target: Tensor,
+    topk_probs: Tensor,
+    loss_coeff: float,
+    loss_mask: Tensor | None = None,
+    global_valid_count: float | None = None,
+) -> Tensor:
+    eps = 1e-10
+    kl_per_elem = target * (
+        paddle.log(target + eps) - paddle.log(topk_probs + eps)
+    )
+    kl_per_pos = kl_per_elem.sum(axis=-1)
+    if loss_mask is not None:
+        lm = loss_mask.reshape(kl_per_pos.shape).astype(kl_per_pos.dtype)
+        return (kl_per_pos * lm).sum() / global_valid_count * float(loss_coeff)
+    return kl_per_pos.mean() * float(loss_coeff)
+
+
+def _indexcache_offload_saved_delta(value: Tensor) -> tuple[Tensor, int | None]:
+    """Keep exact FP16 deltas off GPU until their backward is scheduled."""
+
+    if value.place.is_gpu_place():
+        device_id = value.place.gpu_device_id()
+        return value.cpu(), device_id
+    return value, None
+
+
+def _indexcache_restore_saved_delta(
+    value: Tensor, device_id: int | None
+) -> Tensor:
+    if device_id is not None:
+        return value.cuda(device_id)
+    return value
+
+
+class TileLangCSAIndexerDistillBridge(paddle.autograd.PyLayer):
+    """Keep producer indexer tensors local while exporting score gradients.
+
+    Multi-layer IndexCache distillation needs a served layer's selected-set
+    KL gradient to reach the producer indexer. Sending q/weights/k through
+    every pipeline stage keeps hundreds of MiB live per microbatch. This
+    bridge saves those tensors only on the producer stage and exports the much
+    smaller top-k probability tensor as the differentiable pipeline state.
+
+    The gradient received for ``topk_probs`` is intentionally the served-layer
+    gradient with respect to the selected index scores. When a producer delta
+    is provided, the bridge adds the producer layer's own selected-set loss
+    gradient before invoking one TileLang backward kernel. This preserves the
+    original producer-plus-served distillation math without two full backward
+    contexts for the same indexer tensors.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        index_q: Tensor,
+        weights: Tensor,
+        index_k_comp: Tensor,
+        topk_indices: Tensor,
+        topk_probs: Tensor,
+        producer_score_delta: Tensor | None = None,
+        producer_loss_coeff: float = 0.0,
+        producer_num_rows_override: float | None = None,
+        producer_layer: int = -1,
+    ) -> Tensor:
+        ctx.input_stop_gradients = (
+            bool(index_q.stop_gradient),
+            bool(weights.stop_gradient),
+            bool(index_k_comp.stop_gradient),
+        )
+        saved_tensors = [
+            index_q.detach(),
+            weights.detach(),
+            index_k_comp.detach(),
+            topk_indices.detach(),
+        ]
+        ctx.has_producer_score_delta = producer_score_delta is not None
+        ctx.producer_layer = int(producer_layer)
+        if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
+            print(
+                "[INDEXCACHE_DISTILL_GRAD] "
+                "boundary=producer_bridge_apply "
+                f"producer_layer={ctx.producer_layer} "
+                "producer_loss_combined="
+                f"{ctx.has_producer_score_delta} "
+                f"score_shape={list(topk_probs.shape)}",
+                flush=True,
+            )
+        ctx.producer_score_delta_device_id = None
+        if producer_score_delta is not None:
+            saved_delta, device_id = _indexcache_offload_saved_delta(
+                producer_score_delta.detach()
+            )
+            saved_tensors.append(saved_delta)
+            ctx.producer_score_delta_device_id = device_id
+        ctx.save_for_backward(*saved_tensors)
+        ctx.producer_loss_coeff = float(producer_loss_coeff)
+        ctx.producer_num_rows = producer_num_rows_override
+        return topk_probs.clone()
+
+    @staticmethod
+    def backward(ctx, grad_index_scores: Tensor):
+        saved_tensors = ctx.saved_tensor()
+        index_q, weights, index_k_comp, topk_indices = saved_tensors[:4]
+        if getattr(ctx, "has_producer_score_delta", False):
+            producer_score_delta = _indexcache_restore_saved_delta(
+                saved_tensors[4],
+                getattr(ctx, "producer_score_delta_device_id", None),
+            ).cast("float32")
+            producer_grad = producer_score_delta * (
+                ctx.producer_loss_coeff
+                / max(getattr(ctx, "producer_num_rows", 1.0), 1.0)
+            )
+            scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
+            if scale is not None:
+                producer_grad = producer_grad * scale
+            if grad_index_scores is None:
+                grad_index_scores = producer_grad
+            else:
+                grad_index_scores = (
+                    grad_index_scores.cast("float32") + producer_grad
+                )
+
+        debug_enabled = os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1"
+        if debug_enabled:
+            score_summary = summarize_indexcache_gradients(
+                [("score", grad_index_scores)]
+            )["score"]
+            print(
+                "[INDEXCACHE_DISTILL_GRAD] "
+                "boundary=producer_bridge_backward_enter "
+                f"producer_layer={ctx.producer_layer} "
+                f"score_grad_shape={list(grad_index_scores.shape) if grad_index_scores is not None else None} "
+                f"{format_indexcache_gradient_summary('score_grad', score_summary)}",
+                flush=True,
+            )
+
+        from paddlefleet.tilelang_ops import csa_indexer_bwd
+
+        grad_q, grad_weights, grad_k = csa_indexer_bwd(
+            index_q,
+            weights,
+            index_k_comp,
+            topk_indices,
+            grad_index_scores,
+        )
+        if debug_enabled:
+            print(
+                "[INDEXCACHE_DISTILL_GRAD] "
+                "boundary=producer_bridge_kernel_done "
+                f"producer_layer={ctx.producer_layer} "
+                f"q_grad_shape={list(grad_q.shape)} "
+                f"weights_grad_shape={list(grad_weights.shape)} "
+                f"k_grad_shape={list(grad_k.shape)}",
+                flush=True,
+            )
+        if grad_q.dtype != index_q.dtype:
+            grad_q = grad_q.cast(index_q.dtype)
+        if grad_weights.dtype != weights.dtype:
+            grad_weights = grad_weights.cast(weights.dtype)
+        if grad_k.dtype != index_k_comp.dtype:
+            grad_k = grad_k.cast(index_k_comp.dtype)
+
+        grads = [grad_q, grad_weights, grad_k]
+        for idx, stop_gradient in enumerate(ctx.input_stop_gradients):
+            if stop_gradient:
+                grads[idx] = None
+
+        if debug_enabled:
+            grad_summaries = summarize_indexcache_gradients(
+                list(zip(("q", "weights", "k"), grads))
+            )
+            print(
+                "[INDEXCACHE_DISTILL_GRAD] "
+                "boundary=producer_bridge_grad_ready "
+                f"producer_layer={ctx.producer_layer} "
+                "producer_loss_combined="
+                f"{getattr(ctx, 'has_producer_score_delta', False)} "
+                f"q_grad_shape={list(grad_q.shape)} "
+                f"weights_grad_shape={list(grad_weights.shape)} "
+                f"k_grad_shape={list(grad_k.shape)} "
+                f"{format_indexcache_gradient_summary('q_grad', grad_summaries['q'])} "
+                f"{format_indexcache_gradient_summary('weights_grad', grad_summaries['weights'])} "
+                f"{format_indexcache_gradient_summary('k_grad', grad_summaries['k'])}",
+                flush=True,
+            )
+
+        output_grads = (*grads, None, None)
+        if getattr(ctx, "has_producer_score_delta", False):
+            return (*output_grads, None)
+        return output_grads
+
+
+class IndexCacheServedDistillLossAutoScaler(paddle.autograd.PyLayer):
+    """Send the original selected-score KL gradient to a producer bridge."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        output: Tensor,
+        topk_probs: Tensor,
+        target: Tensor,
+        loss_coeff: float,
+        num_rows_override: float | None = None,
+        loss_mask: Tensor | None = None,
+        served_layer: int = -1,
+        producer_layer: int = -1,
+    ) -> Tensor:
+        ctx.topk_probs_stop_gradient = bool(topk_probs.stop_gradient)
+        ctx.served_layer = int(served_layer)
+        ctx.producer_layer = int(producer_layer)
+        score_delta = topk_probs.detach() - target.detach()
+        ctx.has_loss_mask = loss_mask is not None
+        if loss_mask is not None:
+            score_delta = score_delta * loss_mask.reshape(
+                [score_delta.shape[0], score_delta.shape[1], 1]
+            ).astype(score_delta.dtype)
+        # Backward only needs (topk_probs - target), not both 32-bit tensors.
+        # Their range is [-1, 1], so an FP16 saved delta preserves the score
+        # gradient while reducing this served-layer context from 128 to 32 MiB
+        # for the real [1, 32768, 512] shape.
+        saved_delta, device_id = _indexcache_offload_saved_delta(
+            score_delta.cast("float16")
+        )
+        ctx.save_for_backward(saved_delta)
+        ctx.score_delta_device_id = device_id
+        ctx.loss_coeff = float(loss_coeff)
+        if num_rows_override is not None:
+            ctx.num_rows = num_rows_override
+        else:
+            ctx.num_rows = float(target.shape[0] * target.shape[1])
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        (score_delta,) = ctx.saved_tensor()
+        score_delta = _indexcache_restore_saved_delta(
+            score_delta,
+            getattr(ctx, "score_delta_device_id", None),
+        )
+        grad_index_scores = score_delta.cast("float32") * (
+            ctx.loss_coeff / max(getattr(ctx, "num_rows", 1.0), 1.0)
+        )
+        scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
+        if scale is not None:
+            grad_index_scores = grad_index_scores * scale
+        if ctx.topk_probs_stop_gradient:
+            grad_index_scores = None
+
+        if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
+            score_summary = summarize_indexcache_gradients(
+                [("score", grad_index_scores)]
+            )["score"]
+            print(
+                "[INDEXCACHE_DISTILL_GRAD] boundary=served_score_backward "
+                f"served_layer={ctx.served_layer} "
+                f"producer_layer={ctx.producer_layer} "
+                f"routed={grad_index_scores is not None} "
+                f"score_shape={list(score_delta.shape)} "
+                "saved_delta_offloaded="
+                f"{getattr(ctx, 'score_delta_device_id', None) is not None} "
+                f"has_loss_mask={getattr(ctx, 'has_loss_mask', False)} "
+                f"{format_indexcache_gradient_summary('score_grad', score_summary)}",
+                flush=True,
+            )
+
+        grads = (grad_output, grad_index_scores, None)
+        if getattr(ctx, "has_loss_mask", False):
+            return (*grads, None)
+        return grads
+
+
 class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
     """Attach TileLang CSA indexer loss gradients to the main output.
 
@@ -1420,17 +1739,23 @@ class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
     def forward(
         ctx,
         output: Tensor,
-        target: Tensor,
         index_q: Tensor,
         weights: Tensor,
         index_k_comp: Tensor,
         topk_indices: Tensor,
         topk_probs: Tensor,
+        target: Tensor,
         loss_coeff: float,
         indexer_backend: str = "tilelang",
         num_rows_override: float | None = None,
         loss_mask: Tensor | None = None,
     ) -> Tensor:
+        ctx.input_stop_gradients = (
+            bool(output.stop_gradient),
+            bool(index_q.stop_gradient),
+            bool(weights.stop_gradient),
+            bool(index_k_comp.stop_gradient),
+        )
         ctx.save_for_backward(
             index_q.detach(),
             weights.detach(),
@@ -1478,7 +1803,7 @@ class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
         )
 
         grad_main = grad_output if ctx.output_needs_grad else None
-        grads = (grad_main, None, grad_q, grad_weights, grad_k, None, None)
+        grads = (grad_main, grad_q, grad_weights, grad_k, None, None, None)
         if getattr(ctx, "loss_mask", None) is not None:
             grads += (None,)
         return grads
@@ -1517,6 +1842,7 @@ class TilelangIndexerLossState(NamedTuple):
     index_k_comp: Tensor
     topk_indices: Tensor
     topk_probs: Tensor
+    target: Tensor | None
     indexer_loss_coeff: float
     indexer_backend: str
     global_valid_count: Tensor | None
@@ -2454,6 +2780,710 @@ class CompressedSparseAttention(FleetLayer):
             config, "sparse_attn_global_kv_idx_remap_fusion", False
         )
 
+    def _indexcache_pattern(self) -> str | None:
+        pattern = getattr(self.config, "index_topk_pattern", None)
+        if pattern is None:
+            return None
+        pattern = str(pattern).strip().upper()
+        if not pattern:
+            return None
+        invalid_chars = sorted(set(pattern) - {"F", "S"})
+        if invalid_chars:
+            raise ValueError(
+                "index_topk_pattern may only contain 'F' and 'S', "
+                f"got invalid chars: {invalid_chars}."
+            )
+        if pattern[0] != "F":
+            raise ValueError("index_topk_pattern must start with 'F'.")
+        return pattern
+
+    def _indexcache_recompute_enabled(self) -> bool:
+        return bool(getattr(self.config, "recompute_granularity", None))
+
+    def _indexcache_in_recompute(self) -> bool:
+        return (
+            self._indexcache_recompute_enabled()
+            and self.training
+            and not paddle.is_grad_enabled()
+        )
+
+    def _indexcache_context_msg(self, c4_ordinal: int, pattern: str) -> str:
+        return (
+            f"layer_number={self.layer_number}, "
+            f"c4_ordinal={c4_ordinal}, "
+            f"pattern={pattern}, "
+            "recompute_granularity="
+            f"{getattr(self.config, 'recompute_granularity', None)}, "
+            "pipeline_model_parallel_size="
+            f"{getattr(self.config, 'pipeline_model_parallel_size', 1)}, "
+            "context_parallel_size="
+            f"{getattr(self.config, 'context_parallel_size', 1)}"
+        )
+
+    def _indexcache_requires_explicit_state(self) -> bool:
+        pp_size = int(
+            getattr(self.config, "pipeline_model_parallel_size", 1) or 1
+        )
+        cp_size = int(getattr(self.config, "context_parallel_size", 1) or 1)
+        return (
+            self._indexcache_recompute_enabled() or pp_size > 1 or cp_size > 1
+        )
+
+    @staticmethod
+    def _indexcache_state_kind(indexcache_state: tuple | list | None) -> str:
+        return state_kind(indexcache_state)
+
+    def _indexcache_validate_state_for_reuse(
+        self,
+        indexcache_state: tuple | list | None,
+        c4_ordinal: int,
+        pattern: str,
+    ) -> str:
+        state_kind = self._indexcache_state_kind(indexcache_state)
+        if state_kind == INDEXCACHE_STATE_KIND_INVALID:
+            raise ValueError(
+                "IndexCache state must be either topk-only "
+                f"({INDEXCACHE_TOPK_ONLY_STATE_LEN} tensors) or distill "
+                "(8 tensors), got "
+                f"len={len(indexcache_state)}. "
+                + self._indexcache_context_msg(c4_ordinal, pattern)
+            )
+        if (
+            state_kind == INDEXCACHE_STATE_KIND_DISTILL
+            and not self._indexcache_multi_layer_distill_enabled()
+        ):
+            raise RuntimeError(
+                "IndexCache reuse-only expects a topk-only indexcache_state; "
+                "distill-state tensors require "
+                "indexcache_multi_layer_distill=True. "
+                f"state_kind={state_kind}. "
+                + self._indexcache_context_msg(c4_ordinal, pattern)
+            )
+        return state_kind
+
+    def _indexcache_debug(self, msg: str) -> None:
+        if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
+            cp_msg = (
+                f" cp_rank={self.cp_rank} cp_size={self.cp_size}"
+                if self.cp_enabled
+                else ""
+            )
+            recompute_msg = (
+                " recompute_enabled="
+                f"{self._indexcache_recompute_enabled()}"
+                " in_recompute="
+                f"{self._indexcache_in_recompute()}"
+                " grad_enabled="
+                f"{paddle.is_grad_enabled()}"
+            )
+            print(
+                f"[INDEXCACHE_TRAIN] layer={self.layer_number}{cp_msg}"
+                f"{recompute_msg} {msg}",
+                flush=True,
+            )
+
+    def _indexcache_distill_debug(self, msg: str) -> None:
+        if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
+            cp_msg = (
+                f" cp_rank={self.cp_rank} cp_size={self.cp_size}"
+                if self.cp_enabled
+                else ""
+            )
+            print(
+                f"[INDEXCACHE_DISTILL] layer={self.layer_number}{cp_msg} {msg}",
+                flush=True,
+            )
+
+    def _indexcache_multi_layer_distill_enabled(self) -> bool:
+        return bool(
+            getattr(self.config, "indexcache_multi_layer_distill", False)
+        )
+
+    @staticmethod
+    def _indexcache_served_count(pattern: str, c4_ordinal: int) -> int:
+        next_f = pattern.find("F", c4_ordinal + 1)
+        if next_f == -1:
+            next_f = len(pattern)
+        return max(1, next_f - c4_ordinal)
+
+    def _indexcache_scaled_loss_coeff(self, served_count: int) -> float:
+        coeff = getattr(self.config, "dsa_indexer_loss_coeff", 0.0) or 0.0
+        return float(coeff) / float(max(int(served_count), 1))
+
+    def _indexcache_attach_indexer_loss(
+        self,
+        output: Tensor,
+        indexer_loss: Tensor | None,
+        tilelang_indexer_loss_state: tuple | None,
+        producer_loss_fused: bool,
+    ) -> Tensor:
+        if not (self.training and paddle.is_grad_enabled()):
+            return output
+        if tilelang_indexer_loss_state is not None:
+            if producer_loss_fused:
+                return output
+            return TileLangCSAIndexerLossAutoScaler.apply(
+                output,
+                *tilelang_indexer_loss_state,
+            )
+        if indexer_loss is not None:
+            return DSAIndexerLossAutoScaler.apply(output, indexer_loss)
+        return output
+
+    def _indexcache_clear_cached_state(self) -> None:
+        self.config._indexcache_last_topk_idxs = None
+        self.config._indexcache_last_layer_number = None
+        self.config._indexcache_last_distill_state = None
+        self.config._indexcache_last_served_count = None
+
+    def _indexcache_c4_layers(self) -> list[int]:
+        ratios = getattr(self.config, "csa_compress_ratios", None) or []
+        # DSv4HybridAttention passes ratio index + 1 to CSA, so
+        # self.layer_number is normalized one-based and no longer includes
+        # the model-level empty-head offset.
+        return [
+            int(layer_idx) + 1
+            for layer_idx, ratio in enumerate(ratios)
+            if int(ratio) == 4
+        ]
+
+    def _indexcache_infer_producer_layer(
+        self, c4_ordinal: int, pattern: str
+    ) -> int | None:
+        producer_ordinal = min(c4_ordinal - 1, len(pattern) - 1)
+        while producer_ordinal >= 0 and pattern[producer_ordinal] != "F":
+            producer_ordinal -= 1
+        if producer_ordinal < 0:
+            return None
+
+        c4_layers = self._indexcache_c4_layers()
+        if producer_ordinal >= len(c4_layers):
+            return None
+        return c4_layers[producer_ordinal]
+
+    @staticmethod
+    def _indexcache_has_future_served_layer(
+        pattern: str, c4_ordinal: int
+    ) -> bool:
+        next_f = pattern.find("F", c4_ordinal + 1)
+        end = next_f if next_f != -1 else len(pattern)
+        return "S" in pattern[c4_ordinal + 1 : end]
+
+    def _indexcache_next_c4_action(self) -> tuple[int, str, str] | None:
+        pattern = self._indexcache_pattern()
+        if pattern is None or self.compress_ratio != 4 or self.indexer is None:
+            return None
+
+        c4_layers = self._indexcache_c4_layers()
+        if self.layer_number not in c4_layers:
+            raise RuntimeError(
+                "IndexCache C4 static mapping could not find the current "
+                f"layer={self.layer_number} in csa_compress_ratios C4 layers "
+                f"{c4_layers}."
+            )
+        c4_ordinal = c4_layers.index(self.layer_number)
+        if c4_ordinal >= len(pattern):
+            raise ValueError(
+                "index_topk_pattern must cover every C4 layer in this "
+                f"configuration. pattern={pattern}, c4_layers={c4_layers}, "
+                f"current_c4_ordinal={c4_ordinal}."
+            )
+
+        if c4_ordinal == 0:
+            self._indexcache_clear_cached_state()
+
+        action = pattern[c4_ordinal]
+        return c4_ordinal, action, pattern
+
+    @staticmethod
+    def _indexcache_tensor_to_int(value: Tensor | int | None) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, int):
+            return value
+        try:
+            return int(value.item())
+        except Exception:
+            return int(value.numpy().reshape([-1])[0])
+
+    @staticmethod
+    def _indexcache_forward_state_tensor(value: Tensor) -> Tensor:
+        return detach_stop_gradient_tensor(value)
+
+    def _indexcache_pack_state(
+        self,
+        compress_topk_idxs: Tensor,
+        tilelang_indexer_loss_state: tuple | None = None,
+        served_count: int | None = None,
+        fuse_producer_loss: bool = False,
+    ) -> tuple[Tensor, ...]:
+        state = [self._indexcache_forward_state_tensor(compress_topk_idxs)]
+        include_distill_state = (
+            self._indexcache_multi_layer_distill_enabled()
+            and tilelang_indexer_loss_state is not None
+        )
+        if include_distill_state:
+            (
+                q_indexer_bf,
+                weights_indexer_bf,
+                k_indexer_bf,
+                topk_indices_compressed,
+                topk_probs,
+                *_,
+            ) = tilelang_indexer_loss_state
+            if self.training and paddle.is_grad_enabled():
+                producer_target = (
+                    tilelang_indexer_loss_state[5]
+                    if len(tilelang_indexer_loss_state) > 5
+                    else None
+                )
+                if fuse_producer_loss and producer_target is not None:
+                    producer_loss_coeff = float(tilelang_indexer_loss_state[6])
+                    producer_num_rows = (
+                        tilelang_indexer_loss_state[8]
+                        if len(tilelang_indexer_loss_state) > 8
+                        and tilelang_indexer_loss_state[8] is not None
+                        else float(
+                            producer_target.shape[0] * producer_target.shape[1]
+                        )
+                    )
+                    producer_loss_mask = (
+                        tilelang_indexer_loss_state[9]
+                        if len(tilelang_indexer_loss_state) > 9
+                        else None
+                    )
+                    producer_score_delta = (
+                        topk_probs.detach() - producer_target.detach()
+                    )
+                    if producer_loss_mask is not None:
+                        producer_score_delta = producer_score_delta * (
+                            producer_loss_mask.reshape(
+                                [
+                                    producer_score_delta.shape[0],
+                                    producer_score_delta.shape[1],
+                                    1,
+                                ]
+                            ).astype(producer_score_delta.dtype)
+                        )
+                    # The producer and all served layers contribute score
+                    # gradients to one bridge/backward kernel. Saving one
+                    # FP16 delta preserves the producer loss without retaining
+                    # a second full TileLang backward context.
+                    if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1":
+                        print(
+                            "[INDEXCACHE_DISTILL_GRAD] "
+                            "boundary=producer_bridge_forward "
+                            "producer_loss_combined=True "
+                            f"score_shape={list(topk_probs.shape)}",
+                            flush=True,
+                        )
+                    distill_topk_probs = TileLangCSAIndexerDistillBridge.apply(
+                        q_indexer_bf,
+                        weights_indexer_bf,
+                        k_indexer_bf,
+                        topk_indices_compressed,
+                        topk_probs,
+                        producer_score_delta.cast("float16"),
+                        producer_loss_coeff,
+                        producer_num_rows,
+                        self.layer_number,
+                    )
+                else:
+                    distill_topk_probs = TileLangCSAIndexerDistillBridge.apply(
+                        q_indexer_bf,
+                        weights_indexer_bf,
+                        k_indexer_bf,
+                        topk_indices_compressed,
+                        topk_probs,
+                        None,
+                        0.0,
+                        None,
+                        self.layer_number,
+                    )
+            else:
+                distill_topk_probs = topk_probs.detach()
+            pipeline_topk_probs = distill_topk_probs
+            if (
+                self._indexcache_requires_explicit_state()
+                and distill_topk_probs.dtype == paddle.float32
+            ):
+                # The explicit state crosses pipeline/CP boundaries or is
+                # retained for recompute. BF16 halves its dominant probability
+                # tensor while the cast's backward keeps the producer bridge
+                # gradient-connected. Served layers restore FP32 immediately.
+                pipeline_topk_probs = distill_topk_probs.cast("bfloat16")
+            empty_q = self._indexcache_forward_state_tensor(
+                paddle.empty([0], dtype=q_indexer_bf.dtype)
+            )
+            empty_weights = self._indexcache_forward_state_tensor(
+                paddle.empty([0], dtype=weights_indexer_bf.dtype)
+            )
+            empty_k = self._indexcache_forward_state_tensor(
+                paddle.empty([0], dtype=k_indexer_bf.dtype)
+            )
+            empty_topk_indices = self._indexcache_forward_state_tensor(
+                paddle.empty([0], dtype=topk_indices_compressed.dtype)
+            )
+            compressed_kv_shape = list(k_indexer_bf.shape)
+            compressed_kv_length = (
+                int(compressed_kv_shape[-2])
+                if len(compressed_kv_shape) >= 2
+                else None
+            )
+            pipeline_topk_indices = topk_indices_compressed
+            topk_shape = list(topk_indices_compressed.shape)
+            if (
+                compressed_kv_length is not None
+                and 0 < compressed_kv_length <= (1 << 15)
+                and topk_shape
+                and topk_shape[-1] % 2 == 0
+            ):
+                # Raw block ids are in [-1, n_compressed). Shift them into
+                # [0, 32768] and pair-pack them with base 32769. The maximum
+                # packed value remains within signed int32, reducing the last
+                # dimension by half while retaining Paddle/NCCL's supported
+                # int32 transport dtype. Keep the original tensor local for
+                # TileLang backward and unpack at every served layer.
+                pipeline_topk_indices = _pack_indexcache_pipeline_topk(
+                    topk_indices_compressed
+                )
+            state[INDEXCACHE_STATE_TOPK_IDXS] = (
+                self._indexcache_forward_state_tensor(pipeline_topk_indices)
+            )
+            state.extend(
+                [
+                    empty_q,
+                    empty_weights,
+                    empty_k,
+                    empty_topk_indices,
+                    pipeline_topk_probs,
+                    self._indexcache_forward_state_tensor(
+                        paddle.full([1], self.layer_number, dtype="int64")
+                    ),
+                    self._indexcache_forward_state_tensor(
+                        paddle.full([1], int(served_count or 1), dtype="int64")
+                    ),
+                ]
+            )
+        else:
+            state.extend(
+                [
+                    self._indexcache_forward_state_tensor(
+                        paddle.full([1], self.layer_number, dtype="int64")
+                    ),
+                    self._indexcache_forward_state_tensor(
+                        paddle.full([1], int(served_count or 1), dtype="int64")
+                    ),
+                ]
+            )
+        return apply_stop_gradient_mask(tuple(state))
+
+    def _indexcache_state_topk(
+        self,
+        indexcache_state: tuple | list | None,
+        c4_ordinal: int,
+        pattern: str,
+    ) -> tuple[Tensor | None, int | None, str]:
+        state_kind = self._indexcache_validate_state_for_reuse(
+            indexcache_state, c4_ordinal, pattern
+        )
+        if not indexcache_state:
+            return None, None, state_kind
+        producer_layer = None
+        if state_kind == INDEXCACHE_STATE_KIND_DISTILL:
+            producer_layer = self._indexcache_tensor_to_int(
+                indexcache_state[INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER]
+            )
+        elif state_kind == INDEXCACHE_STATE_KIND_TOPK_ONLY:
+            producer_layer = self._indexcache_tensor_to_int(
+                indexcache_state[INDEXCACHE_TOPK_ONLY_STATE_PRODUCER_LAYER]
+            )
+        if producer_layer is None:
+            producer_layer = getattr(
+                self.config, "_indexcache_last_layer_number", None
+            )
+        return (
+            indexcache_state[INDEXCACHE_STATE_TOPK_IDXS],
+            producer_layer,
+            state_kind,
+        )
+
+    def _indexcache_cache_topk(
+        self,
+        compress_topk_idxs: Tensor,
+        c4_ordinal: int,
+        pattern: str,
+        tilelang_indexer_loss_state: tuple | None = None,
+        served_count: int | None = None,
+        loss_scale: float | None = None,
+        fuse_producer_loss: bool = False,
+    ) -> tuple[Tensor, ...]:
+        use_config_fallback = not self._indexcache_requires_explicit_state()
+        if use_config_fallback:
+            self.config._indexcache_last_topk_idxs = compress_topk_idxs.detach()
+            self.config._indexcache_last_layer_number = self.layer_number
+        else:
+            # Pipeline/CP/recompute consumers are required to use the explicit
+            # returned state. Retaining config fallbacks here keeps one full
+            # top-k tensor and one compact distill state alive unnecessarily.
+            self._indexcache_clear_cached_state()
+        if (
+            self._indexcache_multi_layer_distill_enabled()
+            and tilelang_indexer_loss_state is not None
+        ):
+            state_kind = INDEXCACHE_STATE_KIND_DISTILL
+            if use_config_fallback:
+                self.config._indexcache_last_served_count = served_count
+            self._indexcache_distill_debug(
+                "action=producer "
+                f"c4_ordinal={c4_ordinal} served_count={served_count} "
+                f"loss_scale={loss_scale:.8g}"
+            )
+        else:
+            state_kind = INDEXCACHE_STATE_KIND_TOPK_ONLY
+        self._indexcache_debug(
+            "action=produce "
+            f"c4_ordinal={c4_ordinal} pattern={pattern} "
+            f"state_kind={state_kind} "
+            f"topk_shape={list(compress_topk_idxs.shape)}"
+        )
+        packed_state = self._indexcache_pack_state(
+            compress_topk_idxs,
+            tilelang_indexer_loss_state,
+            served_count,
+            fuse_producer_loss,
+        )
+        if state_kind == INDEXCACHE_STATE_KIND_DISTILL and use_config_fallback:
+            self.config._indexcache_last_distill_state = (
+                packed_state[INDEXCACHE_DISTILL_STATE_TOPK_INDICES],
+                packed_state[INDEXCACHE_DISTILL_STATE_TOPK_PROBS],
+            )
+        return packed_state
+
+    def _indexcache_reuse_topk(
+        self,
+        b: int,
+        sq: int,
+        c4_ordinal: int,
+        pattern: str,
+        indexcache_state: tuple | list | None = None,
+    ) -> Tensor:
+        cached, producer_layer, state_kind = self._indexcache_state_topk(
+            indexcache_state, c4_ordinal, pattern
+        )
+        if cached is None and not self._indexcache_requires_explicit_state():
+            cached = getattr(self.config, "_indexcache_last_topk_idxs", None)
+            producer_layer = getattr(
+                self.config, "_indexcache_last_layer_number", None
+            )
+            if cached is not None:
+                state_kind = "config_fallback"
+        if cached is None:
+            raise RuntimeError(
+                "index_topk_pattern requested reuse before an explicit "
+                "producer top-k state exists. "
+                f"state_kind={state_kind}. "
+                + self._indexcache_context_msg(c4_ordinal, pattern)
+            )
+        cached_shape = list(cached.shape)
+        if (
+            len(cached_shape) < 3
+            or cached_shape[0] != b
+            or cached_shape[1] != sq
+        ):
+            raise ValueError(
+                "Cached IndexCache top-k shape does not match the current "
+                f"layer input. cached={cached_shape}, current_batch={b}, "
+                f"current_seq={sq}."
+            )
+        if producer_layer is None:
+            producer_layer = self._indexcache_infer_producer_layer(
+                c4_ordinal, pattern
+            )
+        if state_kind == INDEXCACHE_STATE_KIND_DISTILL:
+            original_width = int(
+                indexcache_state[INDEXCACHE_DISTILL_STATE_TOPK_PROBS].shape[-1]
+            )
+            cached = _unpack_indexcache_pipeline_topk(cached, original_width)
+            if self.cp_enabled:
+                position_offset = self.cp_rank * sq
+                q_positions = paddle.arange(
+                    position_offset,
+                    position_offset + sq,
+                    dtype="int64",
+                )
+                cached = map_compressed_topk_to_kv_full_cp(
+                    cached,
+                    q_positions,
+                    int(self.compress_ratio),
+                    sq * self.cp_size,
+                )
+            else:
+                cached = _map_compressed_topk_to_kv_full(
+                    cached,
+                    sq,
+                    int(self.compress_ratio),
+                    sq,
+                )
+        self._indexcache_debug(
+            "action=reuse "
+            f"c4_ordinal={c4_ordinal} pattern={pattern} "
+            f"producer_layer={producer_layer} state_kind={state_kind} "
+            f"topk_shape={cached_shape}"
+        )
+        return cached
+
+    def _indexcache_served_distill_state(
+        self,
+        query: Tensor,
+        compressed_kv: Tensor,
+        c4_ordinal: int,
+        pattern: str,
+        loss_mask: Tensor | None = None,
+        global_valid_count: float | None = None,
+        indexcache_state: tuple | list | None = None,
+    ) -> tuple | None:
+        if not (
+            self._indexcache_multi_layer_distill_enabled()
+            and self.training
+            and paddle.is_grad_enabled()
+        ):
+            return None
+
+        producer_state = None
+        producer_layer = None
+        served_count = None
+        if indexcache_state is not None:
+            state_kind = self._indexcache_state_kind(indexcache_state)
+            if state_kind == INDEXCACHE_STATE_KIND_DISTILL:
+                producer_state = (
+                    indexcache_state[INDEXCACHE_DISTILL_STATE_TOPK_INDICES],
+                    indexcache_state[INDEXCACHE_DISTILL_STATE_TOPK_PROBS],
+                )
+                producer_layer = self._indexcache_tensor_to_int(
+                    indexcache_state[INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER]
+                )
+                served_count = self._indexcache_tensor_to_int(
+                    indexcache_state[INDEXCACHE_DISTILL_STATE_SERVED_COUNT]
+                )
+            else:
+                raise RuntimeError(
+                    "indexcache_multi_layer_distill received a producer "
+                    "top-k state without producer loss tensors. "
+                    f"c4_ordinal={c4_ordinal}, pattern={pattern}."
+                )
+
+        if (
+            producer_state is None
+            and not self._indexcache_requires_explicit_state()
+        ):
+            producer_state = getattr(
+                self.config, "_indexcache_last_distill_state", None
+            )
+            producer_layer = getattr(
+                self.config, "_indexcache_last_layer_number", None
+            )
+            served_count = getattr(
+                self.config, "_indexcache_last_served_count", None
+            )
+        if producer_state is None or served_count is None:
+            raise RuntimeError(
+                "indexcache_multi_layer_distill requested an S-layer target "
+                "before an explicit producer distill state exists. "
+                + self._indexcache_context_msg(c4_ordinal, pattern)
+            )
+
+        (
+            topk_indices_compressed,
+            topk_probs,
+        ) = producer_state
+        # Distill pipeline state may pair-pack two block ids into one int32.
+        # Both selected-target implementations retain their established full
+        # shape int32 input contract.
+        topk_indices_compressed = _unpack_indexcache_pipeline_topk(
+            topk_indices_compressed, int(topk_probs.shape[-1])
+        )
+        if topk_probs.dtype != paddle.float32:
+            topk_probs = topk_probs.cast("float32")
+        key_comp_mla = compressed_kv.detach()
+
+        if (
+            self.tp_group is not None
+            and getattr(self.tp_group, "nranks", 1) > 1
+        ):
+            target = _compute_attn_target_on_selected_set(
+                query.detach(),
+                key_comp_mla,
+                topk_indices_compressed.detach(),
+                self.softmax_scale,
+                self.tp_group,
+            )
+        else:
+            from paddlefleet.tilelang_ops import csa_attn_target_reducesum
+
+            target = csa_attn_target_reducesum(
+                query.detach(),
+                key_comp_mla,
+                topk_indices_compressed.detach(),
+                self.softmax_scale,
+            )
+
+        loss_scale = self._indexcache_scaled_loss_coeff(int(served_count))
+        if self.cp_enabled and loss_mask is None:
+            loss_scale /= float(self.cp_size)
+        if loss_scale > 0:
+            loss = _compute_csa_selected_set_kl_loss(
+                target.detach(),
+                topk_probs.detach(),
+                loss_scale,
+                loss_mask,
+                global_valid_count,
+            )
+            DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+                loss=loss,
+                layer_number=self.layer_number,
+                num_layers=DSAIndexerLossLoggingHelper.get_total_num_layers(
+                    self.config
+                ),
+            )
+        self._indexcache_distill_debug(
+            "action=served "
+            f"c4_ordinal={c4_ordinal} pattern={pattern} "
+            f"producer_layer={producer_layer} served_count={served_count} "
+            f"topk_shape={list(topk_indices_compressed.shape)} "
+            f"loss_scale={loss_scale:.8g}"
+        )
+        return (
+            topk_probs,
+            target,
+            loss_scale,
+            global_valid_count if loss_mask is not None else None,
+            loss_mask,
+            self.layer_number,
+            int(producer_layer if producer_layer is not None else -1),
+        )
+
+    def _postprocess_indexer_replay(
+        self,
+        compress_topk_idxs: Tensor,
+        n_compressed: int,
+        offset: int,
+        *,
+        position_offset: int = 0,
+        q_positions: Tensor | None = None,
+    ) -> Tensor:
+        """Extension point for training-side Indexer Replay.
+
+        PaddleFleet owns IndexCache's producer/served state machine, while
+        PaddleRL optionally patches this identity hook to replace the final
+        compressed attention indices with behavior-time Replay indices.  The
+        hook is deliberately after IndexCache state materialization so Replay
+        changes only the indices consumed by attention; it does not corrupt
+        the producer state or multi-layer distillation tensors.
+        """
+        return compress_topk_idxs
+
+
     def _resolve_topk_effective(self, n_compressed: int):
         """Return the CSA indexer top-k width for current phase.
 
@@ -2482,6 +3512,8 @@ class CompressedSparseAttention(FleetLayer):
         loss_mask: Tensor | None = None,
         global_valid_count: float | None = None,
         docmask_meta: CSADocMaskMetadata | None = None,
+        indexer_loss_coeff_override: float | None = None,
+        materialize_distill_state: bool = False,
     ) -> tuple[Tensor, Tensor | None, tuple | None]:
         """Build indexer-selected compressed KV indices and loss state."""
         b, sq, np_heads, _ = query.shape
@@ -2504,18 +3536,27 @@ class CompressedSparseAttention(FleetLayer):
         indexer_backend = getattr(
             self.config, "csa_indexer_backend", "tilelang"
         )
+        if materialize_distill_state and indexer_backend != "tilelang":
+            raise NotImplementedError(
+                "IndexCache distill recompute materialization currently "
+                "supports only csa_indexer_backend='tilelang'."
+            )
         # The indexer loss path is only active during the grad-enabled forward.
         # Full recompute runs the first forward under no_grad; that pass should
-        # only materialize main-attention indices. The backend branch remains
-        # fixed across both forwards.
+        # materialize main-attention indices, plus producer distill state when
+        # a later S layer will consume it. The backend branch remains fixed
+        # across both forwards.
         need_indexer_loss = self.training and paddle.is_grad_enabled()
         # coeff == 0 disables the indexer-loss path entirely (matching
         # DSAttention: 0 disables the KL loss), so the loss kernels/state must
         # not be built -- attention top-k is unaffected.
         indexer_loss_coeff = float(
-            getattr(self.config, "dsa_indexer_loss_coeff", 0.0) or 0.0
+            indexer_loss_coeff_override
+            if indexer_loss_coeff_override is not None
+            else getattr(self.config, "dsa_indexer_loss_coeff", 0.0) or 0.0
         )
         need_indexer_loss = need_indexer_loss and indexer_loss_coeff > 0
+        need_indexer_state = need_indexer_loss or materialize_distill_state
         topk_effective = self._resolve_topk_effective(n_compressed)
 
         causal_mask = _build_compressed_causal_mask(
@@ -2565,11 +3606,11 @@ class CompressedSparseAttention(FleetLayer):
                     valid_range=valid_range,
                     startend_row_indices=startend_row_indices,
                     doc_lens=doc_lens_list,
-                    return_topk_scores=need_indexer_loss,
+                    return_topk_scores=need_indexer_state,
                 )
 
             topk_indices_compressed = topk_indices
-            if need_indexer_loss:
+            if need_indexer_state:
                 (topk_scores,) = topk_scores
                 # Cudnn outputs pre-softmax scores, We need to do softmax ourself.
                 topk_probs = _row_masked_softmax(topk_scores, topk_indices)
@@ -2595,7 +3636,7 @@ class CompressedSparseAttention(FleetLayer):
                 )
 
             topk_indices_compressed = topk_indices
-            if need_indexer_loss:
+            if need_indexer_state:
                 topk_probs = topk_scores
 
         elif (
@@ -2651,14 +3692,38 @@ class CompressedSparseAttention(FleetLayer):
                     docmask_meta=docmask_meta,
                 )
 
-        if indexer_backend in ("cudnn", "tilelang") and need_indexer_loss:
+        if indexer_backend in ("cudnn", "tilelang") and need_indexer_state:
+            target = None
+            if materialize_distill_state:
+                if self.tp_group is not None and getattr(
+                    self.tp_group, "nranks", 1
+                ) > 1:
+                    target = _compute_attn_target_on_selected_set(
+                        query.detach(),
+                        compressed_kv.detach(),
+                        topk_indices.detach(),
+                        self.softmax_scale,
+                        self.tp_group,
+                    )
+                else:
+                    from paddlefleet.tilelang_ops import (
+                        csa_attn_target_reducesum,
+                    )
+
+                    target = csa_attn_target_reducesum(
+                        query.detach(),
+                        compressed_kv.detach(),
+                        topk_indices.detach(),
+                        self.softmax_scale,
+                    )
             tilelang_indexer_loss_state = TilelangIndexerLossState(
                 index_q,
                 weights,
                 index_k_comp,
                 topk_indices,
                 topk_probs,
-                self.indexer_loss_coeff,
+                target,
+                indexer_loss_coeff,
                 indexer_backend,
                 global_valid_count if loss_mask is not None else None,
                 loss_mask,
@@ -2836,6 +3901,7 @@ class CompressedSparseAttention(FleetLayer):
         past_key_values=None,
         layer_idx: int | None = None,
         use_cache: bool = False,
+        indexcache_state: tuple | list | None = None,
     ) -> Tensor:
         """Forward pass for CompressedSparseAttention.
 
@@ -2857,6 +3923,8 @@ class CompressedSparseAttention(FleetLayer):
             output: [b, sq, np * v_head_dim]
         """
         b, sq, np_heads, hn = query.shape
+        indexcache_state_next = indexcache_state
+        indexcache_state_updated = False
 
         # Incremental decode: single-token step against the cached state.
         if use_cache and past_key_values is not None and sq == 1:
@@ -2924,7 +3992,7 @@ class CompressedSparseAttention(FleetLayer):
                     "does not support context parallelism yet, got "
                     f"cp={self.cp_size}."
                 )
-            return self._forward_cp(
+            cp_result = self._forward_cp(
                 query,
                 key,
                 x,
@@ -2932,7 +4000,18 @@ class CompressedSparseAttention(FleetLayer):
                 loss_mask=loss_mask,
                 global_valid_count=global_valid_count,
                 docmask_meta=docmask_meta,
+                indexcache_state=indexcache_state,
             )
+            cp_indexcache_state_updated = isinstance(cp_result, tuple)
+            if isinstance(cp_result, tuple):
+                output, indexcache_state_next = cp_result
+            else:
+                output = cp_result
+            if indexcache_state_next is not None:
+                return output, indexcache_state_next
+            if cp_indexcache_state_updated:
+                return output, None
+            return output
 
         if self.is_mqa_layer:
             output = self._forward_mqa(query, key, docmask_meta=docmask_meta)
@@ -3006,28 +4085,112 @@ class CompressedSparseAttention(FleetLayer):
         tilelang_indexer_loss_state = None
         indexer_topk = 0
         lse_indexer = None
+        indexcache_served_loss_state = None
+        indexcache_producer_loss_fused = False
 
         if (
             self.compress_ratio > 1
             and n_compressed > 0
             and actual_n_compressed > 0
         ):
+            indexcache_action = None
             if self.indexer is not None:
-                (
-                    compress_topk_idxs,
-                    indexer_loss,
-                    tilelang_indexer_loss_state,
-                ) = self._compute_indexer_compressed_topk_idxs(
-                    query,
-                    x,
-                    qr,
-                    compressed_kv,
-                    n_compressed,
-                    offset,
-                    loss_mask=loss_mask,
-                    global_valid_count=global_valid_count,
-                    docmask_meta=docmask_meta,
-                )
+                indexcache_action = self._indexcache_next_c4_action()
+                if (
+                    indexcache_action is not None
+                    and indexcache_action[1] == "S"
+                ):
+                    c4_ordinal, _action, pattern = indexcache_action
+                    compress_topk_idxs = self._indexcache_reuse_topk(
+                        b,
+                        sq,
+                        c4_ordinal,
+                        pattern,
+                        indexcache_state=indexcache_state,
+                    )
+                    indexcache_served_loss_state = (
+                        self._indexcache_served_distill_state(
+                            query,
+                            compressed_kv,
+                            c4_ordinal,
+                            pattern,
+                            loss_mask=loss_mask,
+                            global_valid_count=global_valid_count,
+                            indexcache_state=indexcache_state,
+                        )
+                    )
+                    if self._indexcache_has_future_served_layer(
+                        pattern, c4_ordinal
+                    ):
+                        indexcache_state_next = indexcache_state
+                    else:
+                        indexcache_state_next = None
+                        self._indexcache_clear_cached_state()
+                    indexcache_state_updated = True
+                else:
+                    served_count = None
+                    loss_coeff_override = None
+                    materialize_distill_state = False
+                    if (
+                        indexcache_action is not None
+                        and self._indexcache_multi_layer_distill_enabled()
+                    ):
+                        c4_ordinal, _action, pattern = indexcache_action
+                        served_count = self._indexcache_served_count(
+                            pattern, c4_ordinal
+                        )
+                        loss_coeff_override = (
+                            self._indexcache_scaled_loss_coeff(served_count)
+                        )
+                        materialize_distill_state = (
+                            self._indexcache_has_future_served_layer(
+                                pattern, c4_ordinal
+                            )
+                        )
+                    (
+                        compress_topk_idxs,
+                        indexer_loss,
+                        tilelang_indexer_loss_state,
+                    ) = self._compute_indexer_compressed_topk_idxs(
+                        query,
+                        x,
+                        qr,
+                        compressed_kv,
+                        n_compressed,
+                        offset,
+                        loss_mask=loss_mask,
+                        global_valid_count=global_valid_count,
+                        docmask_meta=docmask_meta,
+                        indexer_loss_coeff_override=loss_coeff_override,
+                        materialize_distill_state=materialize_distill_state,
+                    )
+                    if indexcache_action is not None:
+                        c4_ordinal, _action, pattern = indexcache_action
+                        indexcache_producer_loss_fused = bool(
+                            materialize_distill_state
+                            and tilelang_indexer_loss_state is not None
+                            and len(tilelang_indexer_loss_state) > 5
+                            and tilelang_indexer_loss_state[5] is not None
+                            and self.training
+                            and paddle.is_grad_enabled()
+                        )
+                        produced_state = self._indexcache_cache_topk(
+                            compress_topk_idxs,
+                            c4_ordinal,
+                            pattern,
+                            tilelang_indexer_loss_state,
+                            served_count,
+                            loss_coeff_override,
+                            indexcache_producer_loss_fused,
+                        )
+                        if self._indexcache_has_future_served_layer(
+                            pattern, c4_ordinal
+                        ):
+                            indexcache_state_next = produced_state
+                        else:
+                            indexcache_state_next = None
+                            self._indexcache_clear_cached_state()
+                        indexcache_state_updated = True
             else:
                 # ratio=128: attend to all compressed positions
                 compress_topk_idxs = get_compress_topk_idxs(
@@ -3036,6 +4199,16 @@ class CompressedSparseAttention(FleetLayer):
                     sq,
                     offset,
                     docmask_meta=docmask_meta,
+                )
+            if (
+                self.indexer is not None
+                and indexcache_action is not None
+                and indexcache_action[1] == "S"
+            ):
+                compress_topk_idxs = self._postprocess_indexer_replay(
+                    compress_topk_idxs,
+                    n_compressed,
+                    offset,
                 )
             compress_topk_idxs = compress_topk_idxs.astype("int32")
 
@@ -3070,8 +4243,16 @@ class CompressedSparseAttention(FleetLayer):
         if indexer_topk > 0:
             output, lse_indexer = output
 
-        # Step 6: Attach indexer loss
-        if tilelang_indexer_loss_state is not None and self.training:
+        # Step 6: Attach indexer loss. IndexCache producers that must cross a
+        # recompute/pipeline boundary materialize their target before attention;
+        # the regular path keeps the latest backend's post-attention target
+        # construction (including the cuDNN LSE fast path).
+        if (
+            tilelang_indexer_loss_state is not None
+            and tilelang_indexer_loss_state.target is None
+            and self.training
+            and paddle.is_grad_enabled()
+        ):
             target = self._compute_fused_indexer_target(
                 query,
                 kv_full,
@@ -3081,11 +4262,19 @@ class CompressedSparseAttention(FleetLayer):
                 loss_mask,
                 global_valid_count,
             )
-            output = TileLangCSAIndexerLossAutoScaler.apply(
-                output, target, *tilelang_indexer_loss_state
+            tilelang_indexer_loss_state = tilelang_indexer_loss_state._replace(
+                target=target
             )
-        elif indexer_loss is not None and self.training:
-            output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
+        output = self._indexcache_attach_indexer_loss(
+            output,
+            indexer_loss,
+            tilelang_indexer_loss_state,
+            indexcache_producer_loss_fused,
+        )
+        if indexcache_served_loss_state is not None:
+            output = IndexCacheServedDistillLossAutoScaler.apply(
+                output, *indexcache_served_loss_state
+            )
 
         # KV-cache prefill priming: populate the per-layer decode state so the
         # first decode step continues seamlessly from this prefill.
@@ -3093,6 +4282,10 @@ class CompressedSparseAttention(FleetLayer):
             state = past_key_values.get_csa_state(layer_idx)
             self._prime_cache_prefill(state, kv, kv_full, n_compressed, x, sq)
 
+        if indexcache_state_next is not None:
+            return output, indexcache_state_next
+        if indexcache_state_updated:
+            return output, None
         return output
 
     def _prime_cache_prefill(
@@ -3265,6 +4458,7 @@ class CompressedSparseAttention(FleetLayer):
         loss_mask: Tensor | None = None,
         global_valid_count: float | None = None,
         docmask_meta: CSADocMaskMetadata | None = None,
+        indexcache_state: tuple | list | None = None,
     ) -> Tensor:
         """CP-aware forward: local compress + all-gather, sparse attention.
 
@@ -3284,6 +4478,8 @@ class CompressedSparseAttention(FleetLayer):
             reduce_scatter(SUM) + optimizer x cp_size aggregates them correctly
         """
         b, sq, np_heads, hn = query.shape
+        indexcache_state_next = indexcache_state
+        indexcache_state_updated = False
         sq_global = sq * self.cp_size
         position_offset = self.cp_rank * sq
         q_positions = paddle.arange(
@@ -3365,13 +4561,75 @@ class CompressedSparseAttention(FleetLayer):
         tilelang_indexer_loss_state = None
         indexer_topk = 0
         lse_indexer = None
+        indexcache_served_loss_state = None
+        indexcache_producer_loss_fused = False
 
         if (
             self.compress_ratio > 1
             and n_compressed_global > 0
             and actual_n_compressed > 0
         ):
-            if self.indexer is not None:
+            indexcache_action = self._indexcache_next_c4_action()
+            if (
+                self.indexer is not None
+                and indexcache_action is not None
+                and indexcache_action[1] == "S"
+            ):
+                c4_ordinal, _action, pattern = indexcache_action
+                compress_topk_idxs = self._indexcache_reuse_topk(
+                    b,
+                    sq,
+                    c4_ordinal,
+                    pattern,
+                    indexcache_state=indexcache_state,
+                )
+                indexcache_served_loss_state = (
+                    self._indexcache_served_distill_state(
+                        query,
+                        compressed_kv_global,
+                        c4_ordinal,
+                        pattern,
+                        loss_mask=loss_mask,
+                        global_valid_count=global_valid_count,
+                        indexcache_state=indexcache_state,
+                    )
+                )
+                if self._indexcache_has_future_served_layer(
+                    pattern, c4_ordinal
+                ):
+                    indexcache_state_next = indexcache_state
+                else:
+                    indexcache_state_next = None
+                    self._indexcache_clear_cached_state()
+                indexcache_state_updated = True
+            elif self.indexer is not None:
+                served_count = None
+                loss_coeff_override = None
+                materialize_distill_state = False
+                if (
+                    indexcache_action is not None
+                    and self._indexcache_multi_layer_distill_enabled()
+                ):
+                    c4_ordinal, _action, pattern = indexcache_action
+                    served_count = self._indexcache_served_count(
+                        pattern, c4_ordinal
+                    )
+                    loss_coeff_override = self._indexcache_scaled_loss_coeff(
+                        served_count
+                    )
+                    materialize_distill_state = (
+                        self._indexcache_has_future_served_layer(
+                            pattern, c4_ordinal
+                        )
+                    )
+                if (
+                    materialize_distill_state
+                    and self.indexer_backend != "tilelang"
+                ):
+                    raise NotImplementedError(
+                        "IndexCache distill recompute materialization currently "
+                        "supports only csa_indexer_backend='tilelang'."
+                    )
                 x_det = x.detach()
                 qr_det = qr.detach()
                 if self.training:
@@ -3388,7 +4646,10 @@ class CompressedSparseAttention(FleetLayer):
                 # TilelangIndexerLossState must not be built -- attention top-k
                 # keeps flowing through the no-loss branches below.
                 indexer_loss_coeff = float(
-                    getattr(self.config, "dsa_indexer_loss_coeff", 0.0) or 0.0
+                    loss_coeff_override
+                    if loss_coeff_override is not None
+                    else getattr(self.config, "dsa_indexer_loss_coeff", 0.0)
+                    or 0.0
                 )
                 use_fused_indexer_loss_path = (
                     (use_tilelang_indexer or use_cudnn_indexer)
@@ -3482,6 +4743,7 @@ class CompressedSparseAttention(FleetLayer):
                             k_indexer_global,
                             topk_indices_compressed,
                             topk_probs,
+                            None,
                             float(indexer_loss_coeff)
                             if loss_mask is not None
                             else float(indexer_loss_coeff) / self.cp_size,
@@ -3591,6 +4853,53 @@ class CompressedSparseAttention(FleetLayer):
                     topk_indices_compressed = topk_indices_compressed[
                         ..., :topk_effective
                     ].contiguous()
+                if materialize_distill_state:
+                    if (
+                        self.tp_group is not None
+                        and getattr(self.tp_group, "nranks", 1) > 1
+                    ):
+                        target = _compute_attn_target_on_selected_set(
+                            query.detach(),
+                            compressed_kv_global.detach(),
+                            topk_indices_compressed.detach(),
+                            self.softmax_scale,
+                            self.tp_group,
+                        )
+                    else:
+                        from paddlefleet.tilelang_ops import (
+                            csa_attn_target_reducesum,
+                        )
+
+                        target = csa_attn_target_reducesum(
+                            query.detach(),
+                            compressed_kv_global.detach(),
+                            topk_indices_compressed.detach(),
+                            self.softmax_scale,
+                        )
+                    if tilelang_indexer_loss_state is None:
+                        effective_loss_coeff = (
+                            float(loss_coeff_override)
+                            if loss_mask is not None
+                            else float(loss_coeff_override) / self.cp_size
+                        )
+                        tilelang_indexer_loss_state = TilelangIndexerLossState(
+                            q_indexer_bf,
+                            weights_indexer_bf,
+                            k_indexer_global,
+                            topk_indices_compressed,
+                            topk_probs,
+                            target,
+                            effective_loss_coeff,
+                            indexer_backend,
+                            global_valid_count
+                            if loss_mask is not None
+                            else None,
+                            loss_mask,
+                        )
+                    else:
+                        tilelang_indexer_loss_state = (
+                            tilelang_indexer_loss_state._replace(target=target)
+                        )
 
                 compress_topk_idxs = map_compressed_topk_to_kv_full_cp(
                     topk_indices_compressed,
@@ -3598,6 +4907,37 @@ class CompressedSparseAttention(FleetLayer):
                     self.compress_ratio,
                     offset,
                 )
+                if indexcache_action is not None:
+                    c4_ordinal, _action, pattern = indexcache_action
+                    effective_loss_scale = (
+                        tilelang_indexer_loss_state.indexer_loss_coeff
+                        if tilelang_indexer_loss_state is not None
+                        else loss_coeff_override
+                    )
+                    indexcache_producer_loss_fused = bool(
+                        materialize_distill_state
+                        and tilelang_indexer_loss_state is not None
+                        and tilelang_indexer_loss_state.target is not None
+                        and self.training
+                        and paddle.is_grad_enabled()
+                    )
+                    produced_state = self._indexcache_cache_topk(
+                        compress_topk_idxs,
+                        c4_ordinal,
+                        pattern,
+                        tilelang_indexer_loss_state,
+                        served_count,
+                        effective_loss_scale,
+                        indexcache_producer_loss_fused,
+                    )
+                    if self._indexcache_has_future_served_layer(
+                        pattern, c4_ordinal
+                    ):
+                        indexcache_state_next = produced_state
+                    else:
+                        indexcache_state_next = None
+                        self._indexcache_clear_cached_state()
+                    indexcache_state_updated = True
             else:
                 # HCA path: attend to all compressed positions
                 if docmask_meta is None:
@@ -3616,6 +4956,14 @@ class CompressedSparseAttention(FleetLayer):
                         offset, row_start=position_offset, row_count=sq
                     )
 
+            if self.indexer is not None:
+                compress_topk_idxs = self._postprocess_indexer_replay(
+                    compress_topk_idxs,
+                    n_compressed_global,
+                    offset,
+                    position_offset=position_offset,
+                    q_positions=q_positions,
+                )
             compress_topk_idxs = compress_topk_idxs.astype("int32")
 
             if (
@@ -3646,8 +4994,13 @@ class CompressedSparseAttention(FleetLayer):
         if indexer_topk > 0:
             output, lse_indexer = output
 
-        # Step 5: Attach indexer loss
-        if tilelang_indexer_loss_state is not None and self.training:
+        # Step 5: Attach indexer loss.
+        if (
+            tilelang_indexer_loss_state is not None
+            and tilelang_indexer_loss_state.target is None
+            and self.training
+            and paddle.is_grad_enabled()
+        ):
             target = self._compute_fused_indexer_target(
                 query,
                 kv_full,
@@ -3657,12 +5010,24 @@ class CompressedSparseAttention(FleetLayer):
                 loss_mask,
                 global_valid_count,
             )
-            output = TileLangCSAIndexerLossAutoScaler.apply(
-                output, target, *tilelang_indexer_loss_state
+            tilelang_indexer_loss_state = tilelang_indexer_loss_state._replace(
+                target=target
             )
-        elif indexer_loss is not None and self.training:
-            output = DSAIndexerLossAutoScaler.apply(output, indexer_loss)
+        output = self._indexcache_attach_indexer_loss(
+            output,
+            indexer_loss,
+            tilelang_indexer_loss_state,
+            indexcache_producer_loss_fused,
+        )
+        if indexcache_served_loss_state is not None:
+            output = IndexCacheServedDistillLossAutoScaler.apply(
+                output, *indexcache_served_loss_state
+            )
 
+        if indexcache_state_next is not None:
+            return output, indexcache_state_next
+        if indexcache_state_updated:
+            return output, None
         return output
 
     def compressed_sparse_attn(

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -3486,7 +3486,7 @@ class CompressedSparseAttention(FleetLayer):
         *,
         position_offset: int = 0,
         q_positions: Tensor | None = None,
-    ) -> Tensor:
+    ) -> Tensor | tuple[Tensor, bool]:
         """Extension point for training-side Indexer Replay.
 
         PaddleFleet owns IndexCache's producer/served state machine, while
@@ -3495,6 +3495,12 @@ class CompressedSparseAttention(FleetLayer):
         hook is deliberately after IndexCache state materialization so Replay
         changes only the indices consumed by attention; it does not corrupt
         the producer state or multi-layer distillation tensors.
+
+        Overrides may return either the historical bare ``Tensor`` or
+        ``(Tensor, replay_applied)``.  The explicit boolean is what drives
+        ``lse_indexer_matches_topk``, so a Replay implementation that changes the
+        selected set must report it; see ``_apply_indexer_replay`` for how both
+        return shapes are normalized.
         """
         return compress_topk_idxs
 

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -3498,6 +3498,65 @@ class CompressedSparseAttention(FleetLayer):
         """
         return compress_topk_idxs
 
+    def _apply_indexer_replay(
+        self,
+        compress_topk_idxs: Tensor,
+        n_compressed: int,
+        offset: int,
+        *,
+        position_offset: int = 0,
+        q_positions: Tensor | None = None,
+    ) -> tuple[Tensor, bool]:
+        """Apply the optional Replay hook and report whether it supplied data.
+
+        The native compressed top-k table is used by IndexCache state and all
+        Indexer losses.  The hook may return either the historical Tensor-only
+        result or ``(Tensor, bool)`` where the boolean explicitly says that a
+        Replay payload was applied.  For the historical API, returning the
+        exact input object means "no-op"; a distinct Tensor is treated as a
+        possible Replay result and therefore cannot share the attention
+        ``lse_indexer`` with the native loss table.
+
+        Implementations must not mutate ``compress_topk_idxs`` in place.  The
+        identity fallback keeps existing PaddleRL integrations source
+        compatible while allowing them to opt into an explicit status later.
+        """
+        # Keep the original three-argument hook call for the ordinary path.
+        # A number of downstream integrations override this extension point
+        # without accepting the CP-only keyword arguments.  CP callers provide
+        # the extra context explicitly because Replay rows must be sliced and
+        # mapped against global query positions there.
+        if position_offset == 0 and q_positions is None:
+            replay_result = self._postprocess_indexer_replay(
+                compress_topk_idxs,
+                n_compressed,
+                offset,
+            )
+        else:
+            replay_result = self._postprocess_indexer_replay(
+                compress_topk_idxs,
+                n_compressed,
+                offset,
+                position_offset=position_offset,
+                q_positions=q_positions,
+            )
+        replay_applied = False
+        if (
+            isinstance(replay_result, tuple)
+            and len(replay_result) == 2
+            and isinstance(replay_result[1], bool)
+        ):
+            replayed_topk_idxs, replay_applied = replay_result
+        else:
+            replayed_topk_idxs = replay_result
+            replay_applied = replayed_topk_idxs is not compress_topk_idxs
+        if not isinstance(replayed_topk_idxs, paddle.Tensor):
+            raise TypeError(
+                "Indexer Replay hook must return a paddle.Tensor or "
+                "(paddle.Tensor, bool), got "
+                f"{type(replay_result).__name__}."
+            )
+        return replayed_topk_idxs, bool(replay_applied)
 
     def _resolve_topk_effective(self, n_compressed: int):
         """Return the CSA indexer top-k width for current phase.
@@ -3836,14 +3895,22 @@ class CompressedSparseAttention(FleetLayer):
         lse_indexer: Tensor | None = None,
         loss_mask: Tensor | None = None,
         global_valid_count: float | None = None,
+        lse_indexer_matches_topk: bool = True,
     ) -> Tensor:
         """
         Compute indexer target and track indexer loss for cudnn/tilelang
-        backend. The cudnn target kernel is used only when both indexer
-        and sparse_attn use cudnn backend.
+        backend. The cudnn target kernel is used only when both indexer and
+        sparse_attn use cudnn backend and ``lse_indexer`` was produced from the
+        same columns as ``topk_indices``.  Replay changes the columns consumed
+        by attention, so its LSE must not be paired with the native IndexCache
+        loss table.
         """
 
-        if self.indexer_backend == "cudnn" and lse_indexer is not None:
+        if (
+            self.indexer_backend == "cudnn"
+            and lse_indexer is not None
+            and lse_indexer_matches_topk
+        ):
             from paddlefleet_ops.cudnn.deepseek_sparse_attention import (
                 sparse_attn_score_recompute_wrapper,
             )
@@ -3869,6 +3936,10 @@ class CompressedSparseAttention(FleetLayer):
                 self.softmax_scale,
             )["target"]
         else:
+            # Replay can change the columns consumed by sparse attention.  In
+            # that case its ``lse_indexer`` describes a different set, so
+            # recompute the selected-set target directly from the native
+            # IndexCache table instead of pairing mismatched columns.
             from paddlefleet.tilelang_ops import csa_attn_target_reducesum
 
             target = csa_attn_target_reducesum(
@@ -4419,6 +4490,7 @@ class CompressedSparseAttention(FleetLayer):
         indexcache_served_loss_state = None
         indexcache_producer_loss_fused = False
         indexcache_loss_topk_idxs = None
+        replay_applied = False
 
         if (
             self.compress_ratio > 1
@@ -4537,10 +4609,12 @@ class CompressedSparseAttention(FleetLayer):
                 # learned/reused top-k table. Replay is an attention-only
                 # postprocess and must never redefine those tensors.
                 indexcache_loss_topk_idxs = compress_topk_idxs
-                compress_topk_idxs = self._postprocess_indexer_replay(
-                    compress_topk_idxs,
-                    n_compressed,
-                    offset,
+                compress_topk_idxs, replay_applied = (
+                    self._apply_indexer_replay(
+                        compress_topk_idxs,
+                        n_compressed,
+                        offset,
+                    )
                 )
             compress_topk_idxs = compress_topk_idxs.astype("int32")
 
@@ -4593,6 +4667,7 @@ class CompressedSparseAttention(FleetLayer):
                 lse_indexer,
                 loss_mask,
                 global_valid_count,
+                lse_indexer_matches_topk=not replay_applied,
             )
             tilelang_indexer_loss_state = tilelang_indexer_loss_state._replace(
                 target=target
@@ -4896,6 +4971,7 @@ class CompressedSparseAttention(FleetLayer):
         indexcache_served_loss_state = None
         indexcache_producer_loss_fused = False
         indexcache_loss_topk_idxs = None
+        replay_applied = False
 
         if (
             self.compress_ratio > 1
@@ -5021,12 +5097,14 @@ class CompressedSparseAttention(FleetLayer):
                 # Preserve the native F/S table for the cached state and loss.
                 # Replay may replace only the table consumed by attention.
                 indexcache_loss_topk_idxs = compress_topk_idxs
-                compress_topk_idxs = self._postprocess_indexer_replay(
-                    compress_topk_idxs,
-                    n_compressed_global,
-                    offset,
-                    position_offset=position_offset,
-                    q_positions=q_positions,
+                compress_topk_idxs, replay_applied = (
+                    self._apply_indexer_replay(
+                        compress_topk_idxs,
+                        n_compressed_global,
+                        offset,
+                        position_offset=position_offset,
+                        q_positions=q_positions,
+                    )
                 )
             compress_topk_idxs = compress_topk_idxs.astype("int32")
 
@@ -5073,6 +5151,7 @@ class CompressedSparseAttention(FleetLayer):
                 lse_indexer,
                 loss_mask,
                 global_valid_count,
+                lse_indexer_matches_topk=not replay_applied,
             )
             tilelang_indexer_loss_state = tilelang_indexer_loss_state._replace(
                 target=target

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -1739,12 +1739,12 @@ class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
     def forward(
         ctx,
         output: Tensor,
+        target: Tensor,
         index_q: Tensor,
         weights: Tensor,
         index_k_comp: Tensor,
         topk_indices: Tensor,
         topk_probs: Tensor,
-        target: Tensor,
         loss_coeff: float,
         indexer_backend: str = "tilelang",
         num_rows_override: float | None = None,
@@ -1803,7 +1803,7 @@ class TileLangCSAIndexerLossAutoScaler(paddle.autograd.PyLayer):
         )
 
         grad_main = grad_output if ctx.output_needs_grad else None
-        grads = (grad_main, grad_q, grad_weights, grad_k, None, None, None)
+        grads = (grad_main, None, grad_q, grad_weights, grad_k, None, None)
         if getattr(ctx, "loss_mask", None) is not None:
             grads += (None,)
         return grads
@@ -2924,7 +2924,9 @@ class CompressedSparseAttention(FleetLayer):
                 return output
             return TileLangCSAIndexerLossAutoScaler.apply(
                 output,
-                *tilelang_indexer_loss_state,
+                tilelang_indexer_loss_state[5],
+                *tilelang_indexer_loss_state[:5],
+                *tilelang_indexer_loss_state[6:],
             )
         if indexer_loss is not None:
             return DSAIndexerLossAutoScaler.apply(output, indexer_loss)
@@ -3888,6 +3890,322 @@ class CompressedSparseAttention(FleetLayer):
             )
         return target
 
+    def _compute_indexer_compressed_topk_idxs_cp(
+        self,
+        query: Tensor,
+        x: Tensor,
+        qr: Tensor,
+        compressed_kv_global: Tensor,
+        n_compressed_global: int,
+        offset: int,
+        q_positions: Tensor,
+        position_offset: int,
+        loss_mask: Tensor | None = None,
+        global_valid_count: float | None = None,
+        docmask_meta: CSADocMaskMetadata | None = None,
+        indexcache_action: tuple[int, str, str] | None = None,
+    ) -> tuple:
+        """Compute CP indexer indices and the optional IndexCache loss state.
+
+        The optional ``indexcache_action`` controls the extended six-value
+        return used by the IndexCache/Replay integration. When it is omitted,
+        the legacy three-value contract is returned so older PaddleRL replay
+        patches remain callable.
+        """
+        b, sq, np_heads, _ = query.shape
+        indexer_loss = None
+        tilelang_indexer_loss_state = None
+
+        indexer_backend = getattr(
+            self.config, "csa_indexer_backend", "tilelang"
+        )
+        use_tilelang_indexer = indexer_backend == "tilelang"
+        use_cudnn_indexer = indexer_backend == "cudnn"
+
+        served_count = None
+        loss_coeff_override = None
+        materialize_distill_state = False
+        if (
+            indexcache_action is not None
+            and self._indexcache_multi_layer_distill_enabled()
+        ):
+            c4_ordinal, _action, pattern = indexcache_action
+            served_count = self._indexcache_served_count(
+                pattern, c4_ordinal
+            )
+            loss_coeff_override = self._indexcache_scaled_loss_coeff(
+                served_count
+            )
+            materialize_distill_state = (
+                self._indexcache_has_future_served_layer(
+                    pattern, c4_ordinal
+                )
+            )
+
+        indexer_loss_coeff = float(
+            loss_coeff_override
+            if loss_coeff_override is not None
+            else getattr(self.config, "dsa_indexer_loss_coeff", 0.0) or 0.0
+        )
+        need_indexer_loss = (
+            self.training
+            and paddle.is_grad_enabled()
+            and indexer_loss_coeff > 0
+        )
+        loss_topk_effective = self._resolve_topk_effective(
+            n_compressed_global
+        )
+        # Keep the current mainline phase semantics: phase 2 widens the
+        # attention set, while phase 3 uses the configured learned top-k.
+        attn_topk_effective = self._resolve_topk_effective(
+            n_compressed_global
+        )
+
+        x_det = x.detach()
+        qr_det = qr.detach()
+        if self.training:
+            x_det.stop_gradient = False
+            qr_det.stop_gradient = False
+
+        if docmask_meta is not None:
+            valid_range = docmask_meta.valid_range[
+                :, position_offset : position_offset + sq, :
+            ]
+        else:
+            valid_range = None
+
+        q_indexer_bf, k_indexer_global, weights_indexer_bf = (
+            self.indexer.forward_before_topk(
+                x_det,
+                qr_det,
+                position_offset=position_offset,
+                cp_group=self.cp_group,
+                docmask_meta=docmask_meta,
+            )
+        )
+        topk_probs = None
+
+        if use_tilelang_indexer or use_cudnn_indexer:
+            grad_ctx = (
+                contextlib.nullcontext
+                if need_indexer_loss
+                else paddle.no_grad
+            )
+            with grad_ctx():
+                if use_cudnn_indexer:
+                    from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
+                        cudnn_indexer_topk_fwd,
+                    )
+
+                    topk_indices_compressed, _, *topk_scores = (
+                        cudnn_indexer_topk_fwd(
+                            q_indexer_bf,
+                            k_indexer_global,
+                            weights_indexer_bf,
+                            ratio=self.compress_ratio,
+                            topk_effective=(
+                                loss_topk_effective
+                                if need_indexer_loss
+                                else attn_topk_effective
+                            ),
+                            valid_range=valid_range,
+                            startend_row_indices=(
+                                docmask_meta.startend_row_indices
+                                if docmask_meta is not None
+                                else None
+                            ),
+                            doc_lens=(
+                                docmask_meta.doc_lens_list
+                                if docmask_meta is not None
+                                else None
+                            ),
+                            seq_offset=position_offset,
+                            return_topk_scores=need_indexer_loss,
+                        )
+                    )
+                    if need_indexer_loss:
+                        (topk_scores,) = topk_scores
+                        topk_probs = _row_masked_softmax(
+                            topk_scores, topk_indices_compressed
+                        )
+                else:
+                    from paddlefleet.tilelang_ops import csa_indexer_topk_fwd
+
+                    topk_effective = (
+                        loss_topk_effective
+                        if need_indexer_loss or materialize_distill_state
+                        else attn_topk_effective
+                    )
+                    topk_indices_compressed, topk_probs = (
+                        csa_indexer_topk_fwd(
+                            q_indexer_bf,
+                            k_indexer_global,
+                            weights_indexer_bf,
+                            ratio=self.compress_ratio,
+                            topk_effective=topk_effective,
+                            seq_offset=position_offset,
+                            valid_range=valid_range,
+                        )
+                    )
+
+            if need_indexer_loss:
+                tilelang_indexer_loss_state = TilelangIndexerLossState(
+                    q_indexer_bf,
+                    weights_indexer_bf,
+                    k_indexer_global,
+                    topk_indices_compressed,
+                    topk_probs,
+                    None,
+                    float(indexer_loss_coeff)
+                    if loss_mask is not None
+                    else float(indexer_loss_coeff) / self.cp_size,
+                    indexer_backend,
+                    global_valid_count if loss_mask is not None else None,
+                    loss_mask,
+                )
+        else:
+            if docmask_meta is None:
+                causal_mask = build_causal_mask_cp(
+                    q_positions,
+                    n_compressed_global,
+                    self.compress_ratio,
+                    b,
+                )
+            else:
+                causal_mask_full = docmask_meta.get_compressed_causal_mask()
+                causal_mask = causal_mask_full[
+                    :, position_offset : position_offset + sq, ...
+                ]
+
+            if need_indexer_loss:
+                key_for_loss = (
+                    compressed_kv_global.detach()
+                    .unsqueeze(2)
+                    .expand([-1, -1, np_heads, -1])
+                )
+                weights_for_loss = (
+                    weights_indexer_bf * self.indexer.softmax_scale
+                )
+                indexer_loss = FusedDSAIndexerLoss.apply(
+                    q_indexer_bf,
+                    weights_for_loss,
+                    k_indexer_global,
+                    query.detach(),
+                    key_for_loss.detach(),
+                    self.softmax_scale,
+                    attn_topk_effective,
+                    indexer_loss_coeff,
+                    causal_mask.unsqueeze(1),
+                    getattr(
+                        self.config, "dsa_indexer_use_sparse_loss", True
+                    ),
+                    self.tp_group,
+                    loss_mask,
+                    global_valid_count,
+                )
+                topk_indices_compressed = (
+                    FusedDSAIndexerLoss._last_topk_indices
+                )
+                DSAIndexerLossLoggingHelper.save_loss_to_tracker(
+                    loss=indexer_loss,
+                    layer_number=self.layer_number,
+                    num_layers=DSAIndexerLossLoggingHelper.get_total_num_layers(
+                        self.config
+                    ),
+                )
+                if loss_mask is None:
+                    indexer_loss = indexer_loss / self.cp_size
+            else:
+                _, topk_indices_compressed = fused_qk_topk_naive(
+                    q_indexer_bf,
+                    k_indexer_global,
+                    weights_indexer_bf,
+                    attn_topk_effective,
+                    causal_mask,
+                )
+
+        if topk_indices_compressed.shape[-1] > attn_topk_effective:
+            topk_indices_compressed = topk_indices_compressed[
+                ..., :attn_topk_effective
+            ].contiguous()
+            if (
+                topk_probs is not None
+                and topk_probs.shape[-1] > attn_topk_effective
+            ):
+                topk_probs = topk_probs[..., :attn_topk_effective].contiguous()
+            if tilelang_indexer_loss_state is not None:
+                tilelang_indexer_loss_state = (
+                    tilelang_indexer_loss_state._replace(
+                        topk_indices=topk_indices_compressed,
+                        topk_probs=topk_probs,
+                    )
+                )
+
+        if materialize_distill_state:
+            if topk_probs is None:
+                raise NotImplementedError(
+                    "IndexCache distill state requires a backend that returns "
+                    "selected top-k probabilities."
+                )
+            if (
+                self.tp_group is not None
+                and getattr(self.tp_group, "nranks", 1) > 1
+            ):
+                target = _compute_attn_target_on_selected_set(
+                    query.detach(),
+                    compressed_kv_global.detach(),
+                    topk_indices_compressed.detach(),
+                    self.softmax_scale,
+                    self.tp_group,
+                )
+            else:
+                from paddlefleet.tilelang_ops import csa_attn_target_reducesum
+
+                target = csa_attn_target_reducesum(
+                    query.detach(),
+                    compressed_kv_global.detach(),
+                    topk_indices_compressed.detach(),
+                    self.softmax_scale,
+                )
+            effective_loss_coeff = (
+                float(loss_coeff_override)
+                if loss_mask is not None
+                else float(loss_coeff_override) / self.cp_size
+            )
+            if tilelang_indexer_loss_state is None:
+                tilelang_indexer_loss_state = TilelangIndexerLossState(
+                    q_indexer_bf,
+                    weights_indexer_bf,
+                    k_indexer_global,
+                    topk_indices_compressed,
+                    topk_probs,
+                    target,
+                    effective_loss_coeff,
+                    indexer_backend,
+                    global_valid_count if loss_mask is not None else None,
+                    loss_mask,
+                )
+            else:
+                tilelang_indexer_loss_state = (
+                    tilelang_indexer_loss_state._replace(target=target)
+                )
+
+        compress_topk_idxs = map_compressed_topk_to_kv_full_cp(
+            topk_indices_compressed,
+            q_positions,
+            self.compress_ratio,
+            offset,
+        )
+        result = (
+            compress_topk_idxs,
+            indexer_loss,
+            tilelang_indexer_loss_state,
+            loss_coeff_override,
+            materialize_distill_state,
+            served_count,
+        )
+        return result if indexcache_action is not None else result[:3]
+
     def forward(
         self,
         query: Tensor,
@@ -4603,310 +4921,38 @@ class CompressedSparseAttention(FleetLayer):
                     self._indexcache_clear_cached_state()
                 indexcache_state_updated = True
             elif self.indexer is not None:
-                served_count = None
-                loss_coeff_override = None
-                materialize_distill_state = False
-                if (
-                    indexcache_action is not None
-                    and self._indexcache_multi_layer_distill_enabled()
-                ):
-                    c4_ordinal, _action, pattern = indexcache_action
-                    served_count = self._indexcache_served_count(
-                        pattern, c4_ordinal
-                    )
-                    loss_coeff_override = self._indexcache_scaled_loss_coeff(
-                        served_count
-                    )
-                    materialize_distill_state = (
-                        self._indexcache_has_future_served_layer(
-                            pattern, c4_ordinal
-                        )
-                    )
-                if (
-                    materialize_distill_state
-                    and self.indexer_backend != "tilelang"
-                ):
-                    raise NotImplementedError(
-                        "IndexCache distill recompute materialization currently "
-                        "supports only csa_indexer_backend='tilelang'."
-                    )
-                x_det = x.detach()
-                qr_det = qr.detach()
-                if self.training:
-                    x_det.stop_gradient = False
-                    qr_det.stop_gradient = False
-
-                indexer_backend = getattr(
-                    self.config, "csa_indexer_backend", "tilelang"
-                )
-                use_tilelang_indexer = indexer_backend == "tilelang"
-                use_cudnn_indexer = indexer_backend == "cudnn"
-                # coeff == 0 disables the indexer-loss path entirely (matching
-                # DSAttention: 0 disables the KL loss), so the loss kernels and
-                # TilelangIndexerLossState must not be built -- attention top-k
-                # keeps flowing through the no-loss branches below.
-                indexer_loss_coeff = float(
-                    loss_coeff_override
-                    if loss_coeff_override is not None
-                    else getattr(self.config, "dsa_indexer_loss_coeff", 0.0)
-                    or 0.0
-                )
-                use_fused_indexer_loss_path = (
-                    (use_tilelang_indexer or use_cudnn_indexer)
-                    and self.training
-                    and paddle.is_grad_enabled()
-                    and indexer_loss_coeff > 0
-                )
-                topk_effective = self._resolve_topk_effective(
-                    n_compressed_global
-                )
-
-                # valid_range for varlen: [b, sq_local, 2] or None
-                if docmask_meta is not None:
-                    valid_range = docmask_meta.valid_range[
-                        :, position_offset : position_offset + sq, :
-                    ]
-                else:
-                    valid_range = None
-
-                q_indexer_bf, k_indexer_global, weights_indexer_bf = (
-                    self.indexer.forward_before_topk(
-                        x_det,
-                        qr_det,
-                        position_offset=position_offset,
-                        cp_group=self.cp_group,
-                        docmask_meta=docmask_meta,
-                    )
-                )
-
-                if use_tilelang_indexer or use_cudnn_indexer:
-                    # CP indexer forward with TileLang/cuDNN indexer backend.
-                    # This branch is for both grad-enabled and no-grad.
-                    grad_ctx = (
-                        contextlib.nullcontext
-                        if use_fused_indexer_loss_path
-                        else paddle.no_grad
-                    )
-
-                    with grad_ctx():
-                        if use_cudnn_indexer:
-                            from paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn import (
-                                cudnn_indexer_topk_fwd,
-                            )
-
-                            topk_indices_compressed, _, *topk_probs = (
-                                cudnn_indexer_topk_fwd(
-                                    q_indexer_bf,
-                                    k_indexer_global,
-                                    weights_indexer_bf,
-                                    ratio=self.compress_ratio,
-                                    topk_effective=topk_effective,
-                                    valid_range=valid_range,
-                                    startend_row_indices=docmask_meta.startend_row_indices
-                                    if docmask_meta is not None
-                                    else None,
-                                    doc_lens=docmask_meta.doc_lens_list
-                                    if docmask_meta is not None
-                                    else None,
-                                    seq_offset=position_offset,
-                                    return_topk_scores=use_fused_indexer_loss_path,
-                                )
-                            )
-
-                            if use_fused_indexer_loss_path:
-                                (topk_probs,) = topk_probs
-                                topk_probs = _row_masked_softmax(
-                                    topk_probs, topk_indices_compressed
-                                )
-
-                        else:
-                            from paddlefleet.tilelang_ops import (
-                                csa_indexer_topk_fwd,
-                            )
-
-                            topk_indices_compressed, topk_probs = (
-                                csa_indexer_topk_fwd(
-                                    q_indexer_bf,
-                                    k_indexer_global,
-                                    weights_indexer_bf,
-                                    ratio=self.compress_ratio,
-                                    topk_effective=topk_effective,
-                                    seq_offset=position_offset,
-                                    valid_range=valid_range,
-                                )
-                            )
-
-                    if use_fused_indexer_loss_path:
-                        tilelang_indexer_loss_state = TilelangIndexerLossState(
-                            q_indexer_bf,
-                            weights_indexer_bf,
-                            k_indexer_global,
-                            topk_indices_compressed,
-                            topk_probs,
-                            None,
-                            float(indexer_loss_coeff)
-                            if loss_mask is not None
-                            else float(indexer_loss_coeff) / self.cp_size,
-                            indexer_backend,
-                            global_valid_count
-                            if loss_mask is not None
-                            else None,
-                            loss_mask,
-                        )
-
-                elif (
-                    indexer_loss_coeff > 0
-                    and self.training
-                    and not use_tilelang_indexer
-                    and not use_cudnn_indexer
-                ):
-                    # CP training forward with unfused indexer backend.
-                    # Paddle reference loss path (coeff == 0 never gets here).
-                    key_for_loss = (
-                        compressed_kv_global.detach()
-                        .unsqueeze(2)
-                        .expand([-1, -1, np_heads, -1])
-                    )
-
-                    if docmask_meta is None:
-                        causal_mask = build_causal_mask_cp(
-                            q_positions,
-                            n_compressed_global,
-                            self.compress_ratio,
-                            b,
-                        )
-                    else:
-                        causal_mask_full = (
-                            docmask_meta.get_compressed_causal_mask()
-                        )
-                        causal_mask = causal_mask_full[
-                            :, position_offset : position_offset + sq, ...
-                        ]
-
-                    weights_for_loss = (
-                        weights_indexer_bf * self.indexer.softmax_scale
-                    )
-                    mask_for_loss = causal_mask.unsqueeze(1)
-
-                    indexer_loss = FusedDSAIndexerLoss.apply(
-                        q_indexer_bf,
-                        weights_for_loss,
-                        k_indexer_global,
-                        query.detach(),
-                        key_for_loss.detach(),
-                        self.softmax_scale,
-                        topk_effective,
-                        indexer_loss_coeff,
-                        mask_for_loss,
-                        getattr(
-                            self.config, "dsa_indexer_use_sparse_loss", True
-                        ),
-                        self.tp_group,
-                        loss_mask,
-                        global_valid_count,
-                    )
-                    topk_indices_compressed = (
-                        FusedDSAIndexerLoss._last_topk_indices
-                    )
-                    if indexer_loss_coeff > 0:  # always True in this branch
-                        # CP unfused training path logs only when indexer loss
-                        # is enabled.
-                        DSAIndexerLossLoggingHelper.save_loss_to_tracker(
-                            loss=indexer_loss,
-                            layer_number=self.layer_number,
-                            num_layers=self.config.num_hidden_layers,
-                        )
-                    if loss_mask is None:
-                        indexer_loss = indexer_loss / self.cp_size
-
-                elif not use_tilelang_indexer and not use_cudnn_indexer:
-                    # CP no-loss forward with unfused backend (eval/no-grad,
-                    # or training with coeff == 0); only materialize attention
-                    # top-k.
-                    # Inference-only Paddle topk (use already-gathered global K)
-                    if docmask_meta is None:
-                        causal_mask = build_causal_mask_cp(
-                            q_positions,
-                            n_compressed_global,
-                            self.compress_ratio,
-                            b,
-                        )
-                    else:
-                        causal_mask_full = (
-                            docmask_meta.get_compressed_causal_mask()
-                        )
-                        causal_mask = causal_mask_full[
-                            :, position_offset : position_offset + sq, ...
-                        ]
-
-                    _, topk_indices_compressed = fused_qk_topk_naive(
-                        q_indexer_bf,
-                        k_indexer_global,
-                        weights_indexer_bf,
-                        topk_effective,
-                        causal_mask,
-                    )
-
-                if (
-                    topk_indices_compressed.shape[-1] > topk_effective
-                ):  # CP loss path may return wider top-k than attention consumes.
-                    topk_indices_compressed = topk_indices_compressed[
-                        ..., :topk_effective
-                    ].contiguous()
-                if materialize_distill_state:
-                    if (
-                        self.tp_group is not None
-                        and getattr(self.tp_group, "nranks", 1) > 1
-                    ):
-                        target = _compute_attn_target_on_selected_set(
-                            query.detach(),
-                            compressed_kv_global.detach(),
-                            topk_indices_compressed.detach(),
-                            self.softmax_scale,
-                            self.tp_group,
-                        )
-                    else:
-                        from paddlefleet.tilelang_ops import (
-                            csa_attn_target_reducesum,
-                        )
-
-                        target = csa_attn_target_reducesum(
-                            query.detach(),
-                            compressed_kv_global.detach(),
-                            topk_indices_compressed.detach(),
-                            self.softmax_scale,
-                        )
-                    if tilelang_indexer_loss_state is None:
-                        effective_loss_coeff = (
-                            float(loss_coeff_override)
-                            if loss_mask is not None
-                            else float(loss_coeff_override) / self.cp_size
-                        )
-                        tilelang_indexer_loss_state = TilelangIndexerLossState(
-                            q_indexer_bf,
-                            weights_indexer_bf,
-                            k_indexer_global,
-                            topk_indices_compressed,
-                            topk_probs,
-                            target,
-                            effective_loss_coeff,
-                            indexer_backend,
-                            global_valid_count
-                            if loss_mask is not None
-                            else None,
-                            loss_mask,
-                        )
-                    else:
-                        tilelang_indexer_loss_state = (
-                            tilelang_indexer_loss_state._replace(target=target)
-                        )
-
-                compress_topk_idxs = map_compressed_topk_to_kv_full_cp(
-                    topk_indices_compressed,
-                    q_positions,
-                    self.compress_ratio,
+                cp_result = self._compute_indexer_compressed_topk_idxs_cp(
+                    query,
+                    x,
+                    qr,
+                    compressed_kv_global,
+                    n_compressed_global,
                     offset,
+                    q_positions,
+                    position_offset,
+                    loss_mask=loss_mask,
+                    global_valid_count=global_valid_count,
+                    docmask_meta=docmask_meta,
+                    indexcache_action=indexcache_action,
                 )
+                if len(cp_result) == 3:
+                    (
+                        compress_topk_idxs,
+                        indexer_loss,
+                        tilelang_indexer_loss_state,
+                    ) = cp_result
+                    loss_coeff_override = None
+                    materialize_distill_state = False
+                    served_count = None
+                else:
+                    (
+                        compress_topk_idxs,
+                        indexer_loss,
+                        tilelang_indexer_loss_state,
+                        loss_coeff_override,
+                        materialize_distill_state,
+                        served_count,
+                    ) = cp_result
                 if indexcache_action is not None:
                     c4_ordinal, _action, pattern = indexcache_action
                     effective_loss_scale = (

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -3123,17 +3123,20 @@ class CompressedSparseAttention(FleetLayer):
                 # tensor while the cast's backward keeps the producer bridge
                 # gradient-connected. Served layers restore FP32 immediately.
                 pipeline_topk_probs = distill_topk_probs.cast("bfloat16")
-            empty_q = self._indexcache_forward_state_tensor(
-                paddle.empty([0], dtype=q_indexer_bf.dtype)
+            # Paddle's real PP transport rejects zero-element tensors. These
+            # four slots are protocol placeholders only, so use one zero of
+            # the original dtype: still constant-size, but sendable by NCCL.
+            placeholder_q = self._indexcache_forward_state_tensor(
+                paddle.zeros([1], dtype=q_indexer_bf.dtype)
             )
-            empty_weights = self._indexcache_forward_state_tensor(
-                paddle.empty([0], dtype=weights_indexer_bf.dtype)
+            placeholder_weights = self._indexcache_forward_state_tensor(
+                paddle.zeros([1], dtype=weights_indexer_bf.dtype)
             )
-            empty_k = self._indexcache_forward_state_tensor(
-                paddle.empty([0], dtype=k_indexer_bf.dtype)
+            placeholder_k = self._indexcache_forward_state_tensor(
+                paddle.zeros([1], dtype=k_indexer_bf.dtype)
             )
-            empty_topk_indices = self._indexcache_forward_state_tensor(
-                paddle.empty([0], dtype=topk_indices_compressed.dtype)
+            placeholder_topk_indices = self._indexcache_forward_state_tensor(
+                paddle.zeros([1], dtype=topk_indices_compressed.dtype)
             )
             compressed_kv_shape = list(k_indexer_bf.shape)
             compressed_kv_length = (
@@ -3163,10 +3166,10 @@ class CompressedSparseAttention(FleetLayer):
             )
             state.extend(
                 [
-                    empty_q,
-                    empty_weights,
-                    empty_k,
-                    empty_topk_indices,
+                    placeholder_q,
+                    placeholder_weights,
+                    placeholder_k,
+                    placeholder_topk_indices,
                     pipeline_topk_probs,
                     self._indexcache_forward_state_tensor(
                         paddle.full([1], self.layer_number, dtype="int64")
@@ -4415,6 +4418,7 @@ class CompressedSparseAttention(FleetLayer):
         lse_indexer = None
         indexcache_served_loss_state = None
         indexcache_producer_loss_fused = False
+        indexcache_loss_topk_idxs = None
 
         if (
             self.compress_ratio > 1
@@ -4528,11 +4532,11 @@ class CompressedSparseAttention(FleetLayer):
                     offset,
                     docmask_meta=docmask_meta,
                 )
-            if (
-                self.indexer is not None
-                and indexcache_action is not None
-                and indexcache_action[1] == "S"
-            ):
+            if self.indexer is not None:
+                # IndexCache state and all producer/served losses keep the
+                # learned/reused top-k table. Replay is an attention-only
+                # postprocess and must never redefine those tensors.
+                indexcache_loss_topk_idxs = compress_topk_idxs
                 compress_topk_idxs = self._postprocess_indexer_replay(
                     compress_topk_idxs,
                     n_compressed,
@@ -4584,7 +4588,7 @@ class CompressedSparseAttention(FleetLayer):
             target = self._compute_fused_indexer_target(
                 query,
                 kv_full,
-                compress_topk_idxs,
+                indexcache_loss_topk_idxs,
                 tilelang_indexer_loss_state.topk_probs,
                 lse_indexer,
                 loss_mask,
@@ -4891,6 +4895,7 @@ class CompressedSparseAttention(FleetLayer):
         lse_indexer = None
         indexcache_served_loss_state = None
         indexcache_producer_loss_fused = False
+        indexcache_loss_topk_idxs = None
 
         if (
             self.compress_ratio > 1
@@ -5013,6 +5018,9 @@ class CompressedSparseAttention(FleetLayer):
                     )
 
             if self.indexer is not None:
+                # Preserve the native F/S table for the cached state and loss.
+                # Replay may replace only the table consumed by attention.
+                indexcache_loss_topk_idxs = compress_topk_idxs
                 compress_topk_idxs = self._postprocess_indexer_replay(
                     compress_topk_idxs,
                     n_compressed_global,
@@ -5060,7 +5068,7 @@ class CompressedSparseAttention(FleetLayer):
             target = self._compute_fused_indexer_target(
                 query,
                 kv_full,
-                compress_topk_idxs,
+                indexcache_loss_topk_idxs,
                 tilelang_indexer_loss_state.topk_probs,
                 lse_indexer,
                 loss_mask,

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -987,6 +987,8 @@ class DSv4HybridAttention(Attention):
         past_key_values = kwargs.get("past_key_values", None)
         layer_idx = kwargs.get("layer_idx", None)
         use_cache = kwargs.get("use_cache", False)
+        indexcache_state = kwargs.get("indexcache_state", None)
+        core_attn_returns_indexcache_state = False
 
         # Get Q, K, V tensors
         # In CP mode, pass position_offset so RoPE uses correct global positions.
@@ -1108,7 +1110,13 @@ class DSv4HybridAttention(Attention):
                 past_key_values=past_key_values,
                 layer_idx=layer_idx,
                 use_cache=use_cache,
+                indexcache_state=indexcache_state,
             )
+            core_attn_returns_indexcache_state = isinstance(
+                core_attn_out, tuple
+            )
+            if core_attn_returns_indexcache_state:
+                core_attn_out, indexcache_state = core_attn_out
 
             # Output projection
             output, bias = deferrable_linear(
@@ -1151,6 +1159,8 @@ class DSv4HybridAttention(Attention):
         if original_b > 1:
             output = _unpack_dsv4_logical_batch(output, original_b, original_sq)
 
+        if indexcache_state is not None or core_attn_returns_indexcache_state:
+            return output, bias, indexcache_state
         return output, bias
 
     def _full_attn_forward(
@@ -1165,6 +1175,7 @@ class DSv4HybridAttention(Attention):
         past_key_values=None,
         layer_idx=None,
         use_cache=False,
+        indexcache_state=None,
     ) -> Tensor:
         """Full attention forward: qkv_proj + core_attn + inv_rope + o_group_proj + gated_attn.
 
@@ -1204,7 +1215,7 @@ class DSv4HybridAttention(Attention):
             value = key
 
         # Core attention (CompressedSparseAttention)
-        core_attn_out = self.core_attention(
+        core_attn_result = self.core_attention(
             query,
             key,
             value,
@@ -1216,7 +1227,13 @@ class DSv4HybridAttention(Attention):
             past_key_values=past_key_values,
             layer_idx=layer_idx,
             use_cache=use_cache,
+            indexcache_state=indexcache_state,
         )
+        core_attn_returns_indexcache_state = isinstance(core_attn_result, tuple)
+        if isinstance(core_attn_result, tuple):
+            core_attn_out, indexcache_state = core_attn_result
+        else:
+            core_attn_out = core_attn_result
         # core_attn_out: [b, sq, np * v_head_dim]
 
         if (
@@ -1269,9 +1286,12 @@ class DSv4HybridAttention(Attention):
         # on, the raw grouped-projection output otherwise. Probed here (once,
         # at the producer) instead of at the two self.o_proj(core_attn_out)
         # call sites in forward().
-        return inspect_tensor(
+        core_attn_out = inspect_tensor(
             "attn_o_proj_input", self.layer_number, core_attn_out
         )
+        if indexcache_state is not None or core_attn_returns_indexcache_state:
+            return core_attn_out, indexcache_state
+        return core_attn_out
 
     def _post_core_forward(
         self,

--- a/src/paddlefleet/transformer/indexcache_state.py
+++ b/src/paddlefleet/transformer/indexcache_state.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import paddle
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+INDEXCACHE_STATE_KIND_NONE = "none"
+INDEXCACHE_STATE_KIND_TOPK_ONLY = "topk_only"
+INDEXCACHE_STATE_KIND_DISTILL = "distill"
+INDEXCACHE_STATE_KIND_INVALID = "invalid"
+
+INDEXCACHE_TOPK_ONLY_STATE_LEN = 3
+INDEXCACHE_DISTILL_STATE_LEN = 8
+INDEXCACHE_RECOMPUTE_STATE_MAX_LEN = INDEXCACHE_DISTILL_STATE_LEN
+
+INDEXCACHE_STATE_TOPK_IDXS = 0
+INDEXCACHE_TOPK_ONLY_STATE_PRODUCER_LAYER = 1
+INDEXCACHE_TOPK_ONLY_STATE_SERVED_COUNT = 2
+
+INDEXCACHE_DISTILL_STATE_Q = 1
+INDEXCACHE_DISTILL_STATE_WEIGHTS = 2
+INDEXCACHE_DISTILL_STATE_K = 3
+INDEXCACHE_DISTILL_STATE_TOPK_INDICES = INDEXCACHE_STATE_TOPK_IDXS
+INDEXCACHE_DISTILL_STATE_TOPK_INDICES_PLACEHOLDER = 4
+INDEXCACHE_DISTILL_STATE_TOPK_PROBS = 5
+INDEXCACHE_DISTILL_STATE_PRODUCER_LAYER = 6
+INDEXCACHE_DISTILL_STATE_SERVED_COUNT = 7
+
+INDEXCACHE_DISTILL_GRAD_INDICES = (INDEXCACHE_DISTILL_STATE_TOPK_PROBS,)
+
+
+def summarize_indexcache_gradients(
+    named_tensors: Iterable[tuple[str, paddle.Tensor | None]],
+) -> dict[str, dict[str, int | bool | str | None]]:
+    """Return exact finite/nonzero counts without output-sized temporaries.
+
+    Paddle's fused ``check_numerics`` kernel scans the input directly and
+    returns only ``[num_nan, num_inf, num_zero]`` plus three scalar values.
+    Stacking the tiny stats tensors also lets callers synchronize once when
+    auditing several gradients from the same backward kernel.
+    """
+
+    from paddle.amp.debugging import DebugMode, check_numerics
+
+    summaries: dict[str, dict[str, int | bool | str | None]] = {}
+    pending: list[tuple[str, paddle.Tensor, int]] = []
+    for name, tensor in named_tensors:
+        if tensor is None:
+            summaries[name] = {
+                "present": False,
+                "finite": False,
+                "nonzero": False,
+                "nan": None,
+                "inf": None,
+                "zero": None,
+                "numel": None,
+                "dtype": None,
+            }
+            continue
+        if not isinstance(tensor, paddle.Tensor):
+            raise TypeError(
+                "IndexCache gradient summaries require paddle.Tensor or "
+                f"None, got {type(tensor).__name__} for {name}."
+            )
+        numel = math.prod(int(value) for value in tensor.shape)
+        stats, _values = check_numerics(
+            tensor,
+            "indexcache_gradient",
+            name,
+            DebugMode.CHECK_NAN_INF,
+        )
+        pending.append((name, stats, numel))
+        summaries[name] = {
+            "present": True,
+            "finite": False,
+            "nonzero": False,
+            "nan": None,
+            "inf": None,
+            "zero": None,
+            "numel": numel,
+            "dtype": str(tensor.dtype),
+        }
+
+    if pending:
+        rows = paddle.stack([stats for _name, stats, _numel in pending])
+        host_rows = rows.cpu().numpy().tolist()
+        for (name, _stats, numel), counts in zip(pending, host_rows):
+            nan_count, inf_count, zero_count = (int(value) for value in counts)
+            finite = nan_count == 0 and inf_count == 0
+            summaries[name].update(
+                {
+                    "finite": finite,
+                    "nonzero": finite and zero_count < numel,
+                    "nan": nan_count,
+                    "inf": inf_count,
+                    "zero": zero_count,
+                }
+            )
+    return summaries
+
+
+def format_indexcache_gradient_summary(
+    prefix: str,
+    summary: dict[str, int | bool | str | None],
+) -> str:
+    """Render one summary as stable key/value marker fields."""
+
+    return " ".join(
+        f"{prefix}_{field}={summary[field]}"
+        for field in (
+            "present",
+            "finite",
+            "nonzero",
+            "nan",
+            "inf",
+            "zero",
+            "numel",
+            "dtype",
+        )
+    )
+
+
+def state_kind(indexcache_state: tuple | list | None) -> str:
+    if not indexcache_state:
+        return INDEXCACHE_STATE_KIND_NONE
+    state_len = len(indexcache_state)
+    if state_len == INDEXCACHE_TOPK_ONLY_STATE_LEN:
+        return INDEXCACHE_STATE_KIND_TOPK_ONLY
+    if state_len == INDEXCACHE_DISTILL_STATE_LEN:
+        return INDEXCACHE_STATE_KIND_DISTILL
+    return INDEXCACHE_STATE_KIND_INVALID
+
+
+def is_valid_state(indexcache_state: tuple | list | None) -> bool:
+    return state_kind(indexcache_state) in (
+        INDEXCACHE_STATE_KIND_NONE,
+        INDEXCACHE_STATE_KIND_TOPK_ONLY,
+        INDEXCACHE_STATE_KIND_DISTILL,
+    )
+
+
+def _as_state_tuple(indexcache_state: tuple | list | None) -> tuple | None:
+    if indexcache_state is None:
+        return None
+    return tuple(indexcache_state)
+
+
+def apply_stop_gradient_mask(
+    indexcache_state: tuple | list | None,
+) -> tuple | None:
+    indexcache_state = _as_state_tuple(indexcache_state)
+    kind = state_kind(indexcache_state)
+    if kind == INDEXCACHE_STATE_KIND_NONE:
+        return None
+    if kind == INDEXCACHE_STATE_KIND_INVALID:
+        raise ValueError(
+            "IndexCache state must be either topk-only "
+            f"({INDEXCACHE_TOPK_ONLY_STATE_LEN} tensors) or distill "
+            f"({INDEXCACHE_DISTILL_STATE_LEN} tensors), got "
+            f"len={len(indexcache_state)}."
+        )
+
+    for idx, tensor in enumerate(indexcache_state):
+        if not isinstance(tensor, paddle.Tensor):
+            raise TypeError(
+                "IndexCache state entries must be Paddle tensors, got "
+                f"type={type(tensor).__name__} at index={idx}."
+            )
+        tensor.stop_gradient = not (
+            kind == INDEXCACHE_STATE_KIND_DISTILL
+            and idx in INDEXCACHE_DISTILL_GRAD_INDICES
+        )
+    return indexcache_state
+
+
+def detach_stop_gradient_tensor(value: paddle.Tensor) -> paddle.Tensor:
+    value = value.detach()
+    value.stop_gradient = True
+    return value
+
+
+def clone_state_outputs(indexcache_state: tuple | list | None) -> tuple | None:
+    masked = apply_stop_gradient_mask(indexcache_state)
+    if masked is None:
+        return None
+    cloned = tuple(tensor.clone() for tensor in masked)
+    return apply_stop_gradient_mask(cloned)
+
+
+def flatten_state(indexcache_state: tuple | list | None) -> tuple:
+    masked = apply_stop_gradient_mask(indexcache_state)
+    if masked is None:
+        return ()
+    return masked
+
+
+def state_to_slots(indexcache_state: tuple | list | None) -> tuple:
+    slots = list(flatten_state(indexcache_state))
+    if len(slots) > INDEXCACHE_RECOMPUTE_STATE_MAX_LEN:
+        raise ValueError(
+            "IndexCache recompute state has too many slots: "
+            f"{len(slots)} > {INDEXCACHE_RECOMPUTE_STATE_MAX_LEN}."
+        )
+    slots.extend([None] * (INDEXCACHE_RECOMPUTE_STATE_MAX_LEN - len(slots)))
+    return tuple(slots)
+
+
+def state_from_slots(slots: Iterable) -> tuple | None:
+    state = list(slots)
+    while state and state[-1] is None:
+        state.pop()
+    if not state:
+        return None
+    return apply_stop_gradient_mask(tuple(state))

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -2938,23 +2938,21 @@ class TransformerConfig(ModelParallelConfig):
                         "indexcache_multi_layer_distill=True requires a "
                         "non-empty index_topk_pattern."
                     )
-                if self.context_parallel_size > 1 and (
+                active_mtp = (
                     self.num_nextn_predict_layers is not None
                     and self.num_nextn_predict_layers > 0
-                ):
+                    and not self.mtp_load_weight_only
+                )
+                if self.context_parallel_size > 1 and active_mtp:
                     raise NotImplementedError(
                         "indexcache_multi_layer_distill currently supports "
-                        "CP training only when num_nextn_predict_layers=0."
+                        "CP training only when the MTP forward is disabled. "
+                        "Weight-only MTP is supported."
                     )
                 if self.csa_indexer_backend != "tilelang":
                     raise NotImplementedError(
                         "indexcache_multi_layer_distill currently supports "
                         "only csa_indexer_backend='tilelang'."
-                    )
-                if self.csa_sparse_attn_backend != "tilelang":
-                    raise NotImplementedError(
-                        "indexcache_multi_layer_distill currently supports "
-                        "only csa_sparse_attn_backend='tilelang'."
                     )
 
             if self.index_topk_pattern and self.recompute_granularity:
@@ -2973,11 +2971,6 @@ class TransformerConfig(ModelParallelConfig):
                     raise NotImplementedError(
                         "IndexCache recompute currently supports only "
                         "csa_indexer_backend='tilelang'."
-                    )
-                if self.csa_sparse_attn_backend != "tilelang":
-                    raise NotImplementedError(
-                        "IndexCache recompute currently supports only "
-                        "csa_sparse_attn_backend='tilelang'."
                     )
 
             if (

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -2117,6 +2117,7 @@ class TransformerConfig(ModelParallelConfig):
         self.dsa_indexer_loss_coeff = float(self.dsa_indexer_loss_coeff or 0.0)
 
         for field_name in (
+            "indexcache_multi_layer_distill",
             "indexcache_train_debug",
             "indexcache_stall_trace",
         ):
@@ -2155,6 +2156,103 @@ class TransformerConfig(ModelParallelConfig):
                 "indexcache_stall_trace=True requires at least one positive "
                 "entry in indexcache_stall_trace_layers."
             )
+
+        if self.index_topk_pattern is not None:
+            pattern = str(self.index_topk_pattern).strip().upper()
+            if not pattern:
+                self.index_topk_pattern = None
+            else:
+                invalid_chars = sorted(set(pattern) - {"F", "S"})
+                if invalid_chars:
+                    raise ValueError(
+                        "index_topk_pattern may only contain 'F' and 'S', "
+                        f"got invalid chars: {invalid_chars}."
+                    )
+                if pattern[0] != "F":
+                    raise ValueError(
+                        "index_topk_pattern must start with 'F' so there "
+                        "is a producer before any reused top-k indices."
+                    )
+                self.index_topk_pattern = pattern
+
+        indexcache_requested = bool(
+            self.index_topk_pattern or self.indexcache_multi_layer_distill
+        )
+        if (
+            indexcache_requested
+            and self.experimental_attention_variant != "dsv4_hybrid"
+        ):
+            raise ValueError(
+                "index_topk_pattern / indexcache_multi_layer_distill are only "
+                "supported with experimental_attention_variant='dsv4_hybrid', "
+                f"got {self.experimental_attention_variant!r}."
+            )
+
+        if self.indexcache_multi_layer_distill:
+            if not self.index_topk_pattern:
+                raise ValueError(
+                    "indexcache_multi_layer_distill=True requires a "
+                    "non-empty index_topk_pattern."
+                )
+            active_mtp = (
+                self.num_nextn_predict_layers is not None
+                and self.num_nextn_predict_layers > 0
+                and not self.mtp_load_weight_only
+            )
+            if self.context_parallel_size > 1 and active_mtp:
+                raise NotImplementedError(
+                    "indexcache_multi_layer_distill currently supports "
+                    "CP training only when the MTP forward is disabled. "
+                    "Weight-only MTP is supported."
+                )
+            if self.csa_indexer_backend != "tilelang":
+                raise NotImplementedError(
+                    "indexcache_multi_layer_distill currently supports "
+                    "only csa_indexer_backend='tilelang'."
+                )
+
+        if self.index_topk_pattern:
+            if self.csa_compress_ratios is None:
+                raise ValueError(
+                    "index_topk_pattern requires csa_compress_ratios to be set."
+                )
+            if self.csa_dense_mode:
+                raise ValueError(
+                    "index_topk_pattern requires csa_dense_mode=False."
+                )
+            c4_layer_count = sum(
+                1 for ratio in self.csa_compress_ratios if int(ratio) == 4
+            )
+            if len(self.index_topk_pattern) != c4_layer_count:
+                raise ValueError(
+                    "index_topk_pattern length must equal the number "
+                    f"of ratio=4 CSA layers ({c4_layer_count}), got "
+                    f"{len(self.index_topk_pattern)}."
+                )
+
+            if self.recompute_granularity:
+                if not (
+                    self.recompute_granularity == "full"
+                    and self.recompute_method == "uniform"
+                    and self.recompute_num_layers == 1
+                ):
+                    raise NotImplementedError(
+                        "IndexCache recompute currently supports only "
+                        "recompute_granularity='full', "
+                        "recompute_method='uniform', and "
+                        "recompute_num_layers=1."
+                    )
+                if self.block_attention_residuals:
+                    raise NotImplementedError(
+                        "IndexCache full recompute is incompatible with "
+                        "block_attention_residuals=True: the split attention / "
+                        "MLP recompute path does not propagate indexcache_state."
+                    )
+                if self.csa_indexer_backend != "tilelang":
+                    raise NotImplementedError(
+                        "IndexCache recompute currently supports only "
+                        "csa_indexer_backend='tilelang'."
+                    )
 
         if self.p2p_overlap_dw_calc is not None:
             if isinstance(self.p2p_overlap_dw_calc, str):
@@ -2972,78 +3070,6 @@ class TransformerConfig(ModelParallelConfig):
                             "2048 (cuDNN indexer backward block size / top-k "
                             f"limit), got {self.dsa_index_topk}."
                         )
-
-            if self.index_topk_pattern is not None:
-                pattern = str(self.index_topk_pattern).strip().upper()
-                if not pattern:
-                    self.index_topk_pattern = None
-                else:
-                    invalid_chars = sorted(set(pattern) - {"F", "S"})
-                    if invalid_chars:
-                        raise ValueError(
-                            "index_topk_pattern may only contain 'F' and 'S', "
-                            f"got invalid chars: {invalid_chars}."
-                        )
-                    if pattern[0] != "F":
-                        raise ValueError(
-                            "index_topk_pattern must start with 'F' so there "
-                            "is a producer before any reused top-k indices."
-                        )
-                    if self.csa_dense_mode:
-                        raise ValueError(
-                            "index_topk_pattern requires csa_dense_mode=False."
-                        )
-                    c4_layer_count = sum(
-                        1 for ratio in self.csa_compress_ratios if ratio == 4
-                    )
-                    if len(pattern) != c4_layer_count:
-                        raise ValueError(
-                            "index_topk_pattern length must equal the number "
-                            f"of ratio=4 CSA layers ({c4_layer_count}), got "
-                            f"{len(pattern)}."
-                        )
-                    self.index_topk_pattern = pattern
-
-            if self.indexcache_multi_layer_distill:
-                if not self.index_topk_pattern:
-                    raise ValueError(
-                        "indexcache_multi_layer_distill=True requires a "
-                        "non-empty index_topk_pattern."
-                    )
-                active_mtp = (
-                    self.num_nextn_predict_layers is not None
-                    and self.num_nextn_predict_layers > 0
-                    and not self.mtp_load_weight_only
-                )
-                if self.context_parallel_size > 1 and active_mtp:
-                    raise NotImplementedError(
-                        "indexcache_multi_layer_distill currently supports "
-                        "CP training only when the MTP forward is disabled. "
-                        "Weight-only MTP is supported."
-                    )
-                if self.csa_indexer_backend != "tilelang":
-                    raise NotImplementedError(
-                        "indexcache_multi_layer_distill currently supports "
-                        "only csa_indexer_backend='tilelang'."
-                    )
-
-            if self.index_topk_pattern and self.recompute_granularity:
-                if not (
-                    self.recompute_granularity == "full"
-                    and self.recompute_method == "uniform"
-                    and self.recompute_num_layers == 1
-                ):
-                    raise NotImplementedError(
-                        "IndexCache recompute currently supports only "
-                        "recompute_granularity='full', "
-                        "recompute_method='uniform', and "
-                        "recompute_num_layers=1."
-                    )
-                if self.csa_indexer_backend != "tilelang":
-                    raise NotImplementedError(
-                        "IndexCache recompute currently supports only "
-                        "csa_indexer_backend='tilelang'."
-                    )
 
             if (
                 getattr(self, "csa_tilelang_enable_sparse_attn", None)

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1853,6 +1853,20 @@ class TransformerConfig(ModelParallelConfig):
     overlap backward with sharding gradient reduce for non-pipeline parallelism
     """
 
+    index_topk_pattern: str | None = None
+    """Optional IndexCache training pattern over ratio=4 CSA indexer layers.
+
+    Each character corresponds to one ratio=4 layer in execution order:
+      - "F": run the learned indexer and cache its top-k indices
+      - "S": skip the local indexer and reuse the previous cached top-k indices
+    """
+
+    indexcache_multi_layer_distill: bool = False
+    """Train retained IndexCache indexers with targets from all served layers.
+
+    CP training is supported only for no-MTP TileLang CSA.
+    """
+
     use_fast_hadamard: bool = False
     """Use Tridao's fast Hadamard transform for DSv4 rotate activation function."""
 
@@ -1938,6 +1952,8 @@ class TransformerConfig(ModelParallelConfig):
         "csa_sparse_attn_backend": "csa_sparse_attn_backend",
         "csa_share_docmask_meta": "csa_share_docmask_meta",
         "mqa_share_docmask_meta": "mqa_share_docmask_meta",
+        "index_topk_pattern": "index_topk_pattern",
+        "indexcache_multi_layer_distill": "indexcache_multi_layer_distill",
         "o_groups": "o_groups",
         "o_lora_rank": "o_lora_rank",
         "qk_pos_emb_head_dim": "qk_pos_emb_head_dim",
@@ -2884,6 +2900,85 @@ class TransformerConfig(ModelParallelConfig):
                             "2048 (cuDNN indexer backward block size / top-k "
                             f"limit), got {self.dsa_index_topk}."
                         )
+
+            if self.index_topk_pattern is not None:
+                pattern = str(self.index_topk_pattern).strip().upper()
+                if not pattern:
+                    self.index_topk_pattern = None
+                else:
+                    invalid_chars = sorted(set(pattern) - {"F", "S"})
+                    if invalid_chars:
+                        raise ValueError(
+                            "index_topk_pattern may only contain 'F' and 'S', "
+                            f"got invalid chars: {invalid_chars}."
+                        )
+                    if pattern[0] != "F":
+                        raise ValueError(
+                            "index_topk_pattern must start with 'F' so there "
+                            "is a producer before any reused top-k indices."
+                        )
+                    if self.csa_dense_mode:
+                        raise ValueError(
+                            "index_topk_pattern requires csa_dense_mode=False."
+                        )
+                    c4_layer_count = sum(
+                        1 for ratio in self.csa_compress_ratios if ratio == 4
+                    )
+                    if len(pattern) != c4_layer_count:
+                        raise ValueError(
+                            "index_topk_pattern length must equal the number "
+                            f"of ratio=4 CSA layers ({c4_layer_count}), got "
+                            f"{len(pattern)}."
+                        )
+                    self.index_topk_pattern = pattern
+
+            if self.indexcache_multi_layer_distill:
+                if not self.index_topk_pattern:
+                    raise ValueError(
+                        "indexcache_multi_layer_distill=True requires a "
+                        "non-empty index_topk_pattern."
+                    )
+                if self.context_parallel_size > 1 and (
+                    self.num_nextn_predict_layers is not None
+                    and self.num_nextn_predict_layers > 0
+                ):
+                    raise NotImplementedError(
+                        "indexcache_multi_layer_distill currently supports "
+                        "CP training only when num_nextn_predict_layers=0."
+                    )
+                if self.csa_indexer_backend != "tilelang":
+                    raise NotImplementedError(
+                        "indexcache_multi_layer_distill currently supports "
+                        "only csa_indexer_backend='tilelang'."
+                    )
+                if self.csa_sparse_attn_backend != "tilelang":
+                    raise NotImplementedError(
+                        "indexcache_multi_layer_distill currently supports "
+                        "only csa_sparse_attn_backend='tilelang'."
+                    )
+
+            if self.index_topk_pattern and self.recompute_granularity:
+                if not (
+                    self.recompute_granularity == "full"
+                    and self.recompute_method == "uniform"
+                    and self.recompute_num_layers == 1
+                ):
+                    raise NotImplementedError(
+                        "IndexCache recompute currently supports only "
+                        "recompute_granularity='full', "
+                        "recompute_method='uniform', and "
+                        "recompute_num_layers=1."
+                    )
+                if self.csa_indexer_backend != "tilelang":
+                    raise NotImplementedError(
+                        "IndexCache recompute currently supports only "
+                        "csa_indexer_backend='tilelang'."
+                    )
+                if self.csa_sparse_attn_backend != "tilelang":
+                    raise NotImplementedError(
+                        "IndexCache recompute currently supports only "
+                        "csa_sparse_attn_backend='tilelang'."
+                    )
 
             if (
                 getattr(self, "csa_tilelang_enable_sparse_attn", None)

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1867,6 +1867,35 @@ class TransformerConfig(ModelParallelConfig):
     CP training is supported only for no-MTP TileLang CSA.
     """
 
+    indexcache_train_debug: bool = False
+    """Emit detailed IndexCache state and gradient diagnostics.
+
+    The default is False because enabling this temporary troubleshooting
+    interface introduces device-to-host synchronization, numerical scans, and
+    synchronous logging. It should only be enabled while diagnosing
+    IndexCache state or gradient transport, and can be removed after the
+    PP/CP IndexCache path has stable multi-card CI coverage.
+    """
+
+    indexcache_stall_trace: bool = False
+    """Emit count-only Transformer layer boundary markers for IndexCache.
+
+    The default is False to avoid synchronous logging in the training hot
+    path. This is a temporary troubleshooting interface for locating PP or
+    recompute stalls and can be removed once those paths have stable
+    multi-card CI coverage. ``indexcache_stall_trace_layers`` selects the
+    one-based physical Transformer layers to trace.
+    """
+
+    indexcache_stall_trace_layers: tuple[int, ...] | list[int] = (2,)
+    """One-based physical Transformer layers included in the stall trace.
+
+    The default traces layer 2 when ``indexcache_stall_trace`` is enabled,
+    preserving the original diagnostic scope. JSON/YAML lists and tuples are
+    accepted and normalized in ``__post_init__`` to a sorted tuple of unique
+    positive integers.
+    """
+
     use_fast_hadamard: bool = False
     """Use Tridao's fast Hadamard transform for DSv4 rotate activation function."""
 
@@ -1954,6 +1983,9 @@ class TransformerConfig(ModelParallelConfig):
         "mqa_share_docmask_meta": "mqa_share_docmask_meta",
         "index_topk_pattern": "index_topk_pattern",
         "indexcache_multi_layer_distill": "indexcache_multi_layer_distill",
+        "indexcache_train_debug": "indexcache_train_debug",
+        "indexcache_stall_trace": "indexcache_stall_trace",
+        "indexcache_stall_trace_layers": "indexcache_stall_trace_layers",
         "o_groups": "o_groups",
         "o_lora_rank": "o_lora_rank",
         "qk_pos_emb_head_dim": "qk_pos_emb_head_dim",
@@ -2083,6 +2115,46 @@ class TransformerConfig(ModelParallelConfig):
         # "disabled" and collapses to 0.0, so this config object never exposes
         # None and consumers can key on ``> 0`` instead of ``is not None``.
         self.dsa_indexer_loss_coeff = float(self.dsa_indexer_loss_coeff or 0.0)
+
+        for field_name in (
+            "indexcache_train_debug",
+            "indexcache_stall_trace",
+        ):
+            field_value = getattr(self, field_name)
+            if not isinstance(field_value, bool):
+                raise TypeError(
+                    f"{field_name} must be a bool, got "
+                    f"{type(field_value).__name__}: {field_value!r}."
+                )
+
+        trace_layers = getattr(self, "indexcache_stall_trace_layers")
+        if not isinstance(trace_layers, (list, tuple)):
+            raise TypeError(
+                "indexcache_stall_trace_layers must be a list or tuple of "
+                f"positive integers, got {type(trace_layers).__name__}: "
+                f"{trace_layers!r}."
+            )
+        invalid_trace_layers = [
+            value
+            for value in trace_layers
+            if not isinstance(value, int)
+            or isinstance(value, bool)
+            or value <= 0
+        ]
+        if invalid_trace_layers:
+            raise ValueError(
+                "indexcache_stall_trace_layers must contain only positive "
+                f"integers, got invalid values: {invalid_trace_layers!r}."
+            )
+        self.indexcache_stall_trace_layers = tuple(sorted(set(trace_layers)))
+        if (
+            self.indexcache_stall_trace
+            and not self.indexcache_stall_trace_layers
+        ):
+            raise ValueError(
+                "indexcache_stall_trace=True requires at least one positive "
+                "entry in indexcache_stall_trace_layers."
+            )
 
         if self.p2p_overlap_dw_calc is not None:
             if isinstance(self.p2p_overlap_dw_calc, str):

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -82,26 +82,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _indexcache_stall_trace_enabled(layer_number):
+def _indexcache_stall_trace_enabled(config, layer_number):
     """Return whether count-only stall tracing is enabled for this layer."""
-    if os.environ.get("INDEXCACHE_STALL_TRACE", "0") != "1":
+    if not getattr(config, "indexcache_stall_trace", False):
         return False
-    try:
-        layers = {
-            int(value.strip())
-            for value in os.environ.get(
-                "INDEXCACHE_STALL_TRACE_LAYERS", "2"
-            ).split(",")
-            if value.strip()
-        }
-    except ValueError:
-        return False
+    layers = getattr(config, "indexcache_stall_trace_layers", ())
     return layer_number in layers
 
 
-def _emit_indexcache_stall_trace(layer_number, phase, edge):
+def _emit_indexcache_stall_trace(config, layer_number, phase, edge):
     """Emit a symmetric marker without tensor values or CUDA synchronization."""
-    if _indexcache_stall_trace_enabled(layer_number):
+    if _indexcache_stall_trace_enabled(config, layer_number):
         print(
             "[INDEXCACHE_STALL_TRACE] "
             f"layer={layer_number} phase={phase} edge={edge}",
@@ -374,7 +365,7 @@ class TransformerLayer(nn.Layer):
                 register_indexcache_pipeline_adapter,
             )
 
-            register_indexcache_pipeline_adapter(config.index_topk_pattern)
+            register_indexcache_pipeline_adapter(config)
         TransformerLayer._gpt_model_use_experimental_version = (
             config.gpt_model_use_experimental_version
         )
@@ -1111,7 +1102,10 @@ class TransformerLayer(nn.Layer):
                         )
                     )
                     _emit_indexcache_stall_trace(
-                        self.layer_number, "recompute_body", "enter"
+                        self.config,
+                        self.layer_number,
+                        "recompute_body",
+                        "enter",
                     )
                     body_outputs = self._forward_impl(
                         hidden_states=hidden_states,
@@ -1135,12 +1129,18 @@ class TransformerLayer(nn.Layer):
                         **docmask_meta_kwargs,
                     )
                     _emit_indexcache_stall_trace(
-                        self.layer_number, "recompute_body", "exit"
+                        self.config,
+                        self.layer_number,
+                        "recompute_body",
+                        "exit",
                     )
                     return _flatten_indexcache_recompute_outputs(body_outputs)
 
                 _emit_indexcache_stall_trace(
-                    self.layer_number, "full_recompute", "enter"
+                    self.config,
+                    self.layer_number,
+                    "full_recompute",
+                    "enter",
                 )
                 outputs = recompute(
                     _forward_impl_for_recompute,
@@ -1188,7 +1188,10 @@ class TransformerLayer(nn.Layer):
                     **offload_kwargs,
                 )
                 _emit_indexcache_stall_trace(
-                    self.layer_number, "full_recompute", "exit"
+                    self.config,
+                    self.layer_number,
+                    "full_recompute",
+                    "exit",
                 )
         else:
             outputs = self._forward_impl(**dict_args, **docmask_meta_kwargs)
@@ -1276,9 +1279,9 @@ class TransformerLayer(nn.Layer):
         else:
             dict_args.pop("indexcache_state", None)
         rst = {**dict_args, **rst}
-        if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1" and getattr(
-            self.config, "index_topk_pattern", None
-        ):
+        if getattr(
+            self.config, "indexcache_train_debug", False
+        ) and getattr(self.config, "index_topk_pattern", None):
             state = rst.get("indexcache_state", None)
             if isinstance(state, (tuple, list)):
                 state_len = len(state)
@@ -1560,7 +1563,9 @@ class TransformerLayer(nn.Layer):
                 context (Tensor): Updated context tensor if cross-attention is used,
                 otherwise None.
         """
-        _emit_indexcache_stall_trace(self.layer_number, "attention", "enter")
+        _emit_indexcache_stall_trace(
+            self.config, self.layer_number, "attention", "enter"
+        )
 
         # Residual connection.
         residual = hidden_states
@@ -1573,7 +1578,7 @@ class TransformerLayer(nn.Layer):
         else:
             input_layernorm_output = self.input_layernorm(hidden_states)
         _emit_indexcache_stall_trace(
-            self.layer_number, "input_layernorm", "exit"
+            self.config, self.layer_number, "input_layernorm", "exit"
         )
 
         self._log_md5(
@@ -1652,7 +1657,7 @@ class TransformerLayer(nn.Layer):
                 **extra_kwargs,
             )
         _emit_indexcache_stall_trace(
-            self.layer_number, "self_attention", "exit"
+            self.config, self.layer_number, "self_attention", "exit"
         )
 
         indexcache_state_updated = False
@@ -1713,7 +1718,9 @@ class TransformerLayer(nn.Layer):
         if is_first_fwd:
             hidden_states.stop_gradient = False
 
-        _emit_indexcache_stall_trace(self.layer_number, "attention", "exit")
+        _emit_indexcache_stall_trace(
+            self.config, self.layer_number, "attention", "exit"
+        )
         if indexcache_state_updated or indexcache_state is not None:
             return hidden_states, context, indexcache_state
         return hidden_states, context
@@ -1736,7 +1743,9 @@ class TransformerLayer(nn.Layer):
         Returns:
             output (Tensor): Transformed hidden states of shape [s, b, h].
         """
-        _emit_indexcache_stall_trace(self.layer_number, "mlp", "enter")
+        _emit_indexcache_stall_trace(
+            self.config, self.layer_number, "mlp", "enter"
+        )
 
         # Residual connection.
         residual = hidden_states
@@ -1751,7 +1760,10 @@ class TransformerLayer(nn.Layer):
                 hidden_states
             )
         _emit_indexcache_stall_trace(
-            self.layer_number, "post_attention_layernorm", "exit"
+            self.config,
+            self.layer_number,
+            "post_attention_layernorm",
+            "exit",
         )
 
         self._log_md5(
@@ -1760,7 +1772,9 @@ class TransformerLayer(nn.Layer):
             self.layer_number,
         )
 
-        _emit_indexcache_stall_trace(self.layer_number, "mlp_core", "enter")
+        _emit_indexcache_stall_trace(
+            self.config, self.layer_number, "mlp_core", "enter"
+        )
         if self.recompute_mlp:
             _mlp_input_ids = (
                 input_ids if isinstance(self.mlp, MoELayer) else None
@@ -1806,7 +1820,9 @@ class TransformerLayer(nn.Layer):
                 )
             else:
                 mlp_output_with_bias = self.mlp(post_attention_layernorm_output)
-        _emit_indexcache_stall_trace(self.layer_number, "mlp_core", "exit")
+        _emit_indexcache_stall_trace(
+            self.config, self.layer_number, "mlp_core", "exit"
+        )
 
         # Log MLP raw output before BDA
         if (
@@ -1841,7 +1857,9 @@ class TransformerLayer(nn.Layer):
         if is_first_fwd:
             hidden_states.stop_gradient = False
 
-        _emit_indexcache_stall_trace(self.layer_number, "mlp", "exit")
+        _emit_indexcache_stall_trace(
+            self.config, self.layer_number, "mlp", "exit"
+        )
         return hidden_states
 
     def fp8_quant_weight(self, batch_mode=False, quant_transpose=True):

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -50,6 +50,18 @@ from paddlefleet.train_infer_consistent_ops.inspect_util import (
 )
 from paddlefleet.transformer.dsv4_hybrid_attention import DSv4HybridAttention
 from paddlefleet.transformer.identity_op import IdentityFuncOp, IdentityOp
+from paddlefleet.transformer.indexcache_state import (
+    INDEXCACHE_DISTILL_STATE_LEN,
+    INDEXCACHE_RECOMPUTE_STATE_MAX_LEN,
+    INDEXCACHE_STATE_KIND_DISTILL,
+    INDEXCACHE_STATE_KIND_TOPK_ONLY,
+    INDEXCACHE_TOPK_ONLY_STATE_LEN,
+    apply_stop_gradient_mask,
+    clone_state_outputs,
+    state_from_slots,
+    state_kind,
+    state_to_slots,
+)
 from paddlefleet.transformer.kimi_delta_attention import KimiDeltaAttention
 from paddlefleet.transformer.mlp import MLP
 from paddlefleet.transformer.moe.moe_layer import MoELayer
@@ -68,6 +80,33 @@ if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _indexcache_stall_trace_enabled(layer_number):
+    """Return whether count-only stall tracing is enabled for this layer."""
+    if os.environ.get("INDEXCACHE_STALL_TRACE", "0") != "1":
+        return False
+    try:
+        layers = {
+            int(value.strip())
+            for value in os.environ.get(
+                "INDEXCACHE_STALL_TRACE_LAYERS", "2"
+            ).split(",")
+            if value.strip()
+        }
+    except ValueError:
+        return False
+    return layer_number in layers
+
+
+def _emit_indexcache_stall_trace(layer_number, phase, edge):
+    """Emit a symmetric marker without tensor values or CUDA synchronization."""
+    if _indexcache_stall_trace_enabled(layer_number):
+        print(
+            "[INDEXCACHE_STALL_TRACE] "
+            f"layer={layer_number} phase={phase} edge={edge}",
+            flush=True,
+        )
 
 
 def is_mtp_shared_last_layer(config, layer_number, is_mtp_layer):
@@ -135,6 +174,98 @@ def tensors_clone(outputs):
         raise ValueError(
             f"Unsupported data type:{type(outputs)} in tensors_clone"
         )
+
+
+def _is_indexcache_recompute_state(value):
+    if not (
+        isinstance(value, (tuple, list))
+        and len(value)
+        in (INDEXCACHE_TOPK_ONLY_STATE_LEN, INDEXCACHE_DISTILL_STATE_LEN)
+        and all(isinstance(item, paddle.Tensor) for item in value)
+    ):
+        return False
+    return state_kind(value) in (
+        INDEXCACHE_STATE_KIND_TOPK_ONLY,
+        INDEXCACHE_STATE_KIND_DISTILL,
+    )
+
+
+def _mark_indexcache_recompute_state_stop_gradient(value):
+    if not _is_indexcache_recompute_state(value):
+        return value
+    return apply_stop_gradient_mask(value)
+
+
+def _ensure_recompute_non_leaf_tensor(value):
+    if (
+        isinstance(value, paddle.Tensor)
+        and not value.stop_gradient
+        and getattr(value, "is_leaf", False)
+    ):
+        return paddle.scale(value, scale=1.0, bias=0.0)
+    return value
+
+
+def _describe_indexcache_recompute_input(value):
+    if value is None:
+        return None
+    if isinstance(value, paddle.Tensor):
+        return {
+            "type": "Tensor",
+            "shape": list(value.shape),
+            "dtype": str(value.dtype),
+            "stop_gradient": bool(value.stop_gradient),
+            "is_leaf": bool(getattr(value, "is_leaf", False)),
+        }
+    if isinstance(value, (tuple, list)):
+        return [
+            _describe_indexcache_recompute_input(item)
+            for item in value
+            if item is not None
+        ]
+    return {"type": type(value).__name__}
+
+
+def _clone_indexcache_recompute_state_outputs(value):
+    return clone_state_outputs(value)
+
+
+def _flatten_indexcache_recompute_outputs(outputs):
+    if not isinstance(outputs, tuple) or len(outputs) <= 2:
+        return outputs
+
+    output, context, indexcache_state = outputs[0], outputs[1], outputs[2]
+    if not _is_indexcache_recompute_state(indexcache_state):
+        return outputs
+
+    indexcache_state = _clone_indexcache_recompute_state_outputs(
+        indexcache_state
+    )
+
+    if context is None:
+        return (output, *indexcache_state)
+    return (output, context, *indexcache_state)
+
+
+def _unpack_flattened_indexcache_recompute_outputs(outputs):
+    if not isinstance(outputs, tuple):
+        return None
+
+    if len(outputs) in (
+        1 + INDEXCACHE_TOPK_ONLY_STATE_LEN,
+        1 + INDEXCACHE_DISTILL_STATE_LEN,
+    ) and all(isinstance(item, paddle.Tensor) for item in outputs[1:]):
+        indexcache_state = apply_stop_gradient_mask(outputs[1:])
+        return outputs[0], None, indexcache_state
+
+    if len(outputs) in (
+        2 + INDEXCACHE_TOPK_ONLY_STATE_LEN,
+        2 + INDEXCACHE_DISTILL_STATE_LEN,
+    ) and all(isinstance(item, paddle.Tensor) for item in outputs[2:]):
+        indexcache_state = apply_stop_gradient_mask(outputs[2:])
+        return outputs[0], outputs[1], indexcache_state
+
+    return None
 
 
 @dataclass
@@ -238,6 +369,12 @@ class TransformerLayer(nn.Layer):
         # scheduler, so install here rather than in one subclass: the base is the
         # only place every transformer variant passes through.
         install_recompute_p2p_overlap(config)
+        if getattr(config, "index_topk_pattern", None):
+            from paddlefleet.pipeline_parallel.indexcache_adapter import (
+                register_indexcache_pipeline_adapter,
+            )
+
+            register_indexcache_pipeline_adapter(config.index_topk_pattern)
         TransformerLayer._gpt_model_use_experimental_version = (
             config.gpt_model_use_experimental_version
         )
@@ -922,8 +1059,91 @@ class TransformerLayer(nn.Layer):
                     **cu_seqlens_kwargs,
                 )
             else:
+                indexcache_state = dict_args.get("indexcache_state", None)
+                indexcache_state = (
+                    apply_stop_gradient_mask(indexcache_state)
+                    if indexcache_state is not None
+                    else None
+                )
+                indexcache_state_slots = state_to_slots(indexcache_state)
+                assert (
+                    len(indexcache_state_slots)
+                    == INDEXCACHE_RECOMPUTE_STATE_MAX_LEN
+                )
+
+                def _forward_impl_for_recompute(
+                    hidden_states,
+                    attention_mask=None,
+                    attn_mask_startend_row_indices=None,
+                    context=None,
+                    context_mask=None,
+                    rotary_pos_emb=None,
+                    rotary_pos_cos=None,
+                    rotary_pos_sin=None,
+                    swa_rotary_pos_emb=None,
+                    swa_rotary_pos_cos=None,
+                    swa_rotary_pos_sin=None,
+                    position_ids=None,
+                    attention_bias=None,
+                    packed_seq_params=None,
+                    input_ids=None,
+                    origin_input_ids=None,
+                    cu_seqlens=None,
+                    indexcache_state_0=None,
+                    indexcache_state_1=None,
+                    indexcache_state_2=None,
+                    indexcache_state_3=None,
+                    indexcache_state_4=None,
+                    indexcache_state_5=None,
+                    indexcache_state_6=None,
+                    indexcache_state_7=None,
+                ):
+                    recompute_indexcache_state = state_from_slots(
+                        (
+                            indexcache_state_0,
+                            indexcache_state_1,
+                            indexcache_state_2,
+                            indexcache_state_3,
+                            indexcache_state_4,
+                            indexcache_state_5,
+                            indexcache_state_6,
+                            indexcache_state_7,
+                        )
+                    )
+                    _emit_indexcache_stall_trace(
+                        self.layer_number, "recompute_body", "enter"
+                    )
+                    body_outputs = self._forward_impl(
+                        hidden_states=hidden_states,
+                        attention_mask=attention_mask,
+                        attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+                        context=context,
+                        context_mask=context_mask,
+                        rotary_pos_emb=rotary_pos_emb,
+                        rotary_pos_cos=rotary_pos_cos,
+                        rotary_pos_sin=rotary_pos_sin,
+                        swa_rotary_pos_emb=swa_rotary_pos_emb,
+                        swa_rotary_pos_cos=swa_rotary_pos_cos,
+                        swa_rotary_pos_sin=swa_rotary_pos_sin,
+                        position_ids=position_ids,
+                        attention_bias=attention_bias,
+                        packed_seq_params=packed_seq_params,
+                        input_ids=input_ids,
+                        origin_input_ids=origin_input_ids,
+                        cu_seqlens=cu_seqlens,
+                        indexcache_state=recompute_indexcache_state,
+                        **docmask_meta_kwargs,
+                    )
+                    _emit_indexcache_stall_trace(
+                        self.layer_number, "recompute_body", "exit"
+                    )
+                    return _flatten_indexcache_recompute_outputs(body_outputs)
+
+                _emit_indexcache_stall_trace(
+                    self.layer_number, "full_recompute", "enter"
+                )
                 outputs = recompute(
-                    self._forward_impl,
+                    _forward_impl_for_recompute,
                     hidden_states=hidden_states,
                     attention_mask=attention_mask,
                     attn_mask_startend_row_indices=attn_mask_startend_row_indices.clone()
@@ -956,15 +1176,35 @@ class TransformerLayer(nn.Layer):
                     packed_seq_params=packed_seq_params,
                     input_ids=input_ids,
                     origin_input_ids=origin_input_ids,
-                    **cu_seqlens_kwargs,
-                    **docmask_meta_kwargs,
+                    cu_seqlens=cu_seqlens_kwargs.get("cu_seqlens"),
+                    indexcache_state_0=indexcache_state_slots[0],
+                    indexcache_state_1=indexcache_state_slots[1],
+                    indexcache_state_2=indexcache_state_slots[2],
+                    indexcache_state_3=indexcache_state_slots[3],
+                    indexcache_state_4=indexcache_state_slots[4],
+                    indexcache_state_5=indexcache_state_slots[5],
+                    indexcache_state_6=indexcache_state_slots[6],
+                    indexcache_state_7=indexcache_state_slots[7],
                     **offload_kwargs,
+                )
+                _emit_indexcache_stall_trace(
+                    self.layer_number, "full_recompute", "exit"
                 )
         else:
             outputs = self._forward_impl(**dict_args, **docmask_meta_kwargs)
 
-        if isinstance(outputs, tuple):
+        indexcache_state = None
+        flattened_indexcache_outputs = (
+            _unpack_flattened_indexcache_recompute_outputs(outputs)
+            if self.full_recompute
+            else None
+        )
+        if flattened_indexcache_outputs is not None:
+            output, context, indexcache_state = flattened_indexcache_outputs
+        elif isinstance(outputs, tuple):
             output, context = outputs[0], outputs[1]
+            if len(outputs) > 2:
+                indexcache_state = outputs[2]
         else:
             output, context = outputs, None
 
@@ -1031,7 +1271,43 @@ class TransformerLayer(nn.Layer):
             # dict_args unchanged and will be consumed by MTP layer directly
         if context is not None:
             rst["context"] = context
+        if indexcache_state is not None:
+            rst["indexcache_state"] = indexcache_state
+        else:
+            dict_args.pop("indexcache_state", None)
         rst = {**dict_args, **rst}
+        if os.environ.get("INDEXCACHE_TRAIN_DEBUG", "0") == "1" and getattr(
+            self.config, "index_topk_pattern", None
+        ):
+            state = rst.get("indexcache_state", None)
+            if isinstance(state, (tuple, list)):
+                state_len = len(state)
+                state_shapes = [
+                    list(item.shape)
+                    if isinstance(item, paddle.Tensor)
+                    else type(item).__name__
+                    for item in state
+                ]
+                state_stop_gradients = [
+                    bool(item.stop_gradient)
+                    if isinstance(item, paddle.Tensor)
+                    else None
+                    for item in state
+                ]
+            else:
+                state_len = 0
+                state_shapes = None
+                state_stop_gradients = None
+            print(
+                "[INDEXCACHE_TRAIN_FLOW] "
+                f"layer={self.layer_number} "
+                f"full_recompute={self.full_recompute} "
+                f"flattened={flattened_indexcache_outputs is not None} "
+                f"state_len={state_len} state_shapes={state_shapes} "
+                f"state_stop_gradients={state_stop_gradients} "
+                f"keys={list(rst.keys())}",
+                flush=True,
+            )
         return rst
 
     def _forward_impl(
@@ -1052,11 +1328,34 @@ class TransformerLayer(nn.Layer):
         packed_seq_params: PackedSeqParams | None = None,
         input_ids: Tensor | None = None,
         origin_input_ids: Tensor | None = None,
+        indexcache_state: tuple | list | None = None,
         blocks: list | tuple | None = None,
         cu_seqlens: Tensor | None = None,
         docmask_mb_idx: int = -1,
         **kwargs,
     ):
+        if indexcache_state is None:
+            indexcache_state = kwargs.get("indexcache_state", None)
+        if _is_indexcache_recompute_state(indexcache_state):
+            indexcache_state = _mark_indexcache_recompute_state_stop_gradient(
+                indexcache_state
+            )
+            kwargs["indexcache_state"] = indexcache_state
+        elif indexcache_state is not None and "indexcache_state" not in kwargs:
+            kwargs["indexcache_state"] = indexcache_state
+
+        def unpack_attention_outputs(attention_outputs):
+            if (
+                isinstance(attention_outputs, tuple)
+                and len(attention_outputs) == 3
+            ):
+                return (
+                    attention_outputs[0],
+                    attention_outputs[1],
+                    attention_outputs[2],
+                )
+            return attention_outputs[0], attention_outputs[1], indexcache_state
+
         def need_do_attention():
             # need_do_prefill = forward_meta.max_len_tensor_cpu[1] > 0
             # need_do_decode = forward_meta.max_len_tensor_cpu[2] > 0
@@ -1107,27 +1406,31 @@ class TransformerLayer(nn.Layer):
             # Self-attention (skip internal bda residual)
             with profile("attn"):
                 if need_do_attention():
-                    hidden_states, context = self._forward_attention(
-                        hidden_states=hidden_states,
-                        attention_mask=attention_mask,
-                        attn_mask_startend_row_indices=attn_mask_startend_row_indices,
-                        context=context,
-                        context_mask=context_mask,
-                        rotary_pos_emb=rotary_pos_emb,
-                        rotary_pos_cos=rotary_pos_cos,
-                        rotary_pos_sin=rotary_pos_sin,
-                        swa_rotary_pos_emb=swa_rotary_pos_emb,
-                        swa_rotary_pos_cos=swa_rotary_pos_cos,
-                        swa_rotary_pos_sin=swa_rotary_pos_sin,
-                        position_ids=position_ids,
-                        attention_bias=attention_bias,
-                        packed_seq_params=packed_seq_params,
-                        block_attention_residuals=True,
-                        in_recompute=self.full_recompute,
-                        input_ids=input_ids,
-                        cu_seqlens=cu_seqlens,
-                        docmask_mb_idx=docmask_mb_idx,
-                        **kwargs,
+                    hidden_states, context, indexcache_state = (
+                        unpack_attention_outputs(
+                            self._forward_attention(
+                                hidden_states=hidden_states,
+                                attention_mask=attention_mask,
+                                attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+                                context=context,
+                                context_mask=context_mask,
+                                rotary_pos_emb=rotary_pos_emb,
+                                rotary_pos_cos=rotary_pos_cos,
+                                rotary_pos_sin=rotary_pos_sin,
+                                swa_rotary_pos_emb=swa_rotary_pos_emb,
+                                swa_rotary_pos_cos=swa_rotary_pos_cos,
+                                swa_rotary_pos_sin=swa_rotary_pos_sin,
+                                position_ids=position_ids,
+                                attention_bias=attention_bias,
+                                packed_seq_params=packed_seq_params,
+                                block_attention_residuals=True,
+                                in_recompute=self.full_recompute,
+                                input_ids=input_ids,
+                                cu_seqlens=cu_seqlens,
+                                docmask_mb_idx=docmask_mb_idx,
+                                **kwargs,
+                            )
+                        )
                     )
 
             # Accumulate attn output into partial_block
@@ -1165,26 +1468,30 @@ class TransformerLayer(nn.Layer):
             )
             with profile("attn"):
                 if need_do_attention():
-                    hidden_states, context = self._forward_attention(
-                        hidden_states=hidden_states,
-                        attention_mask=attention_mask,
-                        attn_mask_startend_row_indices=attn_mask_startend_row_indices,
-                        context=context,
-                        context_mask=context_mask,
-                        rotary_pos_emb=rotary_pos_emb,
-                        rotary_pos_cos=rotary_pos_cos,
-                        rotary_pos_sin=rotary_pos_sin,
-                        swa_rotary_pos_emb=swa_rotary_pos_emb,
-                        swa_rotary_pos_cos=swa_rotary_pos_cos,
-                        swa_rotary_pos_sin=swa_rotary_pos_sin,
-                        position_ids=position_ids,
-                        attention_bias=attention_bias,
-                        packed_seq_params=packed_seq_params,
-                        in_recompute=self.full_recompute,
-                        input_ids=input_ids,
-                        cu_seqlens=cu_seqlens,
-                        docmask_mb_idx=docmask_mb_idx,
-                        **kwargs,
+                    hidden_states, context, indexcache_state = (
+                        unpack_attention_outputs(
+                            self._forward_attention(
+                                hidden_states=hidden_states,
+                                attention_mask=attention_mask,
+                                attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+                                context=context,
+                                context_mask=context_mask,
+                                rotary_pos_emb=rotary_pos_emb,
+                                rotary_pos_cos=rotary_pos_cos,
+                                rotary_pos_sin=rotary_pos_sin,
+                                swa_rotary_pos_emb=swa_rotary_pos_emb,
+                                swa_rotary_pos_cos=swa_rotary_pos_cos,
+                                swa_rotary_pos_sin=swa_rotary_pos_sin,
+                                position_ids=position_ids,
+                                attention_bias=attention_bias,
+                                packed_seq_params=packed_seq_params,
+                                in_recompute=self.full_recompute,
+                                input_ids=input_ids,
+                                cu_seqlens=cu_seqlens,
+                                docmask_mb_idx=docmask_mb_idx,
+                                **kwargs,
+                            )
+                        )
                     )
             self._log_md5(
                 hidden_states, "post_attn_residual", self.layer_number
@@ -1197,6 +1504,8 @@ class TransformerLayer(nn.Layer):
                 )
             self._log_md5(output, "layer_output", self.layer_number)
             output = inspect_tensor("layer_output", self.layer_number, output)
+        if indexcache_state is not None:
+            return output, context, indexcache_state
         if context is not None:
             return output, context
         return output
@@ -1251,6 +1560,7 @@ class TransformerLayer(nn.Layer):
                 context (Tensor): Updated context tensor if cross-attention is used,
                 otherwise None.
         """
+        _emit_indexcache_stall_trace(self.layer_number, "attention", "enter")
 
         # Residual connection.
         residual = hidden_states
@@ -1262,6 +1572,9 @@ class TransformerLayer(nn.Layer):
             )
         else:
             input_layernorm_output = self.input_layernorm(hidden_states)
+        _emit_indexcache_stall_trace(
+            self.layer_number, "input_layernorm", "exit"
+        )
 
         self._log_md5(
             input_layernorm_output, "input_layernorm_out", self.layer_number
@@ -1284,6 +1597,11 @@ class TransformerLayer(nn.Layer):
             extra_kwargs["cu_seqlens"] = cu_seqlens
         if "shared_kv" in kwargs:
             extra_kwargs["shared_kv"] = kwargs["shared_kv"]
+        indexcache_state = kwargs.get("indexcache_state", None)
+        if indexcache_state is not None and isinstance(
+            self.self_attn, DSv4HybridAttention
+        ):
+            extra_kwargs["indexcache_state"] = indexcache_state
 
         if isinstance(self.self_attn, MultiLatentAttention):
             attention_output_with_bias = self.self_attn(
@@ -1333,6 +1651,18 @@ class TransformerLayer(nn.Layer):
                 use_cache=kwargs.get("use_cache", False),
                 **extra_kwargs,
             )
+        _emit_indexcache_stall_trace(
+            self.layer_number, "self_attention", "exit"
+        )
+
+        indexcache_state_updated = False
+        if (
+            isinstance(attention_output_with_bias, tuple)
+            and len(attention_output_with_bias) == 3
+        ):
+            indexcache_state = attention_output_with_bias[2]
+            attention_output_with_bias = attention_output_with_bias[:2]
+            indexcache_state_updated = True
 
         with paddle.enable_grad():
             if block_attention_residuals:
@@ -1383,6 +1713,9 @@ class TransformerLayer(nn.Layer):
         if is_first_fwd:
             hidden_states.stop_gradient = False
 
+        _emit_indexcache_stall_trace(self.layer_number, "attention", "exit")
+        if indexcache_state_updated or indexcache_state is not None:
+            return hidden_states, context, indexcache_state
         return hidden_states, context
 
     def _forward_mlp(
@@ -1403,6 +1736,7 @@ class TransformerLayer(nn.Layer):
         Returns:
             output (Tensor): Transformed hidden states of shape [s, b, h].
         """
+        _emit_indexcache_stall_trace(self.layer_number, "mlp", "enter")
 
         # Residual connection.
         residual = hidden_states
@@ -1416,6 +1750,9 @@ class TransformerLayer(nn.Layer):
             post_attention_layernorm_output = self.post_attention_layernorm(
                 hidden_states
             )
+        _emit_indexcache_stall_trace(
+            self.layer_number, "post_attention_layernorm", "exit"
+        )
 
         self._log_md5(
             post_attention_layernorm_output,
@@ -1423,6 +1760,7 @@ class TransformerLayer(nn.Layer):
             self.layer_number,
         )
 
+        _emit_indexcache_stall_trace(self.layer_number, "mlp_core", "enter")
         if self.recompute_mlp:
             _mlp_input_ids = (
                 input_ids if isinstance(self.mlp, MoELayer) else None
@@ -1468,6 +1806,7 @@ class TransformerLayer(nn.Layer):
                 )
             else:
                 mlp_output_with_bias = self.mlp(post_attention_layernorm_output)
+        _emit_indexcache_stall_trace(self.layer_number, "mlp_core", "exit")
 
         # Log MLP raw output before BDA
         if (
@@ -1502,6 +1841,7 @@ class TransformerLayer(nn.Layer):
         if is_first_fwd:
             hidden_states.stop_gradient = False
 
+        _emit_indexcache_stall_trace(self.layer_number, "mlp", "exit")
         return hidden_states
 
     def fp8_quant_weight(self, batch_mode=False, quant_transpose=True):
@@ -1887,6 +2227,11 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         if isinstance(self.self_attn, KimiDeltaAttention):
             # Built once per step by the embedding; None makes KDA build its own.
             extra_kwargs["cu_seqlens"] = kwargs.get("cu_seqlens")
+        indexcache_state = kwargs.get("indexcache_state", None)
+        if indexcache_state is not None and isinstance(
+            self.self_attn, DSv4HybridAttention
+        ):
+            extra_kwargs["indexcache_state"] = indexcache_state
         # Micro-batch slot for the shared document-mask metadata, decided in
         # ``forward`` (outside recompute) and only read here. This override is
         # the ``_forward_attention`` that runs whenever enable_hyper_connections
@@ -1947,6 +2292,15 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 **extra_kwargs,
             )
 
+        indexcache_state_updated = False
+        if (
+            isinstance(attention_output_with_bias, tuple)
+            and len(attention_output_with_bias) == 3
+        ):
+            indexcache_state = attention_output_with_bias[2]
+            attention_output_with_bias = attention_output_with_bias[:2]
+            indexcache_state_updated = True
+
         # mHC: fused H_res + H_post + bias-dropout-add
         attention_output_with_bias = inspect_tensor(
             "Attn_output",
@@ -1997,6 +2351,8 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         if is_first_fwd:
             hidden_states.stop_gradient = False
 
+        if indexcache_state_updated or indexcache_state is not None:
+            return hidden_states, context, indexcache_state
         return hidden_states, context
 
     def _forward_mlp(

--- a/tests/multi_card_tests/pipeline_parallel/test_indexcache_pipeline.py
+++ b/tests/multi_card_tests/pipeline_parallel/test_indexcache_pipeline.py
@@ -1,0 +1,175 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Two-rank PP regression for IndexCache F -> S state transport.
+
+Run with:
+    PYTHONPATH=.:./src python -m paddle.distributed.launch --devices 0,1 \
+        tests/multi_card_tests/pipeline_parallel/test_indexcache_pipeline.py
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import paddle
+import paddle.distributed as dist
+import paddle.nn.functional as F
+from paddle import nn
+from paddle.distributed import fleet
+from paddle.distributed.fleet import distributed_model
+from paddle.distributed.fleet.meta_parallel import LayerDesc, PipelineLayer
+
+from paddlefleet.pipeline_parallel.indexcache_adapter import (
+    register_indexcache_pipeline_adapter,
+)
+from paddlefleet.transformer.indexcache_state import apply_stop_gradient_mask
+
+
+class _IndexCacheProducer(nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.producer_scale = self.create_parameter(
+            shape=[1],
+            dtype="float32",
+            default_initializer=nn.initializer.Constant(0.0),
+        )
+
+    def forward(self, inputs):
+        hidden_states = inputs["hidden_states"]
+        batch, seq = hidden_states.shape
+        logits = paddle.stack(
+            [self.producer_scale, -self.producer_scale], axis=-1
+        ).reshape([1, 1, 2])
+        topk_probs = F.softmax(logits, axis=-1).expand([batch, seq, 2])
+        topk_indices = paddle.arange(batch * seq * 2, dtype="int32").reshape(
+            [batch, seq, 2]
+        )
+        state = apply_stop_gradient_mask(
+            (
+                topk_indices,
+                paddle.zeros([1], dtype="float32"),
+                paddle.zeros([1], dtype="float32"),
+                paddle.zeros([1], dtype="float32"),
+                paddle.zeros([1], dtype="int32"),
+                topk_probs,
+                paddle.full([1], 1, dtype="int64"),
+                paddle.full([1], 1, dtype="int64"),
+            )
+        )
+        return {
+            "hidden_states": hidden_states,
+            "indexcache_state": state,
+        }
+
+
+class _IndexCacheServed(nn.Layer):
+    def forward(self, inputs):
+        state = inputs["indexcache_state"]
+        hidden_states = inputs["hidden_states"]
+
+        assert isinstance(state, tuple)
+        assert len(state) == 8
+        expected_shapes = (
+            [1, 2, 2],
+            [1],
+            [1],
+            [1],
+            [1],
+            [1, 2, 2],
+            [1],
+            [1],
+        )
+        expected_dtypes = (
+            paddle.int32,
+            paddle.float32,
+            paddle.float32,
+            paddle.float32,
+            paddle.int32,
+            paddle.float32,
+            paddle.int64,
+            paddle.int64,
+        )
+        assert tuple(list(tensor.shape) for tensor in state) == expected_shapes
+        assert tuple(tensor.dtype for tensor in state) == expected_dtypes
+        assert tuple(tensor.stop_gradient for tensor in state) == (
+            True,
+            True,
+            True,
+            True,
+            True,
+            False,
+            True,
+            True,
+        )
+        expected_topk = paddle.arange(4, dtype="int32").reshape([1, 2, 2])
+        assert bool(paddle.equal_all(state[0], expected_topk))
+
+        # Keep a zero-valued hidden-state edge so the test also exercises a
+        # regular pipeline tensor alongside the differentiable state-5 edge.
+        return hidden_states * 0.0 + state[5][..., 0]
+
+
+class _MeanLoss(nn.Layer):
+    def forward(self, output, _labels):
+        return output.mean()
+
+
+class TestIndexCachePipeline(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if dist.get_world_size() != 2:
+            raise unittest.SkipTest("IndexCache PP regression requires 2 ranks")
+
+        strategy = fleet.DistributedStrategy()
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": 2,
+        }
+        strategy.pipeline_configs = {
+            "accumulate_steps": 1,
+            "micro_batch_size": 1,
+        }
+        fleet.init(is_collective=True, strategy=strategy)
+        register_indexcache_pipeline_adapter(
+            SimpleNamespace(
+                index_topk_pattern="FS",
+                indexcache_train_debug=False,
+            )
+        )
+
+    def test_f_to_s_state_and_gradient_cross_stage(self):
+        model = PipelineLayer(
+            layers=[
+                LayerDesc(_IndexCacheProducer),
+                LayerDesc(_IndexCacheServed),
+            ],
+            num_stages=2,
+            loss_fn=_MeanLoss(),
+        )
+        pipeline = distributed_model(model)
+        inputs = {"hidden_states": paddle.ones([1, 2], dtype="float32")}
+        labels = paddle.zeros([1, 1], dtype="float32")
+
+        loss = pipeline.forward_backward_pipeline((inputs, labels))
+        self.assertIsInstance(loss, paddle.Tensor)
+
+        stage_id = fleet.get_hybrid_communicate_group().get_stage_id()
+        if stage_id == 0:
+            producer_parameters = [
+                parameter
+                for name, parameter in model.named_parameters()
+                if name.endswith("producer_scale")
+            ]
+            self.assertEqual(len(producer_parameters), 1)
+            producer_grad = producer_parameters[0].grad
+            self.assertIsNotNone(producer_grad)
+            self.assertGreater(abs(float(producer_grad.item())), 0.0)
+
+        dist.barrier()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/multi_card_tests/transformer/test_indexcache_cp.py
+++ b/tests/multi_card_tests/transformer/test_indexcache_cp.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Two-rank CP regression for IndexCache F/S Replay ordering and gradients.
+
+Run with:
+    PYTHONPATH=.:./src python -m paddle.distributed.launch --devices 0,1 \
+        tests/multi_card_tests/transformer/test_indexcache_cp.py
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import paddle
+import paddle.distributed as dist
+import paddle.nn.functional as F
+from paddle.distributed import fleet
+
+from paddlefleet.transformer.cp_utils import all_gather_cp
+from paddlefleet.transformer.csa_attention import CompressedSparseAttention
+from paddlefleet.transformer.indexcache_state import apply_stop_gradient_mask
+
+
+CP_SIZE = None
+CP_RANK = None
+CP_GROUP = None
+
+
+def setUpModule():
+    global CP_SIZE, CP_RANK, CP_GROUP
+    world_size = dist.get_world_size()
+    if world_size != 2:
+        raise unittest.SkipTest("IndexCache CP regression requires 2 ranks")
+
+    strategy = fleet.DistributedStrategy()
+    strategy.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": 1,
+        "pp_degree": 1,
+        "sharding_degree": world_size,
+        "sep_degree": 1,
+        "cp_degree": world_size,
+        "ep_degree": world_size,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+    }
+    fleet.init(is_collective=True, strategy=strategy)
+    CP_GROUP = fleet.get_hybrid_communicate_group().get_context_parallel_group()
+    CP_RANK = CP_GROUP.rank
+    CP_SIZE = CP_GROUP.nranks
+
+
+class _CollectiveCompressor:
+    def __call__(self, x, cp_group=None, docmask_meta=None):
+        del docmask_meta
+        local_compressed = x[:, ::4, :1].contiguous()
+        return all_gather_cp(local_compressed, dim=1, group=cp_group)
+
+
+class _IndexCacheCPHarness:
+    def __init__(self, action, producer_scale=None):
+        self.action = action
+        self.config = SimpleNamespace()
+        self.cp_enabled = True
+        self.cp_size = CP_SIZE
+        self.cp_rank = CP_RANK
+        self.cp_group = CP_GROUP
+        self.tp_group = None
+        self.is_hca_layer = False
+        self.compressor = _CollectiveCompressor()
+        self.compress_ratio = 4
+        self.indexer = object()
+        self.window_size = 2
+        self.indexer_backend = "unfused"
+        self.sparse_attn_backend = "unfused"
+        self.attn_sink = paddle.zeros([1], dtype="float32")
+        self.softmax_scale = 1.0
+        self.training = True
+        self.layer_number = 1 if action == "F" else 2
+        self.producer_scale = producer_scale
+        self.native_topk = None
+        self.replay_topk = None
+        self.replay_input = None
+        self.attention_topk = None
+        self.kv_full_shape = None
+
+    def _indexcache_next_c4_action(self):
+        return 0 if self.action == "F" else 1, self.action, "FS"
+
+    @staticmethod
+    def _indexcache_has_future_served_layer(pattern, c4_ordinal):
+        return pattern == "FS" and c4_ordinal == 0
+
+    @staticmethod
+    def _indexcache_served_count(pattern, c4_ordinal):
+        assert pattern == "FS" and c4_ordinal == 0
+        return 1
+
+    @staticmethod
+    def _indexcache_scaled_loss_coeff(served_count):
+        assert served_count == 1
+        return 1.0
+
+    def _compute_indexer_compressed_topk_idxs_cp(
+        self,
+        query,
+        x,
+        qr,
+        compressed_kv_global,
+        n_compressed_global,
+        offset,
+        q_positions,
+        position_offset,
+        **_kwargs,
+    ):
+        del x, qr, compressed_kv_global, n_compressed_global
+        del q_positions, position_offset
+        assert self.action == "F"
+        batch, seq = query.shape[:2]
+        self.native_topk = paddle.full(
+            [batch, seq, 2],
+            offset + CP_RANK,
+            dtype="int32",
+        )
+        logits = paddle.stack(
+            [self.producer_scale, -self.producer_scale], axis=-1
+        ).reshape([1, 1, 2])
+        topk_probs = F.softmax(logits, axis=-1).expand([batch, seq, 2])
+        loss_state = SimpleNamespace(
+            topk_probs=topk_probs,
+            target=paddle.full_like(topk_probs, 0.5),
+            indexer_loss_coeff=1.0,
+        )
+        return self.native_topk, None, loss_state, 1.0, True, 1
+
+    def _indexcache_cache_topk(
+        self,
+        compress_topk_idxs,
+        _c4_ordinal,
+        _pattern,
+        tilelang_indexer_loss_state,
+        *_args,
+    ):
+        assert bool(paddle.equal_all(compress_topk_idxs, self.native_topk))
+        topk_probs = tilelang_indexer_loss_state.topk_probs
+        return apply_stop_gradient_mask(
+            (
+                compress_topk_idxs,
+                paddle.zeros([1], dtype="float32"),
+                paddle.zeros([1], dtype="float32"),
+                paddle.zeros([1], dtype="float32"),
+                paddle.zeros([1], dtype="int32"),
+                topk_probs,
+                paddle.full([1], self.layer_number, dtype="int64"),
+                paddle.full([1], 1, dtype="int64"),
+            )
+        )
+
+    def _indexcache_reuse_topk(
+        self,
+        _batch,
+        _seq,
+        _c4_ordinal,
+        _pattern,
+        indexcache_state=None,
+    ):
+        assert self.action == "S"
+        self.native_topk = indexcache_state[0]
+        return self.native_topk
+
+    def _indexcache_served_distill_state(
+        self,
+        query,
+        _compressed_kv,
+        _c4_ordinal,
+        _pattern,
+        indexcache_state=None,
+        **_kwargs,
+    ):
+        batch, seq = query.shape[:2]
+        target = paddle.zeros([batch, seq, 2], dtype="float32")
+        target[..., 1] = 1.0
+        return (
+            indexcache_state[5],
+            target,
+            1.0,
+            None,
+            None,
+            self.layer_number,
+            1,
+            False,
+        )
+
+    def _postprocess_indexer_replay(
+        self,
+        compress_topk_idxs,
+        _n_compressed,
+        offset,
+        **_kwargs,
+    ):
+        self.replay_input = compress_topk_idxs
+        self.replay_topk = paddle.full(
+            compress_topk_idxs.shape,
+            offset + CP_SIZE + CP_RANK,
+            dtype="int32",
+        )
+        return self.replay_topk
+
+    def compressed_sparse_attn(
+        self,
+        query,
+        kv_full,
+        _attn_sink,
+        topk_idxs,
+        _softmax_scale,
+        **_kwargs,
+    ):
+        self.attention_topk = topk_idxs[..., -2:]
+        self.kv_full_shape = list(kv_full.shape)
+        # Keep the CP all-gather in the backward graph without changing values.
+        return query.cast("float32").sum(axis=-1) + kv_full.mean() * 0.0
+
+    @staticmethod
+    def _indexcache_attach_indexer_loss(
+        output,
+        _indexer_loss,
+        _tilelang_indexer_loss_state,
+        _producer_loss_fused,
+    ):
+        return output
+
+    @staticmethod
+    def _indexcache_clear_cached_state():
+        return None
+
+
+class TestIndexCacheContextParallel(unittest.TestCase):
+    def test_f_s_replay_preserves_state_and_producer_gradient(self):
+        batch, seq = 1, 8
+        query = paddle.randn([batch, seq, 1, 1], dtype="float32")
+        key = paddle.randn([batch, seq, 1, 1], dtype="float32")
+        x = paddle.randn([batch, seq, 1], dtype="float32")
+        qr = paddle.randn([batch, seq, 1], dtype="float32")
+        for tensor in (query, key, x, qr):
+            tensor.stop_gradient = False
+
+        producer_scale = paddle.to_tensor([0.25], dtype="float32")
+        producer_scale.stop_gradient = False
+        producer = _IndexCacheCPHarness("F", producer_scale)
+        producer_output, state = CompressedSparseAttention._forward_cp(
+            producer,
+            query,
+            key,
+            x,
+            qr,
+        )
+
+        self.assertIs(producer.replay_input, producer.native_topk)
+        self.assertTrue(paddle.equal_all(state[0], producer.native_topk).item())
+        self.assertTrue(
+            paddle.equal_all(producer.attention_topk, producer.replay_topk).item()
+        )
+
+        served = _IndexCacheCPHarness("S")
+        served_output, cleared_state = CompressedSparseAttention._forward_cp(
+            served,
+            query,
+            key,
+            x,
+            qr,
+            indexcache_state=state,
+        )
+        self.assertIsNone(cleared_state)
+        self.assertIs(served.replay_input, served.native_topk)
+        self.assertTrue(paddle.equal_all(served.native_topk, state[0]).item())
+        self.assertTrue(
+            paddle.equal_all(served.attention_topk, served.replay_topk).item()
+        )
+        expected_kv_length = seq * CP_SIZE + (seq // 4) * CP_SIZE
+        self.assertEqual(producer.kv_full_shape[1], expected_kv_length)
+        self.assertEqual(served.kv_full_shape[1], expected_kv_length)
+
+        (served_output.sum() + producer_output.sum() * 0.0).backward()
+        self.assertIsNotNone(producer_scale.grad)
+        self.assertGreater(abs(float(producer_scale.grad.item())), 0.0)
+
+        dist.barrier()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/test_indexcache_core.py
+++ b/tests/single_card_tests/test_indexcache_core.py
@@ -1,0 +1,782 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import paddle
+
+from paddlefleet.transformer.csa_attention import (
+    CompressedSparseAttention,
+    IndexCacheServedDistillLossAutoScaler,
+    TileLangCSAIndexerDistillBridge,
+    TileLangCSAIndexerLossAutoScaler,
+    _indexcache_offload_saved_delta,
+    _indexcache_restore_saved_delta,
+    _unpack_indexcache_pipeline_topk,
+)
+from paddlefleet.transformer.dsa_attention import DSAIndexerLossAutoScaler
+from paddlefleet.transformer.indexcache_state import (
+    INDEXCACHE_DISTILL_GRAD_INDICES,
+    INDEXCACHE_DISTILL_STATE_TOPK_INDICES_PLACEHOLDER,
+    INDEXCACHE_STATE_KIND_DISTILL,
+    INDEXCACHE_STATE_KIND_TOPK_ONLY,
+    apply_stop_gradient_mask,
+    format_indexcache_gradient_summary,
+    state_from_slots,
+    state_kind,
+    state_to_slots,
+    summarize_indexcache_gradients,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+def _config_for_pattern(pattern, **overrides):
+    ratios = [item for _ in pattern for item in (4, 128)]
+    kwargs = {
+        "num_hidden_layers": len(ratios),
+        "experimental_attention_variant": "dsv4_hybrid",
+        "csa_compress_ratios": ratios,
+        "index_topk_pattern": pattern,
+    }
+    kwargs.update(overrides)
+    return TransformerConfig(**kwargs)
+
+
+def _layer_config(pattern, **overrides):
+    config = SimpleNamespace(
+        index_topk_pattern=pattern,
+        indexcache_multi_layer_distill=False,
+        recompute_granularity=None,
+        pipeline_model_parallel_size=1,
+        context_parallel_size=1,
+        csa_compress_ratios=[4] * len(pattern),
+        num_empty_layers_add_in_head=0,
+        dsa_indexer_loss_coeff=0.03,
+        csa_indexer_backend="tilelang",
+        _indexcache_last_topk_idxs=None,
+        _indexcache_last_layer_number=None,
+        _indexcache_last_distill_state=None,
+        _indexcache_last_served_count=None,
+    )
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _make_layer(config, layer_number):
+    layer = object.__new__(CompressedSparseAttention)
+    object.__setattr__(layer, "config", config)
+    object.__setattr__(layer, "compress_ratio", 4)
+    object.__setattr__(layer, "indexer", object())
+    object.__setattr__(layer, "layer_number", layer_number)
+    object.__setattr__(layer, "cp_enabled", False)
+    object.__setattr__(layer, "cp_rank", 0)
+    object.__setattr__(layer, "cp_size", 1)
+    object.__setattr__(layer, "training", True)
+    return layer
+
+
+class TestIndexCacheGradientNumerics(unittest.TestCase):
+    def test_fused_summary_distinguishes_finite_nonzero_zero_nan_and_inf(self):
+        for dtype in ("float32", "float16", "bfloat16"):
+            with self.subTest(dtype=dtype):
+                summaries = summarize_indexcache_gradients(
+                    [
+                        (
+                            "normal",
+                            paddle.to_tensor([0.0, 2.0, -3.0], dtype=dtype),
+                        ),
+                        ("zero", paddle.zeros([3], dtype=dtype)),
+                        (
+                            "nan",
+                            paddle.to_tensor([0.0, float("nan")], dtype=dtype),
+                        ),
+                        (
+                            "inf",
+                            paddle.to_tensor([0.0, float("inf")], dtype=dtype),
+                        ),
+                        ("missing", None),
+                    ]
+                )
+
+                self.assertTrue(summaries["normal"]["finite"])
+                self.assertTrue(summaries["normal"]["nonzero"])
+                self.assertEqual(summaries["normal"]["zero"], 1)
+                self.assertTrue(summaries["zero"]["finite"])
+                self.assertFalse(summaries["zero"]["nonzero"])
+                self.assertEqual(summaries["zero"]["zero"], 3)
+                self.assertFalse(summaries["nan"]["finite"])
+                self.assertEqual(summaries["nan"]["nan"], 1)
+                self.assertFalse(summaries["inf"]["finite"])
+                self.assertEqual(summaries["inf"]["inf"], 1)
+                self.assertFalse(summaries["missing"]["present"])
+                self.assertIn(
+                    "normal_nonzero=True",
+                    format_indexcache_gradient_summary(
+                        "normal", summaries["normal"]
+                    ),
+                )
+
+
+class TestIndexCacheConfig(unittest.TestCase):
+    def test_common_patterns_are_normalized_and_accepted(self):
+        for pattern in ("F", "FSF", "FSSF"):
+            config = _config_for_pattern(pattern.lower())
+            self.assertEqual(config.index_topk_pattern, pattern)
+
+    def test_distill_and_supported_recompute_are_accepted(self):
+        distill = _config_for_pattern(
+            "FSS",
+            indexcache_multi_layer_distill=True,
+            num_nextn_predict_layers=0,
+        )
+        self.assertTrue(distill.indexcache_multi_layer_distill)
+
+        recompute = _config_for_pattern(
+            "FSS",
+            recompute_granularity="full",
+            recompute_method="uniform",
+            recompute_num_layers=1,
+        )
+        self.assertEqual(recompute.recompute_method, "uniform")
+
+    def test_invalid_pattern_contracts_fail_fast(self):
+        cases = (
+            ({"pattern": "FX"}, ValueError),
+            ({"pattern": "SF"}, ValueError),
+            (
+                {
+                    "pattern": "F",
+                    "csa_compress_ratios": [4, 128, 4, 128],
+                    "num_hidden_layers": 4,
+                },
+                ValueError,
+            ),
+            (
+                {
+                    "pattern": "FS",
+                    "index_topk_pattern": None,
+                    "indexcache_multi_layer_distill": True,
+                },
+                ValueError,
+            ),
+            (
+                {
+                    "pattern": "FS",
+                    "recompute_granularity": "selective",
+                    "recompute_modules": ["core_attn"],
+                },
+                NotImplementedError,
+            ),
+        )
+        for values, error in cases:
+            pattern = values.pop("pattern")
+            with self.subTest(values=values), self.assertRaises(error):
+                _config_for_pattern(pattern, **values)
+
+
+class TestIndexCacheCoreState(unittest.TestCase):
+    def test_saved_delta_offload_roundtrip_preserves_device_id(self):
+        class FakePlace:
+            @staticmethod
+            def is_gpu_place():
+                return True
+
+            @staticmethod
+            def gpu_device_id():
+                return 3
+
+        class FakeGpuValue:
+            place = FakePlace()
+
+            @staticmethod
+            def cpu():
+                return FakeCpuValue()
+
+        class FakeCpuValue:
+            @staticmethod
+            def cuda(device_id):
+                return ("restored", device_id)
+
+        saved, device_id = _indexcache_offload_saved_delta(FakeGpuValue())
+
+        self.assertIsInstance(saved, FakeCpuValue)
+        self.assertEqual(device_id, 3)
+        self.assertEqual(
+            _indexcache_restore_saved_delta(saved, device_id),
+            ("restored", 3),
+        )
+
+    def test_fused_producer_loss_does_not_fall_through_to_scalar_loss(self):
+        producer = _make_layer(_layer_config("FS"), 0)
+        output = paddle.ones([1], dtype="float32")
+        indexer_loss = paddle.ones([], dtype="float32")
+        tilelang_state = (paddle.ones([1], dtype="float32"),)
+
+        with (
+            patch.object(
+                TileLangCSAIndexerLossAutoScaler, "apply"
+            ) as tilelang_apply,
+            patch.object(DSAIndexerLossAutoScaler, "apply") as scalar_apply,
+        ):
+            result = producer._indexcache_attach_indexer_loss(
+                output,
+                indexer_loss,
+                tilelang_state,
+                producer_loss_fused=True,
+            )
+
+        self.assertIs(result, output)
+        tilelang_apply.assert_not_called()
+        scalar_apply.assert_not_called()
+
+    def test_action_mapping_for_f_s_fsf_and_fssf(self):
+        for pattern in ("F", "FS", "FSF", "FSSF"):
+            config = _layer_config(pattern)
+            actions = []
+            for ordinal, layer_number in enumerate(range(1, len(pattern) + 1)):
+                layer = _make_layer(config, layer_number)
+                actions.append(layer._indexcache_next_c4_action())
+            self.assertEqual(
+                actions,
+                [(idx, action, pattern) for idx, action in enumerate(pattern)],
+            )
+
+    def test_full_model_c4_mapping_uses_normalized_one_based_layers(self):
+        pattern = "FSSSFSSSFSSSFSSSFSSSF"
+        ratios = [128] * 43
+        for ratio_index in range(2, 43, 2):
+            ratios[ratio_index] = 4
+
+        for empty_head in (0, 7):
+            with self.subTest(empty_head=empty_head):
+                config = _layer_config(
+                    pattern,
+                    csa_compress_ratios=ratios,
+                    num_empty_layers_add_in_head=empty_head,
+                )
+                first_c4 = _make_layer(config, 3)
+                second_c4 = _make_layer(config, 5)
+                self.assertEqual(
+                    first_c4._indexcache_c4_layers(), list(range(3, 44, 2))
+                )
+                self.assertEqual(
+                    first_c4._indexcache_next_c4_action(), (0, "F", pattern)
+                )
+                self.assertEqual(
+                    second_c4._indexcache_next_c4_action(), (1, "S", pattern)
+                )
+                self.assertEqual(
+                    second_c4._indexcache_infer_producer_layer(1, pattern), 3
+                )
+
+    def test_topk_only_state_is_reused_without_running_an_s_indexer(self):
+        pattern = "FSS"
+        config = _layer_config(pattern)
+        producer = _make_layer(config, 0)
+        topk = paddle.arange(6, dtype="int32").reshape([1, 2, 3])
+        state = producer._indexcache_cache_topk(topk, 0, pattern)
+
+        self.assertEqual(state_kind(state), INDEXCACHE_STATE_KIND_TOPK_ONLY)
+        served = _make_layer(config, 1)
+        reused = served._indexcache_reuse_topk(1, 2, 1, pattern, state)
+        self.assertTrue(paddle.equal_all(reused, topk).item())
+
+    def test_distill_state_and_recompute_slots_preserve_gradient_contract(self):
+        pattern = "FSS"
+        config = _layer_config(
+            pattern,
+            indexcache_multi_layer_distill=True,
+            pipeline_model_parallel_size=2,
+        )
+        producer = _make_layer(config, 0)
+        topk = paddle.arange(8, dtype="int32").reshape([1, 2, 4])
+        raw_topk = paddle.to_tensor(
+            [[[-1, 0, 1, 8191], [2, 3, 4, 5]]], dtype="int32"
+        )
+        loss_state = (
+            paddle.ones([1], dtype="float32"),
+            paddle.ones([1], dtype="float32") * 2,
+            paddle.ones([1, 2, 1], dtype="float32") * 3,
+            raw_topk,
+            paddle.ones(topk.shape, dtype="float32"),
+        )
+        state = producer._indexcache_cache_topk(
+            topk,
+            0,
+            pattern,
+            tilelang_indexer_loss_state=loss_state,
+            served_count=2,
+            loss_scale=0.015,
+        )
+
+        self.assertEqual(state_kind(state), INDEXCACHE_STATE_KIND_DISTILL)
+        self.assertEqual(INDEXCACHE_DISTILL_GRAD_INDICES, (5,))
+        self.assertEqual(
+            [state[idx].numel() for idx in (1, 2, 3, 4)], [0, 0, 0, 0]
+        )
+        self.assertEqual(state[0].dtype, paddle.int32)
+        self.assertEqual(list(state[0].shape), [1, 2, 2])
+        self.assertEqual(state[5].dtype, paddle.bfloat16)
+        self.assertTrue(
+            paddle.equal_all(
+                _unpack_indexcache_pipeline_topk(state[0], 4), raw_topk
+            ).item()
+        )
+        for idx, tensor in enumerate(state):
+            self.assertEqual(
+                tensor.stop_gradient,
+                idx not in INDEXCACHE_DISTILL_GRAD_INDICES,
+            )
+
+        slots = state_to_slots(state)
+        self.assertEqual(len(slots), 8)
+        restored = state_from_slots(slots)
+        self.assertEqual(state_kind(restored), INDEXCACHE_STATE_KIND_DISTILL)
+        self.assertEqual(producer._indexcache_served_count(pattern, 0), 3)
+        self.assertAlmostEqual(producer._indexcache_scaled_loss_coeff(2), 0.015)
+
+    def test_distill_state_reconstructs_attention_indices_for_reuse(self):
+        pattern = "FS"
+        config = _layer_config(
+            pattern,
+            indexcache_multi_layer_distill=True,
+            pipeline_model_parallel_size=2,
+        )
+        producer = _make_layer(config, 0)
+        raw_topk = paddle.zeros([1, 4, 2], dtype="int32")
+        mapped_topk = paddle.to_tensor(
+            [[[-1, -1], [-1, -1], [-1, -1], [4, 4]]], dtype="int32"
+        )
+        loss_state = (
+            paddle.ones([1], dtype="float32"),
+            paddle.ones([1], dtype="float32"),
+            paddle.ones([1, 1, 1], dtype="float32"),
+            raw_topk,
+            paddle.ones(raw_topk.shape, dtype="float32"),
+        )
+        state = producer._indexcache_cache_topk(
+            mapped_topk,
+            0,
+            pattern,
+            tilelang_indexer_loss_state=loss_state,
+            served_count=1,
+            loss_scale=0.03,
+        )
+
+        self.assertEqual(INDEXCACHE_DISTILL_STATE_TOPK_INDICES_PLACEHOLDER, 4)
+        self.assertEqual(state[0].dtype, paddle.int32)
+        self.assertEqual(list(state[0].shape), [1, 4, 1])
+        self.assertEqual(state[5].dtype, paddle.bfloat16)
+        self.assertTrue(
+            paddle.equal_all(
+                _unpack_indexcache_pipeline_topk(state[0], 2), raw_topk
+            ).item()
+        )
+        self.assertEqual(state[4].numel(), 0)
+        served = _make_layer(config, 1)
+        reused = served._indexcache_reuse_topk(1, 4, 1, pattern, state)
+        self.assertEqual(reused.dtype, paddle.int32)
+        self.assertTrue(paddle.equal_all(reused, mapped_topk).item())
+
+    def test_cp_distill_state_reconstructs_global_attention_indices(self):
+        pattern = "FS"
+        config = _layer_config(
+            pattern,
+            indexcache_multi_layer_distill=True,
+            pipeline_model_parallel_size=2,
+            context_parallel_size=8,
+        )
+        producer = _make_layer(config, 0)
+        raw_topk = paddle.to_tensor(
+            [[[0, 7], [0, 7], [0, 7], [0, 7]]], dtype="int32"
+        )
+        loss_state = (
+            paddle.ones([1], dtype="float32"),
+            paddle.ones([1], dtype="float32"),
+            paddle.ones([1, 8, 1], dtype="float32"),
+            raw_topk,
+            paddle.ones(raw_topk.shape, dtype="float32"),
+        )
+        state = producer._indexcache_cache_topk(
+            paddle.full(raw_topk.shape, -1, dtype="int32"),
+            0,
+            pattern,
+            tilelang_indexer_loss_state=loss_state,
+            served_count=1,
+            loss_scale=0.03,
+        )
+
+        expected_by_rank = {
+            0: paddle.to_tensor(
+                [[[-1, -1], [-1, -1], [-1, -1], [32, -1]]],
+                dtype="int32",
+            ),
+            7: paddle.to_tensor(
+                [[[32, -1], [32, -1], [32, -1], [32, 39]]],
+                dtype="int32",
+            ),
+        }
+        for cp_rank, expected in expected_by_rank.items():
+            with self.subTest(cp_rank=cp_rank):
+                served = _make_layer(config, 1)
+                served.cp_enabled = True
+                served.cp_rank = cp_rank
+                served.cp_size = 8
+                reused = served._indexcache_reuse_topk(
+                    1, 4, 1, pattern, state
+                )
+                self.assertTrue(paddle.equal_all(reused, expected).item())
+
+    @patch("paddlefleet.tilelang_ops.csa_indexer_bwd")
+    def test_pipeline_probability_cast_preserves_bridge_gradient(
+        self, mock_bwd
+    ):
+        pattern = "FS"
+        config = _layer_config(
+            pattern,
+            indexcache_multi_layer_distill=True,
+            pipeline_model_parallel_size=2,
+        )
+        producer = _make_layer(config, 0)
+        q = paddle.ones([1, 2], dtype="float32")
+        weights = paddle.ones([1, 1], dtype="float32")
+        k = paddle.ones([1, 1, 1], dtype="float32")
+        for tensor in (q, weights, k):
+            tensor.stop_gradient = False
+        raw_topk = paddle.to_tensor([[[-1, 0]]], dtype="int32")
+        topk_probs = paddle.to_tensor([[[0.25, 0.75]]], dtype="float32")
+        producer_target = paddle.to_tensor([[[0.5, 0.5]]], dtype="float32")
+        mock_bwd.return_value = (
+            paddle.full_like(q, 2.0),
+            paddle.full_like(weights, 3.0),
+            paddle.full_like(k, 4.0),
+        )
+        state = producer._indexcache_pack_state(
+            raw_topk,
+            (
+                q,
+                weights,
+                k,
+                raw_topk,
+                topk_probs,
+                producer_target,
+                0.2,
+                "tilelang",
+                1.0,
+                None,
+            ),
+            served_count=1,
+            fuse_producer_loss=True,
+        )
+
+        self.assertEqual(state[5].dtype, paddle.bfloat16)
+        state[5].cast("float32").sum().backward()
+        expected_score_grad = paddle.ones_like(topk_probs) + (
+            (topk_probs - producer_target).cast("float16").cast("float32") * 0.2
+        )
+        self.assertTrue(
+            paddle.allclose(
+                mock_bwd.call_args.args[4], expected_score_grad
+            ).item()
+        )
+        mock_bwd.assert_called_once()
+        self.assertTrue(paddle.equal_all(q.grad, paddle.full_like(q, 2.0)))
+        self.assertTrue(
+            paddle.equal_all(weights.grad, paddle.full_like(weights, 3.0))
+        )
+        self.assertTrue(paddle.equal_all(k.grad, paddle.full_like(k, 4.0)))
+
+    def test_explicit_state_does_not_retain_config_fallback_tensors(self):
+        pattern = "FS"
+        config = _layer_config(
+            pattern,
+            indexcache_multi_layer_distill=True,
+            pipeline_model_parallel_size=2,
+        )
+        producer = _make_layer(config, 0)
+        raw_topk = paddle.zeros([1, 1, 2], dtype="int32")
+        loss_state = (
+            paddle.ones([1], dtype="float32"),
+            paddle.ones([1], dtype="float32"),
+            paddle.ones([1, 1, 1], dtype="float32"),
+            raw_topk,
+            paddle.ones(raw_topk.shape, dtype="float32"),
+        )
+        state = producer._indexcache_cache_topk(
+            raw_topk,
+            0,
+            pattern,
+            tilelang_indexer_loss_state=loss_state,
+            served_count=1,
+            loss_scale=0.03,
+        )
+
+        self.assertEqual(state_kind(state), INDEXCACHE_STATE_KIND_DISTILL)
+        self.assertIsNone(config._indexcache_last_topk_idxs)
+        self.assertIsNone(config._indexcache_last_layer_number)
+        self.assertIsNone(config._indexcache_last_distill_state)
+        self.assertIsNone(config._indexcache_last_served_count)
+
+    def test_distill_state_keeps_full_int32_above_pair_pack_domain(self):
+        pattern = "FS"
+        config = _layer_config(pattern, indexcache_multi_layer_distill=True)
+        producer = _make_layer(config, 0)
+        raw_topk = paddle.zeros([1, 1, 2], dtype="int32")
+        loss_state = (
+            paddle.ones([1], dtype="float32"),
+            paddle.ones([1], dtype="float32"),
+            paddle.ones([1, (1 << 15) + 1, 1], dtype="float32"),
+            raw_topk,
+            paddle.ones(raw_topk.shape, dtype="float32"),
+        )
+        state = producer._indexcache_cache_topk(
+            raw_topk,
+            0,
+            pattern,
+            tilelang_indexer_loss_state=loss_state,
+            served_count=1,
+            loss_scale=0.03,
+        )
+
+        self.assertEqual(state[0].dtype, paddle.int32)
+        self.assertEqual(list(state[0].shape), [1, 1, 2])
+        self.assertTrue(paddle.equal_all(state[0], raw_topk).item())
+
+    def test_distill_state_keeps_full_int32_for_odd_topk_width(self):
+        pattern = "FS"
+        config = _layer_config(pattern, indexcache_multi_layer_distill=True)
+        producer = _make_layer(config, 0)
+        raw_topk = paddle.zeros([1, 1, 3], dtype="int32")
+        loss_state = (
+            paddle.ones([1], dtype="float32"),
+            paddle.ones([1], dtype="float32"),
+            paddle.ones([1, 8, 1], dtype="float32"),
+            raw_topk,
+            paddle.ones(raw_topk.shape, dtype="float32"),
+        )
+        state = producer._indexcache_cache_topk(
+            raw_topk,
+            0,
+            pattern,
+            tilelang_indexer_loss_state=loss_state,
+            served_count=1,
+            loss_scale=0.03,
+        )
+
+        self.assertEqual(state[0].dtype, paddle.int32)
+        self.assertEqual(list(state[0].shape), [1, 1, 3])
+        self.assertTrue(paddle.equal_all(state[0], raw_topk).item())
+
+    def test_missing_explicit_state_fails_for_pipeline_or_recompute(self):
+        pattern = "FS"
+        config = _layer_config(pattern, pipeline_model_parallel_size=2)
+        served = _make_layer(config, 1)
+        with self.assertRaisesRegex(
+            RuntimeError, "explicit producer top-k state"
+        ):
+            served._indexcache_reuse_topk(1, 2, 1, pattern, None)
+
+    def test_invalid_state_length_is_rejected(self):
+        with self.assertRaises(ValueError):
+            apply_stop_gradient_mask((paddle.ones([1]), paddle.ones([1])))
+
+    @patch("paddlefleet.tilelang_ops.csa_indexer_bwd")
+    def test_compact_distill_bridge_preserves_selected_score_gradient(
+        self, mock_bwd
+    ):
+        q = paddle.ones([1, 2], dtype="float32")
+        weights = paddle.ones([1, 1], dtype="float32")
+        k = paddle.ones([1, 2], dtype="float32")
+        for tensor in (q, weights, k):
+            tensor.stop_gradient = False
+        topk_indices = paddle.to_tensor([[[0, 1]]], dtype="int32")
+        topk_probs = paddle.to_tensor([[[0.25, 0.75]]], dtype="float32")
+        target = paddle.to_tensor([[[0.5, 0.5]]], dtype="float32")
+        mock_bwd.return_value = (
+            paddle.full_like(q, 2.0),
+            paddle.full_like(weights, 3.0),
+            paddle.full_like(k, 4.0),
+        )
+
+        previous_scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
+        DSAIndexerLossAutoScaler._main_loss_backward_scale = None
+        marker_output = StringIO()
+        with (
+            patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}),
+            redirect_stdout(marker_output),
+        ):
+            try:
+                bridged_probs = TileLangCSAIndexerDistillBridge.apply(
+                    q,
+                    weights,
+                    k,
+                    topk_indices,
+                    topk_probs,
+                    None,
+                    0.0,
+                    None,
+                    2,
+                )
+                output_leaf = paddle.ones([1], dtype="float32")
+                output_leaf.stop_gradient = False
+                output = output_leaf * 1.0
+                output = IndexCacheServedDistillLossAutoScaler.apply(
+                    output,
+                    bridged_probs,
+                    target,
+                    0.4,
+                    None,
+                    None,
+                    3,
+                    2,
+                )
+                output.sum().backward()
+            finally:
+                DSAIndexerLossAutoScaler._main_loss_backward_scale = (
+                    previous_scale
+                )
+
+        expected_score_grad = (topk_probs - target) * 0.4
+        actual_score_grad = mock_bwd.call_args.args[4]
+        self.assertTrue(
+            paddle.allclose(actual_score_grad, expected_score_grad).item()
+        )
+        self.assertTrue(
+            paddle.allclose(q.grad, paddle.full_like(q, 2.0)).item()
+        )
+        self.assertTrue(
+            paddle.allclose(weights.grad, paddle.full_like(weights, 3.0)).item()
+        )
+        self.assertTrue(
+            paddle.allclose(k.grad, paddle.full_like(k, 4.0)).item()
+        )
+        markers = marker_output.getvalue()
+        self.assertIn(
+            "boundary=served_score_backward served_layer=3 producer_layer=2",
+            markers,
+        )
+        self.assertIn("score_grad_finite=True", markers)
+        self.assertIn("score_grad_nonzero=True", markers)
+        self.assertIn(
+            "boundary=producer_bridge_grad_ready producer_layer=2", markers
+        )
+        for prefix in ("q_grad", "weights_grad", "k_grad"):
+            self.assertIn(f"{prefix}_finite=True", markers)
+            self.assertIn(f"{prefix}_nonzero=True", markers)
+
+    @patch("paddlefleet.tilelang_ops.csa_indexer_bwd")
+    def test_compact_distill_bridge_combines_producer_and_served_gradients(
+        self, mock_bwd
+    ):
+        q = paddle.ones([1, 2], dtype="float32")
+        weights = paddle.ones([1, 1], dtype="float32")
+        k = paddle.ones([1, 2], dtype="float32")
+        for tensor in (q, weights, k):
+            tensor.stop_gradient = False
+        topk_indices = paddle.to_tensor([[[0, 1]]], dtype="int32")
+        topk_probs = paddle.to_tensor([[[0.25, 0.75]]], dtype="float32")
+        producer_target = paddle.to_tensor([[[0.75, 0.25]]], dtype="float32")
+        served_target = paddle.to_tensor([[[0.5, 0.5]]], dtype="float32")
+        producer_delta = (topk_probs - producer_target).cast("float16")
+        mock_bwd.return_value = (
+            paddle.full_like(q, 2.0),
+            paddle.full_like(weights, 3.0),
+            paddle.full_like(k, 4.0),
+        )
+
+        previous_scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
+        DSAIndexerLossAutoScaler._main_loss_backward_scale = paddle.to_tensor(
+            2.0, dtype="float32"
+        )
+        try:
+            bridged_probs = TileLangCSAIndexerDistillBridge.apply(
+                q,
+                weights,
+                k,
+                topk_indices,
+                topk_probs,
+                producer_delta,
+                0.2,
+                1.0,
+            )
+            output_leaf = paddle.ones([1], dtype="float32")
+            output_leaf.stop_gradient = False
+            output = IndexCacheServedDistillLossAutoScaler.apply(
+                output_leaf * 1.0,
+                bridged_probs,
+                served_target,
+                0.4,
+                1.0,
+                None,
+            )
+            output.sum().backward()
+        finally:
+            DSAIndexerLossAutoScaler._main_loss_backward_scale = previous_scale
+
+        expected_served = (
+            (topk_probs - served_target).cast("float16").cast("float32")
+            * 0.4
+            * 2.0
+        )
+        expected_producer = producer_delta.cast("float32") * 0.2 * 2.0
+        actual_score_grad = mock_bwd.call_args.args[4]
+        mock_bwd.assert_called_once()
+        self.assertTrue(
+            paddle.allclose(
+                actual_score_grad, expected_served + expected_producer
+            ).item()
+        )
+        self.assertTrue(
+            paddle.allclose(q.grad, paddle.full_like(q, 2.0)).item()
+        )
+        self.assertTrue(
+            paddle.allclose(weights.grad, paddle.full_like(weights, 3.0)).item()
+        )
+        self.assertTrue(
+            paddle.allclose(k.grad, paddle.full_like(k, 4.0)).item()
+        )
+
+    def test_served_distill_gradient_preserves_mask_and_main_loss_scale(self):
+        topk_probs = paddle.to_tensor(
+            [[[0.25, 0.75], [0.6, 0.4]]], dtype="float32"
+        )
+        topk_probs.stop_gradient = False
+        target = paddle.to_tensor([[[0.5, 0.5], [0.2, 0.8]]], dtype="float32")
+        loss_mask = paddle.to_tensor([[1.0, 0.0]], dtype="float32")
+        output_leaf = paddle.ones([1], dtype="float32")
+        output_leaf.stop_gradient = False
+        output = output_leaf * 1.0
+
+        previous_scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
+        DSAIndexerLossAutoScaler._main_loss_backward_scale = paddle.to_tensor(
+            2.0, dtype="float32"
+        )
+        try:
+            output = IndexCacheServedDistillLossAutoScaler.apply(
+                output,
+                topk_probs,
+                target,
+                0.4,
+                1.0,
+                loss_mask,
+            )
+            output.sum().backward()
+        finally:
+            DSAIndexerLossAutoScaler._main_loss_backward_scale = previous_scale
+
+        expected = (
+            (topk_probs - target).cast("float16").cast("float32") * 0.4 * 2.0
+        )
+        expected[:, 1, :] = 0.0
+        self.assertTrue(paddle.allclose(topk_probs.grad, expected).item())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/test_indexcache_core.py
+++ b/tests/single_card_tests/test_indexcache_core.py
@@ -56,6 +56,7 @@ def _layer_config(pattern, **overrides):
     config = SimpleNamespace(
         index_topk_pattern=pattern,
         indexcache_multi_layer_distill=False,
+        indexcache_train_debug=False,
         recompute_granularity=None,
         pipeline_model_parallel_size=1,
         context_parallel_size=1,
@@ -129,6 +130,54 @@ class TestIndexCacheGradientNumerics(unittest.TestCase):
 
 
 class TestIndexCacheConfig(unittest.TestCase):
+    def test_debug_config_defaults_and_normalizes_trace_layers(self):
+        default = _config_for_pattern("F")
+        self.assertFalse(default.indexcache_train_debug)
+        self.assertFalse(default.indexcache_stall_trace)
+        self.assertEqual(default.indexcache_stall_trace_layers, (2,))
+
+        configured = _config_for_pattern(
+            "F",
+            indexcache_train_debug=True,
+            indexcache_stall_trace=True,
+            indexcache_stall_trace_layers=[2, 1, 2],
+        )
+        self.assertTrue(configured.indexcache_train_debug)
+        self.assertTrue(configured.indexcache_stall_trace)
+        self.assertEqual(configured.indexcache_stall_trace_layers, (1, 2))
+
+    def test_debug_config_defaults_survive_from_config(self):
+        config = TransformerConfig.from_config(
+            SimpleNamespace(
+                num_hidden_layers=2,
+                experimental_attention_variant="dsv4_hybrid",
+                csa_compress_ratios=[4, 128],
+                index_topk_pattern="F",
+            )
+        )
+        self.assertFalse(config.indexcache_train_debug)
+        self.assertFalse(config.indexcache_stall_trace)
+        self.assertEqual(config.indexcache_stall_trace_layers, (2,))
+
+    def test_debug_config_rejects_invalid_values(self):
+        cases = (
+            ({"indexcache_train_debug": 1}, TypeError),
+            ({"indexcache_stall_trace": "true"}, TypeError),
+            ({"indexcache_stall_trace_layers": "2"}, TypeError),
+            ({"indexcache_stall_trace_layers": [0]}, ValueError),
+            ({"indexcache_stall_trace_layers": [True]}, ValueError),
+            (
+                {
+                    "indexcache_stall_trace": True,
+                    "indexcache_stall_trace_layers": [],
+                },
+                ValueError,
+            ),
+        )
+        for overrides, error in cases:
+            with self.subTest(overrides=overrides), self.assertRaises(error):
+                _config_for_pattern("F", **overrides)
+
     def test_common_patterns_are_normalized_and_accepted(self):
         for pattern in ("F", "FSF", "FSSF"):
             config = _config_for_pattern(pattern.lower())
@@ -240,6 +289,20 @@ class TestIndexCacheConfig(unittest.TestCase):
 
 
 class TestIndexCacheCoreState(unittest.TestCase):
+    def test_train_debug_is_driven_by_config(self):
+        config = _layer_config("F", indexcache_train_debug=True)
+        layer = _make_layer(config, 1)
+        output = StringIO()
+        with redirect_stdout(output):
+            layer._indexcache_debug("action=test")
+        self.assertIn("action=test", output.getvalue())
+
+        config.indexcache_train_debug = False
+        output = StringIO()
+        with redirect_stdout(output):
+            layer._indexcache_debug("action=disabled")
+        self.assertEqual(output.getvalue(), "")
+
     def test_cp_indexer_helper_preserves_legacy_and_extended_contracts(self):
         config = _layer_config(
             "F",
@@ -753,10 +816,7 @@ class TestIndexCacheCoreState(unittest.TestCase):
         previous_scale = DSAIndexerLossAutoScaler._main_loss_backward_scale
         DSAIndexerLossAutoScaler._main_loss_backward_scale = None
         marker_output = StringIO()
-        with (
-            patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}),
-            redirect_stdout(marker_output),
-        ):
+        with redirect_stdout(marker_output):
             try:
                 bridged_probs = TileLangCSAIndexerDistillBridge.apply(
                     q,
@@ -768,6 +828,7 @@ class TestIndexCacheCoreState(unittest.TestCase):
                     0.0,
                     None,
                     2,
+                    True,
                 )
                 output_leaf = paddle.ones([1], dtype="float32")
                 output_leaf.stop_gradient = False
@@ -781,6 +842,7 @@ class TestIndexCacheCoreState(unittest.TestCase):
                     None,
                     3,
                     2,
+                    True,
                 )
                 output.sum().backward()
             finally:

--- a/tests/single_card_tests/test_indexcache_core.py
+++ b/tests/single_card_tests/test_indexcache_core.py
@@ -20,7 +20,11 @@ from paddlefleet.transformer.csa_attention import (
     _indexcache_restore_saved_delta,
     _unpack_indexcache_pipeline_topk,
 )
-from paddlefleet.transformer.dsa_attention import DSAIndexerLossAutoScaler
+from paddlefleet.transformer.dsa_attention import (
+    DSAIndexerLossAutoScaler,
+    DSAIndexerLossLoggingHelper,
+    FusedDSAIndexerLoss,
+)
 from paddlefleet.transformer.indexcache_state import (
     INDEXCACHE_DISTILL_GRAD_INDICES,
     INDEXCACHE_DISTILL_STATE_TOPK_INDICES_PLACEHOLDER,
@@ -146,6 +150,60 @@ class TestIndexCacheConfig(unittest.TestCase):
         )
         self.assertEqual(recompute.recompute_method, "uniform")
 
+    def test_baseline_cp_distill_recompute_contract_is_accepted(self):
+        config = _config_for_pattern(
+            "FS",
+            csa_compress_ratios=[4, 128, 4, 128, 0],
+            indexcache_multi_layer_distill=True,
+            context_parallel_size=8,
+            num_nextn_predict_layers=1,
+            mtp_load_weight_only=True,
+            csa_indexer_backend="tilelang",
+            csa_sparse_attn_backend="cudnn",
+            recompute_granularity="full",
+            recompute_method="uniform",
+            recompute_num_layers=1,
+        )
+
+        self.assertTrue(config.mtp_load_weight_only)
+        self.assertEqual(config.csa_sparse_attn_backend, "cudnn")
+        self.assertEqual(config.recompute_granularity, "full")
+
+    def test_cp_distill_rejects_active_mtp(self):
+        with self.assertRaisesRegex(NotImplementedError, "MTP forward"):
+            _config_for_pattern(
+                "FS",
+                csa_compress_ratios=[4, 128, 4, 128, 0],
+                indexcache_multi_layer_distill=True,
+                context_parallel_size=8,
+                num_nextn_predict_layers=1,
+                mtp_load_weight_only=False,
+            )
+
+    def test_distill_rejects_non_tilelang_indexer(self):
+        with self.assertRaisesRegex(
+            NotImplementedError, "csa_indexer_backend='tilelang'"
+        ):
+            _config_for_pattern(
+                "FS",
+                indexcache_multi_layer_distill=True,
+                csa_indexer_backend="unfused",
+                csa_sparse_attn_backend="cudnn",
+            )
+
+    def test_recompute_rejects_non_tilelang_indexer(self):
+        with self.assertRaisesRegex(
+            NotImplementedError, "csa_indexer_backend='tilelang'"
+        ):
+            _config_for_pattern(
+                "FS",
+                csa_indexer_backend="unfused",
+                csa_sparse_attn_backend="cudnn",
+                recompute_granularity="full",
+                recompute_method="uniform",
+                recompute_num_layers=1,
+            )
+
     def test_invalid_pattern_contracts_fail_fast(self):
         cases = (
             ({"pattern": "FX"}, ValueError),
@@ -182,6 +240,93 @@ class TestIndexCacheConfig(unittest.TestCase):
 
 
 class TestIndexCacheCoreState(unittest.TestCase):
+    def test_cp_indexer_helper_preserves_legacy_and_extended_contracts(self):
+        config = _layer_config(
+            "F",
+            csa_indexer_backend="unfused",
+            dsa_indexer_use_sparse_loss=True,
+            num_hidden_layers=1,
+        )
+        layer = _make_layer(config, 1)
+        layer.cp_size = 2
+        object.__setattr__(layer, "cp_group", None)
+        object.__setattr__(layer, "tp_group", None)
+        object.__setattr__(layer, "softmax_scale", 1.0)
+
+        q_indexer = paddle.zeros([1, 4, 1, 2], dtype="float32")
+        k_indexer = paddle.zeros([1, 2, 2], dtype="float32")
+        weights = paddle.zeros([1, 4, 1], dtype="float32")
+        indexer = SimpleNamespace(
+            index_topk=2,
+            softmax_scale=1.0,
+            forward_before_topk=lambda *_args, **_kwargs: (
+                q_indexer,
+                k_indexer,
+                weights,
+            ),
+        )
+        object.__setattr__(layer, "indexer", indexer)
+
+        query = paddle.zeros([1, 4, 2, 3], dtype="float32")
+        x = paddle.zeros([1, 4, 8], dtype="float32")
+        qr = paddle.zeros([1, 4, 6], dtype="float32")
+        compressed_kv = paddle.zeros([1, 2, 3], dtype="float32")
+        q_positions = paddle.arange(4, dtype="int64")
+        topk_indices = paddle.zeros([1, 4, 2], dtype="int32")
+        mapped_topk = paddle.full([1, 4, 2], 4, dtype="int32")
+        indexer_loss = paddle.to_tensor(2.0, dtype="float32")
+
+        with (
+            patch.object(
+                FusedDSAIndexerLoss,
+                "apply",
+                return_value=indexer_loss,
+            ),
+            patch.object(
+                FusedDSAIndexerLoss,
+                "_last_topk_indices",
+                topk_indices,
+                create=True,
+            ),
+            patch.object(
+                DSAIndexerLossLoggingHelper,
+                "save_loss_to_tracker",
+            ) as save_loss,
+            patch(
+                "paddlefleet.transformer.csa_attention."
+                "map_compressed_topk_to_kv_full_cp",
+                return_value=mapped_topk,
+            ),
+        ):
+            legacy = layer._compute_indexer_compressed_topk_idxs_cp(
+                query,
+                x,
+                qr,
+                compressed_kv,
+                2,
+                4,
+                q_positions,
+                0,
+            )
+            extended = layer._compute_indexer_compressed_topk_idxs_cp(
+                query,
+                x,
+                qr,
+                compressed_kv,
+                2,
+                4,
+                q_positions,
+                0,
+                indexcache_action=(0, "F", "F"),
+            )
+
+        self.assertEqual(len(legacy), 3)
+        self.assertIs(legacy[0], mapped_topk)
+        self.assertAlmostEqual(float(legacy[1]), 1.0)
+        self.assertEqual(len(extended), 6)
+        self.assertEqual(extended[3:], (None, False, None))
+        self.assertEqual(save_loss.call_count, 2)
+
     def test_saved_delta_offload_roundtrip_preserves_device_id(self):
         class FakePlace:
             @staticmethod

--- a/tests/single_card_tests/test_indexcache_core.py
+++ b/tests/single_card_tests/test_indexcache_core.py
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 
 import unittest
-from contextlib import redirect_stdout
+from contextlib import ExitStack, redirect_stdout
 from io import StringIO
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -12,8 +12,10 @@ from unittest.mock import patch
 import paddle
 
 from paddlefleet.transformer.csa_attention import (
+    CompressOrSkip,
     CompressedSparseAttention,
     IndexCacheServedDistillLossAutoScaler,
+    TilelangIndexerLossState,
     TileLangCSAIndexerDistillBridge,
     TileLangCSAIndexerLossAutoScaler,
     _indexcache_offload_saved_delta,
@@ -161,6 +163,7 @@ class TestIndexCacheConfig(unittest.TestCase):
 
     def test_debug_config_rejects_invalid_values(self):
         cases = (
+            ({"indexcache_multi_layer_distill": 1}, TypeError),
             ({"indexcache_train_debug": 1}, TypeError),
             ({"indexcache_stall_trace": "true"}, TypeError),
             ({"indexcache_stall_trace_layers": "2"}, TypeError),
@@ -177,6 +180,20 @@ class TestIndexCacheConfig(unittest.TestCase):
         for overrides, error in cases:
             with self.subTest(overrides=overrides), self.assertRaises(error):
                 _config_for_pattern("F", **overrides)
+
+    def test_indexcache_fields_reject_non_dsv4_variants(self):
+        for overrides in (
+            {"index_topk_pattern": "F"},
+            {"indexcache_multi_layer_distill": True},
+        ):
+            with (
+                self.subTest(overrides=overrides),
+                self.assertRaisesRegex(
+                    ValueError,
+                    "experimental_attention_variant='dsv4_hybrid'",
+                ),
+            ):
+                TransformerConfig(num_hidden_layers=1, **overrides)
 
     def test_common_patterns_are_normalized_and_accepted(self):
         for pattern in ("F", "FSF", "FSSF"):
@@ -253,6 +270,18 @@ class TestIndexCacheConfig(unittest.TestCase):
                 recompute_num_layers=1,
             )
 
+    def test_recompute_rejects_block_attention_residuals(self):
+        with self.assertRaisesRegex(
+            NotImplementedError, "block_attention_residuals"
+        ):
+            _config_for_pattern(
+                "FS",
+                recompute_granularity="full",
+                recompute_method="uniform",
+                recompute_num_layers=1,
+                block_attention_residuals=True,
+            )
+
     def test_invalid_pattern_contracts_fail_fast(self):
         cases = (
             ({"pattern": "FX"}, ValueError),
@@ -289,6 +318,261 @@ class TestIndexCacheConfig(unittest.TestCase):
 
 
 class TestIndexCacheCoreState(unittest.TestCase):
+    def _assert_replay_only_changes_attention(self, action, cp_enabled):
+        pattern = "FS"
+        config = _layer_config(
+            pattern,
+            indexcache_multi_layer_distill=True,
+            context_parallel_size=2 if cp_enabled else 1,
+        )
+        layer = _make_layer(config, 1 if action == "F" else 2)
+        object.__setattr__(layer, "is_mqa_layer", False)
+        object.__setattr__(layer, "is_hca_layer", False)
+        object.__setattr__(layer, "compressor", object())
+        object.__setattr__(layer, "window_size", 2)
+        object.__setattr__(layer, "indexer_backend", "tilelang")
+        object.__setattr__(layer, "sparse_attn_backend", "unfused")
+        object.__setattr__(
+            layer, "attn_sink", paddle.zeros([1], dtype="float32")
+        )
+        object.__setattr__(layer, "softmax_scale", 1.0)
+        object.__setattr__(layer, "tp_group", None)
+
+        if cp_enabled:
+            object.__setattr__(layer, "cp_enabled", True)
+            object.__setattr__(layer, "cp_size", 2)
+            object.__setattr__(layer, "cp_rank", 0)
+            object.__setattr__(layer, "cp_group", None)
+
+        batch, seq = 1, 8
+        query = paddle.zeros([batch, seq, 1, 2], dtype="float32")
+        key = paddle.zeros([batch, seq, 1, 2], dtype="float32")
+        x = paddle.zeros([batch, seq, 4], dtype="float32")
+        qr = paddle.zeros([batch, seq, 2], dtype="float32")
+        window = paddle.full([batch, seq, 1], -1, dtype="int32")
+        original = paddle.full([batch, seq, 2], 8, dtype="int32")
+        replay = paddle.full([batch, seq, 2], 9, dtype="int32")
+        topk_probs = paddle.full(
+            [batch, seq, 2], 0.5, dtype="float32"
+        )
+        loss_state = TilelangIndexerLossState(
+            paddle.ones([1], dtype="float32"),
+            paddle.ones([1], dtype="float32"),
+            paddle.ones([1, 2, 1], dtype="float32"),
+            paddle.zeros([batch, seq, 2], dtype="int32"),
+            topk_probs,
+            None,
+            0.1,
+            "tilelang",
+            None,
+            None,
+        )
+        packed_state = (paddle.ones([1], dtype="float32"),)
+        attention_output = paddle.ones(
+            [batch, seq, 1, 2], dtype="float32"
+        )
+
+        class _Compressor:
+            def __call__(self, *_args, **_kwargs):
+                return paddle.zeros([batch, 4, 2], dtype="float32")
+
+        if cp_enabled:
+            object.__setattr__(layer, "compressor", _Compressor())
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(
+                    CompressedSparseAttention,
+                    "_indexcache_next_c4_action",
+                    return_value=(0 if action == "F" else 1, action, pattern),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    CompressedSparseAttention,
+                    "_indexcache_has_future_served_layer",
+                    return_value=action == "F",
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    CompressedSparseAttention,
+                    "_indexcache_multi_layer_distill_enabled",
+                    return_value=True,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    CompressedSparseAttention,
+                    "_indexcache_served_count",
+                    return_value=1,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    CompressedSparseAttention,
+                    "_indexcache_scaled_loss_coeff",
+                    return_value=0.1,
+                )
+            )
+            cache_topk = stack.enter_context(
+                patch.object(
+                    CompressedSparseAttention,
+                    "_indexcache_cache_topk",
+                    return_value=packed_state,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    CompressedSparseAttention,
+                    "_indexcache_reuse_topk",
+                    return_value=original,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    CompressedSparseAttention,
+                    "_indexcache_served_distill_state",
+                    return_value=None,
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    CompressedSparseAttention,
+                    "_indexcache_clear_cached_state",
+                )
+            )
+            replay_hook = stack.enter_context(
+                patch.object(
+                    CompressedSparseAttention,
+                    "_postprocess_indexer_replay",
+                    return_value=replay,
+                )
+            )
+            sparse_attn = stack.enter_context(
+                patch.object(
+                    CompressedSparseAttention,
+                    "compressed_sparse_attn",
+                    return_value=attention_output,
+                )
+            )
+            fused_target = stack.enter_context(
+                patch.object(
+                    CompressedSparseAttention,
+                    "_compute_fused_indexer_target",
+                    return_value=paddle.full_like(topk_probs, 0.5),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    CompressedSparseAttention,
+                    "_indexcache_attach_indexer_loss",
+                    side_effect=lambda output, *_args, **_kwargs: output,
+                )
+            )
+
+            if cp_enabled:
+                stack.enter_context(
+                    patch(
+                        "paddlefleet.transformer.csa_attention."
+                        "get_window_topk_idxs_cp",
+                        return_value=window,
+                    )
+                )
+                stack.enter_context(
+                    patch(
+                        "paddlefleet.transformer.csa_attention.all_gather_cp",
+                        return_value=paddle.zeros(
+                            [batch, seq * 2, 2], dtype="float32"
+                        ),
+                    )
+                )
+                stack.enter_context(
+                    patch.object(
+                        CompressedSparseAttention,
+                        "_compute_indexer_compressed_topk_idxs_cp",
+                        return_value=(
+                            original,
+                            None,
+                            loss_state if action == "F" else None,
+                            0.1,
+                            action == "F",
+                            1,
+                        ),
+                    )
+                )
+                result = CompressedSparseAttention._forward_cp(
+                    layer,
+                    query,
+                    key,
+                    x,
+                    qr,
+                    indexcache_state=(
+                        packed_state if action == "S" else None
+                    ),
+                )
+            else:
+                stack.enter_context(
+                    patch(
+                        "paddlefleet.transformer.csa_attention."
+                        "get_window_topk_idxs",
+                        return_value=window,
+                    )
+                )
+                stack.enter_context(
+                    patch.object(
+                        CompressOrSkip,
+                        "apply",
+                        return_value=paddle.zeros(
+                            [batch, seq + 2, 2], dtype="float32"
+                        ),
+                    )
+                )
+                stack.enter_context(
+                    patch.object(
+                        CompressedSparseAttention,
+                        "_compute_indexer_compressed_topk_idxs",
+                        return_value=(
+                            original,
+                            None,
+                            loss_state if action == "F" else None,
+                        ),
+                    )
+                )
+                result = CompressedSparseAttention.forward(
+                    layer,
+                    query,
+                    key,
+                    key,
+                    x=x,
+                    qr=qr,
+                    indexcache_state=(
+                        packed_state if action == "S" else None
+                    ),
+                )
+
+        replay_hook.assert_called_once()
+        self.assertIs(replay_hook.call_args.args[0], original)
+        compressed_attention_topk = sparse_attn.call_args.args[3][..., -2:]
+        self.assertTrue(
+            paddle.equal_all(compressed_attention_topk, replay).item()
+        )
+        if action == "F":
+            self.assertIs(cache_topk.call_args.args[0], original)
+            self.assertIs(fused_target.call_args.args[2], original)
+            self.assertIs(result[1], packed_state)
+        else:
+            cache_topk.assert_not_called()
+            fused_target.assert_not_called()
+
+    def test_replay_preserves_native_f_s_state_and_loss_indices(self):
+        for cp_enabled in (False, True):
+            for action in ("F", "S"):
+                with self.subTest(cp_enabled=cp_enabled, action=action):
+                    self._assert_replay_only_changes_attention(
+                        action, cp_enabled
+                    )
+
     def test_train_debug_is_driven_by_config(self):
         config = _layer_config("F", indexcache_train_debug=True)
         layer = _make_layer(config, 1)
@@ -527,7 +811,7 @@ class TestIndexCacheCoreState(unittest.TestCase):
         self.assertEqual(state_kind(state), INDEXCACHE_STATE_KIND_DISTILL)
         self.assertEqual(INDEXCACHE_DISTILL_GRAD_INDICES, (5,))
         self.assertEqual(
-            [state[idx].numel() for idx in (1, 2, 3, 4)], [0, 0, 0, 0]
+            [state[idx].numel() for idx in (1, 2, 3, 4)], [1, 1, 1, 1]
         )
         self.assertEqual(state[0].dtype, paddle.int32)
         self.assertEqual(list(state[0].shape), [1, 2, 2])
@@ -587,7 +871,7 @@ class TestIndexCacheCoreState(unittest.TestCase):
                 _unpack_indexcache_pipeline_topk(state[0], 2), raw_topk
             ).item()
         )
-        self.assertEqual(state[4].numel(), 0)
+        self.assertEqual(state[4].numel(), 1)
         served = _make_layer(config, 1)
         reused = served._indexcache_reuse_topk(1, 4, 1, pattern, state)
         self.assertEqual(reused.dtype, paddle.int32)

--- a/tests/single_card_tests/test_indexcache_core.py
+++ b/tests/single_card_tests/test_indexcache_core.py
@@ -12,12 +12,12 @@ from unittest.mock import patch
 import paddle
 
 from paddlefleet.transformer.csa_attention import (
-    CompressOrSkip,
     CompressedSparseAttention,
+    CompressOrSkip,
     IndexCacheServedDistillLossAutoScaler,
-    TilelangIndexerLossState,
     TileLangCSAIndexerDistillBridge,
     TileLangCSAIndexerLossAutoScaler,
+    TilelangIndexerLossState,
     _indexcache_offload_saved_delta,
     _indexcache_restore_saved_delta,
     _unpack_indexcache_pipeline_topk,
@@ -560,6 +560,9 @@ class TestIndexCacheCoreState(unittest.TestCase):
         if action == "F":
             self.assertIs(cache_topk.call_args.args[0], original)
             self.assertIs(fused_target.call_args.args[2], original)
+            self.assertFalse(
+                fused_target.call_args.kwargs["lse_indexer_matches_topk"]
+            )
             self.assertIs(result[1], packed_state)
         else:
             cache_topk.assert_not_called()
@@ -572,6 +575,125 @@ class TestIndexCacheCoreState(unittest.TestCase):
                     self._assert_replay_only_changes_attention(
                         action, cp_enabled
                     )
+
+    def test_replay_status_supports_legacy_and_explicit_hooks(self):
+        config = _layer_config("F")
+        layer = _make_layer(config, 1)
+        native = paddle.zeros([1, 2, 2], dtype="int32")
+        replay = paddle.ones_like(native)
+
+        with patch.object(
+            CompressedSparseAttention,
+            "_postprocess_indexer_replay",
+            return_value=native,
+        ):
+            result, applied = layer._apply_indexer_replay(native, 2, 4)
+        self.assertIs(result, native)
+        self.assertFalse(applied)
+
+        with patch.object(
+            CompressedSparseAttention,
+            "_postprocess_indexer_replay",
+            return_value=replay,
+        ):
+            result, applied = layer._apply_indexer_replay(native, 2, 4)
+        self.assertIs(result, replay)
+        self.assertTrue(applied)
+
+        with patch.object(
+            CompressedSparseAttention,
+            "_postprocess_indexer_replay",
+            return_value=(replay, True),
+        ):
+            result, applied = layer._apply_indexer_replay(native, 2, 4)
+        self.assertIs(result, replay)
+        self.assertTrue(applied)
+
+        with patch.object(
+            CompressedSparseAttention,
+            "_postprocess_indexer_replay",
+            return_value=(native.clone(), False),
+        ):
+            result, applied = layer._apply_indexer_replay(native, 2, 4)
+        self.assertFalse(applied)
+        self.assertTrue(paddle.equal_all(result, native).item())
+
+        with patch.object(
+            CompressedSparseAttention,
+            "_postprocess_indexer_replay",
+            return_value=None,
+        ), self.assertRaisesRegex(TypeError, "must return"):
+            layer._apply_indexer_replay(native, 2, 4)
+
+    def test_replay_status_preserves_legacy_hook_call_signature(self):
+        config = _layer_config("F")
+        layer = _make_layer(config, 1)
+        native = paddle.zeros([1, 2, 2], dtype="int32")
+
+        def legacy_hook(topk_indices, n_compressed, offset):
+            self.assertEqual((n_compressed, offset), (2, 4))
+            return topk_indices
+
+        with patch.object(
+            CompressedSparseAttention,
+            "_postprocess_indexer_replay",
+            side_effect=legacy_hook,
+        ) as hook:
+            result, applied = layer._apply_indexer_replay(native, 2, 4)
+
+        self.assertIs(result, native)
+        self.assertFalse(applied)
+        hook.assert_called_once_with(native, 2, 4)
+
+    def test_fused_target_falls_back_when_lse_does_not_match_topk(self):
+        config = _layer_config(
+            "F",
+            csa_indexer_backend="cudnn",
+            dsa_indexer_loss_coeff=0.0,
+        )
+        layer = _make_layer(config, 1)
+        object.__setattr__(layer, "indexer_backend", "cudnn")
+        object.__setattr__(layer, "indexer_loss_coeff", 0.0)
+        object.__setattr__(layer, "softmax_scale", 1.0)
+
+        query = paddle.zeros([1, 2, 1, 2], dtype="float32")
+        key = paddle.zeros([1, 4, 2], dtype="float32")
+        native_indices = paddle.to_tensor(
+            [[[2, 3], [2, -1]]], dtype="int32"
+        )
+        topk_probs = paddle.to_tensor(
+            [[[0.5, 0.5], [1.0, 0.0]]], dtype="float32"
+        )
+        replay_lse = paddle.zeros([1, 2, 1], dtype="float32")
+        expected = paddle.full_like(topk_probs, 0.5)
+
+        with (
+            patch(
+                "paddlefleet.tilelang_ops.csa_attn_target_reducesum",
+                return_value=expected,
+            ) as fallback,
+            patch(
+                "paddlefleet_ops.cudnn.deepseek_sparse_attention."
+                "sparse_attn_score_recompute_wrapper"
+            ) as cudnn_target,
+        ):
+            actual = layer._compute_fused_indexer_target(
+                query,
+                key,
+                native_indices,
+                topk_probs,
+                replay_lse,
+                lse_indexer_matches_topk=False,
+            )
+
+        fallback.assert_called_once()
+        fallback_args = fallback.call_args.args
+        self.assertIs(fallback_args[0], query)
+        self.assertIs(fallback_args[1], key)
+        self.assertIs(fallback_args[2], native_indices)
+        self.assertEqual(fallback_args[3], layer.softmax_scale)
+        cudnn_target.assert_not_called()
+        self.assertIs(actual, expected)
 
     def test_train_debug_is_driven_by_config(self):
         config = _layer_config("F", indexcache_train_debug=True)

--- a/tests/single_card_tests/test_indexcache_pipeline_adapter.py
+++ b/tests/single_card_tests/test_indexcache_pipeline_adapter.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import paddle
+from paddle.distributed.fleet.meta_parallel import pipeline_parallel
 from paddle.distributed.fleet.meta_parallel.pp_utils.forward_backward_overlap_utils import (
     ScheduleNode,
 )
@@ -47,9 +48,9 @@ _SECOND_REGISTRATION = register_indexcache_pipeline_adapter(_ADAPTER_CONFIG)
 def _make_distill_state(offset):
     return (
         paddle.to_tensor([offset], dtype="int64"),
-        paddle.empty([0]),
-        paddle.empty([0]),
-        paddle.empty([0]),
+        paddle.zeros([1]),
+        paddle.zeros([1]),
+        paddle.zeros([1]),
         paddle.to_tensor([offset], dtype="int64"),
         paddle.to_tensor([0.5 + offset], stop_gradient=False),
         paddle.to_tensor([offset], dtype="int64"),
@@ -62,6 +63,14 @@ class TestIndexCachePipelineBackward(unittest.TestCase):
         self.assertFalse(_EMPTY_PATTERN_REGISTRATION)
         self.assertTrue(_FIRST_REGISTRATION)
         self.assertFalse(_SECOND_REGISTRATION)
+        self.assertIs(
+            pipeline_parallel.dict_to_tuple_helper,
+            _dict_to_tuple_helper,
+        )
+        self.assertIs(
+            pipeline_parallel.tuple_to_dict_helper,
+            _tuple_to_dict_helper,
+        )
 
     def test_clear_dataptr_clone_uses_zero_allocation_alias_gradient(self):
         class ForbiddenAllocatingClone:

--- a/tests/single_card_tests/test_indexcache_pipeline_adapter.py
+++ b/tests/single_card_tests/test_indexcache_pipeline_adapter.py
@@ -6,6 +6,7 @@
 import unittest
 from contextlib import redirect_stdout
 from io import StringIO
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import paddle
@@ -28,9 +29,19 @@ from paddlefleet.pipeline_parallel.indexcache_adapter import (
     register_indexcache_pipeline_adapter,
 )
 
-_EMPTY_PATTERN_REGISTRATION = register_indexcache_pipeline_adapter(None)
-_FIRST_REGISTRATION = register_indexcache_pipeline_adapter("FS")
-_SECOND_REGISTRATION = register_indexcache_pipeline_adapter("FS")
+_EMPTY_CONFIG = SimpleNamespace(
+    index_topk_pattern=None,
+    indexcache_train_debug=False,
+)
+_ADAPTER_CONFIG = SimpleNamespace(
+    index_topk_pattern="FS",
+    indexcache_train_debug=False,
+)
+_EMPTY_PATTERN_REGISTRATION = register_indexcache_pipeline_adapter(
+    _EMPTY_CONFIG
+)
+_FIRST_REGISTRATION = register_indexcache_pipeline_adapter(_ADAPTER_CONFIG)
+_SECOND_REGISTRATION = register_indexcache_pipeline_adapter(_ADAPTER_CONFIG)
 
 
 def _make_distill_state(offset):
@@ -81,7 +92,9 @@ class TestIndexCachePipelineBackward(unittest.TestCase):
             with self.subTest(name=name):
                 output = StringIO()
                 with (
-                    patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}),
+                    patch.object(
+                        _ADAPTER_CONFIG, "indexcache_train_debug", True
+                    ),
                     redirect_stdout(output),
                 ):
                     _debug_state5_gradient(
@@ -93,7 +106,7 @@ class TestIndexCachePipelineBackward(unittest.TestCase):
                 self.assertIn(f"grad_nonzero={nonzero}", marker)
 
     def test_pipeline_metadata_recovers_state5_producer_layer(self):
-        with patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}):
+        with patch.object(_ADAPTER_CONFIG, "indexcache_train_debug", True):
             pipeline_inputs = _dict_to_tuple_helper(
                 {
                     "hidden_states": paddle.to_tensor(
@@ -106,7 +119,7 @@ class TestIndexCachePipelineBackward(unittest.TestCase):
             self.assertEqual(_indexcache_producer_layer(pipeline_inputs), 7)
 
     def test_pipeline_metadata_avoids_item_after_dataptr_clear(self):
-        with patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}):
+        with patch.object(_ADAPTER_CONFIG, "indexcache_train_debug", True):
             pipeline_inputs = _dict_to_tuple_helper(
                 {
                     "hidden_states": paddle.to_tensor(
@@ -141,7 +154,7 @@ class TestIndexCachePipelineBackward(unittest.TestCase):
             self.assertIn("producer_layer=7", output.getvalue())
 
     def test_missing_metadata_skips_released_producer_tensor(self):
-        with patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}):
+        with patch.object(_ADAPTER_CONFIG, "indexcache_train_debug", True):
             state = _make_distill_state(7)
             state[6]._clear_dataptr()
             pipeline_inputs = _dict_to_tuple_helper({"indexcache_state": state})
@@ -154,7 +167,7 @@ class TestIndexCachePipelineBackward(unittest.TestCase):
             def apply(value):
                 return value.clone()
 
-        with patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}):
+        with patch.object(_ADAPTER_CONFIG, "indexcache_train_debug", True):
             pipeline_inputs = _dict_to_tuple_helper(
                 {"indexcache_state": _make_distill_state(7)}
             )
@@ -170,7 +183,7 @@ class TestIndexCachePipelineBackward(unittest.TestCase):
             self.assertEqual(_indexcache_producer_layer((cloned,)), 7)
 
     def test_fresh_state_dict_captures_metadata_before_detach(self):
-        with patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}):
+        with patch.object(_ADAPTER_CONFIG, "indexcache_train_debug", True):
             inputs = {"indexcache_state": _make_distill_state(7)}
             detached = _detach_and_requires_grad(inputs)
             detached_state = detached["indexcache_state"]
@@ -186,7 +199,7 @@ class TestIndexCachePipelineBackward(unittest.TestCase):
             def apply(_value):
                 raise AssertionError("allocating FakeClone must not run")
 
-        with patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}):
+        with patch.object(_ADAPTER_CONFIG, "indexcache_train_debug", True):
             cloned = _clone_and_clear_dataptr(
                 {"indexcache_state": _make_distill_state(7)},
                 ForbiddenAllocatingClone,
@@ -205,7 +218,7 @@ class TestIndexCachePipelineBackward(unittest.TestCase):
         )
         output = StringIO()
         with (
-            patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}),
+            patch.object(_ADAPTER_CONFIG, "indexcache_train_debug", True),
             redirect_stdout(output),
         ):
             outputs = node.forward({"indexcache_state": _make_distill_state(7)})

--- a/tests/single_card_tests/test_indexcache_pipeline_adapter.py
+++ b/tests/single_card_tests/test_indexcache_pipeline_adapter.py
@@ -1,0 +1,386 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from unittest.mock import patch
+
+import paddle
+from paddle.distributed.fleet.meta_parallel.pp_utils.forward_backward_overlap_utils import (
+    ScheduleNode,
+)
+from paddle.distributed.fleet.meta_parallel.pp_utils.p2p_communication import (
+    SendRecvMeta,
+)
+
+from paddlefleet.pipeline_parallel.indexcache_adapter import (
+    _clone_and_clear_dataptr,
+    _debug_state5_gradient,
+    _detach_and_requires_grad,
+    _dict_to_tuple_helper,
+    _get_pipeline_key,
+    _indexcache_producer_layer,
+    _normalize_pipeline_input_gradients,
+    _tuple_to_dict_helper,
+    register_indexcache_pipeline_adapter,
+)
+
+_EMPTY_PATTERN_REGISTRATION = register_indexcache_pipeline_adapter(None)
+_FIRST_REGISTRATION = register_indexcache_pipeline_adapter("FS")
+_SECOND_REGISTRATION = register_indexcache_pipeline_adapter("FS")
+
+
+def _make_distill_state(offset):
+    return (
+        paddle.to_tensor([offset], dtype="int64"),
+        paddle.empty([0]),
+        paddle.empty([0]),
+        paddle.empty([0]),
+        paddle.to_tensor([offset], dtype="int64"),
+        paddle.to_tensor([0.5 + offset], stop_gradient=False),
+        paddle.to_tensor([offset], dtype="int64"),
+        paddle.to_tensor([0], dtype="int64"),
+    )
+
+
+class TestIndexCachePipelineBackward(unittest.TestCase):
+    def test_adapter_registration_is_explicit_and_idempotent(self):
+        self.assertFalse(_EMPTY_PATTERN_REGISTRATION)
+        self.assertTrue(_FIRST_REGISTRATION)
+        self.assertFalse(_SECOND_REGISTRATION)
+
+    def test_clear_dataptr_clone_uses_zero_allocation_alias_gradient(self):
+        class ForbiddenAllocatingClone:
+            @staticmethod
+            def apply(_value):
+                raise AssertionError("allocating FakeClone must not run")
+
+        value = paddle.to_tensor([1.0, 2.0], stop_gradient=False)
+        cloned = _clone_and_clear_dataptr(
+            value,
+            ForbiddenAllocatingClone,
+            clear_dataptr=True,
+        )
+        paddle.autograd.backward(cloned, paddle.ones_like(value))
+
+        self.assertTrue(
+            paddle.equal_all(value.grad, paddle.ones_like(value)).item()
+        )
+
+    def test_state5_debug_marker_reports_finite_and_nonzero(self):
+        cases = (
+            ("normal", paddle.to_tensor([0.0, 2.0]), True, True),
+            ("zero", paddle.zeros([2]), True, False),
+            ("nan", paddle.to_tensor([float("nan")]), False, False),
+            ("missing", None, False, False),
+        )
+        for name, grad, finite, nonzero in cases:
+            with self.subTest(name=name):
+                output = StringIO()
+                with (
+                    patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}),
+                    redirect_stdout(output),
+                ):
+                    _debug_state5_gradient(
+                        "indexcache_state 5", grad, "test", 2
+                    )
+                marker = output.getvalue()
+                self.assertIn("producer_layer=2", marker)
+                self.assertIn(f"grad_finite={finite}", marker)
+                self.assertIn(f"grad_nonzero={nonzero}", marker)
+
+    def test_pipeline_metadata_recovers_state5_producer_layer(self):
+        with patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}):
+            pipeline_inputs = _dict_to_tuple_helper(
+                {
+                    "hidden_states": paddle.to_tensor(
+                        [4.0], stop_gradient=False
+                    ),
+                    "indexcache_state": _make_distill_state(7),
+                }
+            )
+            _tuple_to_dict_helper(pipeline_inputs)
+            self.assertEqual(_indexcache_producer_layer(pipeline_inputs), 7)
+
+    def test_pipeline_metadata_avoids_item_after_dataptr_clear(self):
+        with patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}):
+            pipeline_inputs = _dict_to_tuple_helper(
+                {
+                    "hidden_states": paddle.to_tensor(
+                        [4.0], stop_gradient=False
+                    ),
+                    "indexcache_state": _make_distill_state(7),
+                }
+            )
+            state5 = next(
+                tensor
+                for tensor in pipeline_inputs
+                if _get_pipeline_key(tensor) == "indexcache_state 5"
+            )
+            producer_tensor = next(
+                tensor
+                for tensor in pipeline_inputs
+                if _get_pipeline_key(tensor) == "indexcache_state 6"
+            )
+            delattr(state5, "_paddlefleet_indexcache_producer_layer")
+            _tuple_to_dict_helper(pipeline_inputs)
+            producer_tensor._clear_dataptr()
+
+            output = StringIO()
+            with redirect_stdout(output):
+                gradients = _normalize_pipeline_input_gradients(
+                    pipeline_inputs,
+                    (paddle.ones([1]), paddle.ones([1])),
+                )
+
+            self.assertEqual(len(gradients), 2)
+            self.assertEqual(_indexcache_producer_layer(pipeline_inputs), 7)
+            self.assertIn("producer_layer=7", output.getvalue())
+
+    def test_missing_metadata_skips_released_producer_tensor(self):
+        with patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}):
+            state = _make_distill_state(7)
+            state[6]._clear_dataptr()
+            pipeline_inputs = _dict_to_tuple_helper({"indexcache_state": state})
+
+            self.assertIsNone(_indexcache_producer_layer(pipeline_inputs))
+
+    def test_producer_metadata_survives_detach_and_clone(self):
+        class SimpleClone:
+            @staticmethod
+            def apply(value):
+                return value.clone()
+
+        with patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}):
+            pipeline_inputs = _dict_to_tuple_helper(
+                {"indexcache_state": _make_distill_state(7)}
+            )
+            state5 = next(
+                tensor
+                for tensor in pipeline_inputs
+                if _get_pipeline_key(tensor) == "indexcache_state 5"
+            )
+            detached = _detach_and_requires_grad(state5)
+            cloned = _clone_and_clear_dataptr(state5, SimpleClone)
+
+            self.assertEqual(_indexcache_producer_layer((detached,)), 7)
+            self.assertEqual(_indexcache_producer_layer((cloned,)), 7)
+
+    def test_fresh_state_dict_captures_metadata_before_detach(self):
+        with patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}):
+            inputs = {"indexcache_state": _make_distill_state(7)}
+            detached = _detach_and_requires_grad(inputs)
+            detached_state = detached["indexcache_state"]
+            detached_state[6]._clear_dataptr()
+
+            self.assertEqual(
+                _indexcache_producer_layer((detached_state[5],)), 7
+            )
+
+    def test_fresh_state_dict_captures_metadata_before_alias_clear(self):
+        class ForbiddenAllocatingClone:
+            @staticmethod
+            def apply(_value):
+                raise AssertionError("allocating FakeClone must not run")
+
+        with patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}):
+            cloned = _clone_and_clear_dataptr(
+                {"indexcache_state": _make_distill_state(7)},
+                ForbiddenAllocatingClone,
+                clear_dataptr=True,
+            )
+            cloned_state = cloned["indexcache_state"]
+
+            self.assertEqual(_indexcache_producer_layer((cloned_state[5],)), 7)
+
+    def test_schedule_node_marker_uses_captured_producer_metadata(self):
+        node = ScheduleNode(
+            lambda inputs: {
+                "score": inputs["indexcache_state"][5] * 2,
+            },
+            name="indexcache_state5_gradient",
+        )
+        output = StringIO()
+        with (
+            patch.dict("os.environ", {"INDEXCACHE_TRAIN_DEBUG": "1"}),
+            redirect_stdout(output),
+        ):
+            outputs = node.forward({"indexcache_state": _make_distill_state(7)})
+            node.backward(paddle.ones_like(outputs["score"]))
+
+        marker = output.getvalue()
+        self.assertIn("source=schedule_node", marker)
+        self.assertIn("producer_layer=7", marker)
+        self.assertIn("grad_finite=True", marker)
+        self.assertIn("grad_nonzero=True", marker)
+
+    def test_replaced_distill_state_uses_sendable_zero_gradients(self):
+        old_state = _make_distill_state(0)
+        new_state = _make_distill_state(10)
+        node = ScheduleNode(
+            lambda inputs: {
+                "hidden": inputs["hidden"] * 2,
+                "indexcache_state": new_state,
+            },
+            name="replace_indexcache_producer",
+        )
+
+        outputs = node.forward(
+            {
+                "hidden": paddle.to_tensor([4.0], stop_gradient=False),
+                "indexcache_state": old_state,
+            }
+        )
+        output_grads = tuple(
+            paddle.ones_like(tensor)
+            for tensor in _dict_to_tuple_helper(outputs)
+            if not tensor.stop_gradient
+        )
+        input_grads = node.backward(output_grads)
+
+        self.assertEqual(len(input_grads), 2)
+        self.assertTrue(
+            all(isinstance(grad, paddle.Tensor) for grad in input_grads)
+        )
+        self.assertTrue(all(not grad.stop_gradient for grad in input_grads))
+        self.assertEqual(input_grads[0].item(), 2.0)
+        self.assertEqual(input_grads[1].item(), 0.0)
+
+        meta = SendRecvMeta()
+        meta.set_send_message(input_grads)
+        self.assertEqual(len(meta.send_shape_message), 2)
+
+    def test_missing_non_indexcache_gradient_fails_fast(self):
+        node = ScheduleNode(
+            lambda inputs: {"hidden": inputs["hidden"] * 2},
+            name="drop_regular_pipeline_input",
+        )
+        outputs = node.forward(
+            {
+                "hidden": paddle.to_tensor([4.0], stop_gradient=False),
+                "unused": paddle.to_tensor([5.0], stop_gradient=False),
+            }
+        )
+        output_grads = tuple(
+            paddle.ones_like(tensor)
+            for tensor in _dict_to_tuple_helper(outputs)
+            if not tensor.stop_gradient
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "missing a gradient outside IndexCache state",
+        ):
+            node.backward(output_grads)
+
+    def test_outer_pipeline_boundary_uses_sendable_zero_gradients(self):
+        pipeline_inputs = _dict_to_tuple_helper(
+            {
+                "hidden_states": paddle.to_tensor([4.0], stop_gradient=False),
+                "indexcache_state": _make_distill_state(0),
+            }
+        )
+        converted_inputs, use_dict = _tuple_to_dict_helper(pipeline_inputs)
+
+        self.assertTrue(use_dict)
+        self.assertIn("indexcache_state", converted_inputs)
+        self.assertTrue(
+            all(not hasattr(tensor, "key") for tensor in pipeline_inputs)
+        )
+
+        hidden_grad = paddle.ones_like(pipeline_inputs[0])
+        hidden_grad.stop_gradient = False
+        input_grads = _normalize_pipeline_input_gradients(
+            pipeline_inputs,
+            (hidden_grad, None),
+        )
+
+        self.assertEqual(len(input_grads), 2)
+        self.assertTrue(
+            all(isinstance(grad, paddle.Tensor) for grad in input_grads)
+        )
+        self.assertTrue(all(not grad.stop_gradient for grad in input_grads))
+        self.assertEqual(input_grads[0].item(), 1.0)
+        self.assertEqual(input_grads[1].item(), 0.0)
+
+        meta = SendRecvMeta()
+        meta.set_send_message(input_grads)
+        self.assertEqual(len(meta.send_shape_message), 2)
+
+    def test_outer_pipeline_boundary_preserves_baseline_none_gradient(self):
+        hidden = paddle.to_tensor([4.0], stop_gradient=False)
+        unused = paddle.to_tensor([5.0], stop_gradient=False)
+        input_grads = (paddle.ones_like(hidden), None)
+
+        normalized = _normalize_pipeline_input_gradients(
+            (hidden, unused),
+            input_grads,
+        )
+
+        self.assertIs(normalized, input_grads)
+
+    def test_outer_pipeline_boundary_handles_released_state(self):
+        pipeline_inputs = _dict_to_tuple_helper(
+            {
+                "hidden_states": paddle.to_tensor([4.0], stop_gradient=False),
+                "indexcache_state": _make_distill_state(0),
+            }
+        )
+        _tuple_to_dict_helper(pipeline_inputs)
+        released_inputs = [
+            tensor
+            for tensor in pipeline_inputs
+            if _get_pipeline_key(tensor)
+            in {
+                "indexcache_state 5",
+            }
+        ]
+        expected_metadata = [
+            (list(tensor.shape), tensor.dtype) for tensor in released_inputs
+        ]
+        for tensor in released_inputs:
+            tensor._clear_dataptr()
+
+        hidden_grad = paddle.ones_like(pipeline_inputs[0])
+        hidden_grad.stop_gradient = False
+        input_grads = _normalize_pipeline_input_gradients(
+            pipeline_inputs,
+            (hidden_grad, None),
+        )
+
+        self.assertEqual(len(released_inputs), 1)
+        self.assertEqual(len(input_grads), 2)
+        for grad, (shape, dtype) in zip(input_grads[1:], expected_metadata):
+            self.assertEqual(list(grad.shape), shape)
+            self.assertEqual(grad.dtype, dtype)
+            self.assertFalse(grad.stop_gradient)
+            self.assertEqual(float(grad.sum().item()), 0.0)
+
+        meta = SendRecvMeta()
+        meta.set_send_message(input_grads)
+        self.assertEqual(len(meta.send_shape_message), 2)
+
+    def test_outer_pipeline_boundary_rejects_missing_hidden_gradient(self):
+        pipeline_inputs = _dict_to_tuple_helper(
+            {
+                "hidden_states": paddle.to_tensor([4.0], stop_gradient=False),
+                "indexcache_state": _make_distill_state(0),
+            }
+        )
+        _tuple_to_dict_helper(pipeline_inputs)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "missing a gradient outside IndexCache state",
+        ):
+            _normalize_pipeline_input_gradients(
+                pipeline_inputs,
+                (None, None),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/test_indexcache_transformer_layer.py
+++ b/tests/single_card_tests/test_indexcache_transformer_layer.py
@@ -53,9 +53,26 @@ def _bias_dropout_add(_training, _fused):
     return apply
 
 
+def _fake_fused_h_res_h_post_bda(
+    _hyper_connection,
+    _h_res,
+    _original_residual,
+    _h_post,
+    layer_output_with_bias,
+    _enable_recompute,
+):
+    return layer_output_with_bias[0], None
+
+
+def _fake_forward_mlp(hidden_states, input_ids=None, **_kwargs):
+    del input_ids
+    return hidden_states
+
+
 def _make_attention_layer(layer_type, state_update):
     layer = SimpleNamespace(
         recompute_input_layernorm=False,
+        recompute_mhc_forward=False,
         input_layernorm=lambda value: value,
         layer_number=1,
         self_attn=_FakeSelfAttention(state_update),
@@ -70,6 +87,10 @@ def _make_attention_layer(layer_type, state_update):
     )
     if layer_type is HyperConnectionTransformerLayer:
         layer.self_attention_hyper_connection = _FakeHyperConnection()
+        layer._fused_h_res_h_post_bda = _fake_fused_h_res_h_post_bda
+        layer._cast_and_discard_fused_bda = (
+            lambda output, _ori_dtype, _span: output
+        )
     return layer
 
 
@@ -93,7 +114,7 @@ def _make_forward_impl_layer(attention_result):
         ),
         _log_md5=lambda *_args, **_kwargs: None,
         _forward_attention=lambda **_kwargs: attention_result,
-        _forward_mlp=lambda hidden_states, input_ids=None: hidden_states,
+        _forward_mlp=_fake_forward_mlp,
     )
 
 

--- a/tests/single_card_tests/test_indexcache_transformer_layer.py
+++ b/tests/single_card_tests/test_indexcache_transformer_layer.py
@@ -4,6 +4,8 @@
 # you may not use this file except in compliance with the License.
 
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from types import SimpleNamespace
 
 import paddle
@@ -11,6 +13,8 @@ import paddle
 from paddlefleet.transformer.transformer_layer import (
     HyperConnectionTransformerLayer,
     TransformerLayer,
+    _emit_indexcache_stall_trace,
+    _indexcache_stall_trace_enabled,
 )
 
 _STATE_NOT_UPDATED = object()
@@ -119,6 +123,28 @@ def _make_forward_impl_layer(attention_result):
 
 
 class TestIndexCacheTransformerLayerStateTransitions(unittest.TestCase):
+    def test_stall_trace_is_driven_by_normalized_config(self):
+        disabled = SimpleNamespace(
+            indexcache_stall_trace=False,
+            indexcache_stall_trace_layers=(2,),
+        )
+        enabled = SimpleNamespace(
+            indexcache_stall_trace=True,
+            indexcache_stall_trace_layers=(2, 4),
+        )
+
+        self.assertFalse(_indexcache_stall_trace_enabled(disabled, 2))
+        self.assertTrue(_indexcache_stall_trace_enabled(enabled, 2))
+        self.assertFalse(_indexcache_stall_trace_enabled(enabled, 3))
+
+        output = StringIO()
+        with redirect_stdout(output):
+            _emit_indexcache_stall_trace(enabled, 2, "attention", "enter")
+            _emit_indexcache_stall_trace(enabled, 3, "attention", "enter")
+        marker = output.getvalue()
+        self.assertIn("layer=2 phase=attention edge=enter", marker)
+        self.assertNotIn("layer=3", marker)
+
     def test_forward_attention_preserves_no_update_replace_and_clear(self):
         hidden_states = paddle.ones([1, 1, 4], dtype="float32")
         old_state = _topk_state(1)

--- a/tests/single_card_tests/test_indexcache_transformer_layer.py
+++ b/tests/single_card_tests/test_indexcache_transformer_layer.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import unittest
+from types import SimpleNamespace
+
+import paddle
+
+from paddlefleet.transformer.transformer_layer import (
+    HyperConnectionTransformerLayer,
+    TransformerLayer,
+)
+
+_STATE_NOT_UPDATED = object()
+
+
+class _FakeSelfAttention:
+    def __init__(self, state_update):
+        self.state_update = state_update
+
+    def __call__(self, hidden_states, **_kwargs):
+        output = hidden_states * 1.0
+        if self.state_update is _STATE_NOT_UPDATED:
+            return output, None
+        return output, None, self.state_update
+
+
+class _FakeHyperConnection:
+    def __call__(self, hidden_states):
+        return hidden_states, hidden_states, hidden_states
+
+    @staticmethod
+    def fused_h_res_h_post_bda(
+        *,
+        h_res,
+        original_residual,
+        h_post,
+        layer_output_with_bias,
+        dropout_prob,
+        training,
+        fused,
+    ):
+        del h_res, original_residual, h_post, dropout_prob, training, fused
+        return layer_output_with_bias[0]
+
+
+def _bias_dropout_add(_training, _fused):
+    def apply(output_with_bias, _residual, _dropout_prob):
+        return output_with_bias[0]
+
+    return apply
+
+
+def _make_attention_layer(layer_type, state_update):
+    layer = SimpleNamespace(
+        recompute_input_layernorm=False,
+        input_layernorm=lambda value: value,
+        layer_number=1,
+        self_attn=_FakeSelfAttention(state_update),
+        self_attn_bda=_bias_dropout_add,
+        pre_cross_attn_layernorm=lambda value: value,
+        cross_attention=lambda value, **_kwargs: (value, None),
+        cross_attn_bda=_bias_dropout_add,
+        training=True,
+        config=SimpleNamespace(bias_dropout_fusion=False),
+        hidden_dropout_prob=0.0,
+        _log_md5=lambda *_args, **_kwargs: None,
+    )
+    if layer_type is HyperConnectionTransformerLayer:
+        layer.self_attention_hyper_connection = _FakeHyperConnection()
+    return layer
+
+
+def _topk_state(value):
+    return (
+        paddle.to_tensor([value], dtype="int32"),
+        paddle.to_tensor([value], dtype="int64"),
+        paddle.to_tensor([0], dtype="int64"),
+    )
+
+
+def _make_forward_impl_layer(attention_result):
+    return SimpleNamespace(
+        training=True,
+        layer_number=1,
+        full_recompute=False,
+        mlp=object(),
+        config=SimpleNamespace(
+            block_attention_residuals=False,
+            multi_latent_attention=False,
+        ),
+        _log_md5=lambda *_args, **_kwargs: None,
+        _forward_attention=lambda **_kwargs: attention_result,
+        _forward_mlp=lambda hidden_states, input_ids=None: hidden_states,
+    )
+
+
+class TestIndexCacheTransformerLayerStateTransitions(unittest.TestCase):
+    def test_forward_attention_preserves_no_update_replace_and_clear(self):
+        hidden_states = paddle.ones([1, 1, 4], dtype="float32")
+        old_state = _topk_state(1)
+        new_state = _topk_state(2)
+        cases = (
+            ("no_update", _STATE_NOT_UPDATED, old_state, True, old_state),
+            ("replace", new_state, old_state, True, new_state),
+            ("explicit_clear", None, old_state, True, None),
+            ("empty_no_update", _STATE_NOT_UPDATED, None, False, None),
+        )
+
+        for layer_type in (
+            TransformerLayer,
+            HyperConnectionTransformerLayer,
+        ):
+            for name, update, incoming, has_state_output, expected in cases:
+                with self.subTest(layer=layer_type.__name__, case=name):
+                    layer = _make_attention_layer(layer_type, update)
+                    result = layer_type._forward_attention(
+                        layer,
+                        hidden_states,
+                        indexcache_state=incoming,
+                    )
+                    if has_state_output:
+                        self.assertEqual(len(result), 3)
+                        self.assertIs(result[2], expected)
+                    else:
+                        self.assertEqual(len(result), 2)
+
+    def test_forward_impl_distinguishes_explicit_clear_from_no_update(self):
+        hidden_states = paddle.ones([1, 1, 4], dtype="float32")
+        old_state = _topk_state(1)
+
+        clear_layer = _make_forward_impl_layer((hidden_states, None, None))
+        cleared = TransformerLayer._forward_impl(
+            clear_layer,
+            hidden_states=hidden_states,
+            indexcache_state=old_state,
+        )
+        self.assertIsInstance(cleared, paddle.Tensor)
+
+        no_update_layer = _make_forward_impl_layer((hidden_states, None))
+        retained = TransformerLayer._forward_impl(
+            no_update_layer,
+            hidden_states=hidden_states,
+            indexcache_state=old_state,
+        )
+        self.assertEqual(len(retained), 3)
+        self.assertIs(retained[2], old_state)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
+++ b/tests/single_card_tests/transformer/test_dsv4_hybrid_attention.py
@@ -85,6 +85,7 @@ from paddlefleet.transformer.csa_attention import (
     CSADocMaskMetadata,
     _apply_rope,
     _build_compressed_causal_mask,
+    _compute_attn_target_on_selected_set,
     get_compress_topk_idxs,
     get_mqa_causal_topk_idxs,
     get_valid_range,
@@ -1677,6 +1678,150 @@ class TestDSv4HybridDocumentRoPE(unittest.TestCase):
             )
 
         self.assertTrue(output.isfinite().all().item())
+
+    def test_cudnn_replay_uses_native_topk_for_indexer_target(self):
+        """Replay attention columns must not be paired with native LSE."""
+        import paddlefleet_ops.cudnn.deepseek_sparse_attention as DSA
+
+        import paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn as SA
+        import paddlefleet.cudnn_ops.indexer.csa_indexer_fwd_cudnn as IND
+        import paddlefleet.tilelang_ops
+
+        paddle.seed(_SEED)
+        ratio = 4
+        config = _make_config(
+            csa_compress_ratios=[ratio],
+            num_layers=1,
+            csa_indexer_backend="cudnn",
+            csa_sparse_attn_backend="cudnn",
+        )
+        model_parallel_cuda_manual_seed(_SEED)
+        attn = _build_attention(config, layer_number=0)
+        attn.train()
+
+        seq_len = 128
+        seq_len_comp = seq_len // ratio
+        hidden_states = paddle.randn(
+            [1, seq_len, config.hidden_size], dtype="bfloat16"
+        )
+        startend_row_indices = paddle.full(
+            [1, 1, seq_len, 1], seq_len, dtype="int32"
+        )
+
+        valid_mask = paddle.arange(1, seq_len + 1).unsqueeze(
+            1
+        ) >= paddle.arange(ratio, seq_len + ratio, ratio)
+        native_compressed = paddle.arange(
+            seq_len_comp, dtype="int32"
+        ).broadcast_to([1, seq_len, seq_len_comp])
+        native_compressed = paddle.where(
+            valid_mask,
+            native_compressed,
+            paddle.to_tensor(-1, dtype="int32"),
+        )
+        topk_scores = paddle.randn(
+            [1, seq_len, seq_len_comp], dtype="float32"
+        )
+        topk_scores = paddle.where(
+            valid_mask,
+            topk_scores,
+            paddle.to_tensor(float("-inf"), dtype="float32"),
+        )
+        seen = {}
+
+        def _mock_indexer_topk(index_q, index_k_comp, weights, **kwargs):
+            del index_q, index_k_comp, weights
+            self.assertEqual(kwargs.get("topk_effective"), seq_len_comp)
+            self.assertTrue(kwargs.get("return_topk_scores"))
+            return native_compressed, None, topk_scores
+
+        def _mock_flash_mla(q, kv, attn_sink, topk_idxs, **kwargs):
+            del attn_sink
+            self.assertEqual(kwargs.get("indexer_topk"), seq_len_comp)
+            seen["attention_topk"] = topk_idxs[..., :seq_len_comp]
+            output = paddle.randn(
+                [*q.shape[:3], kv.shape[-1]], dtype="bfloat16"
+            )
+            lse = paddle.randn(q.shape[:3], dtype="float32")
+            return output, lse, lse
+
+        def _mock_score_recompute(*_args, **_kwargs):
+            raise AssertionError(
+                "Replay LSE must not be passed to the native target columns"
+            )
+
+        native_target = paddlefleet.tilelang_ops.csa_attn_target_reducesum
+
+        def _record_native_target(query, key, topk_indices, softmax_scale):
+            seen["target_query"] = query
+            seen["target_key"] = key
+            seen["target_topk"] = topk_indices
+            seen["target_scale"] = softmax_scale
+            target = native_target(
+                query, key, topk_indices, softmax_scale
+            )
+            seen["target"] = target
+            return target
+
+        def _replay(native_indices, _n_compressed, offset, **_kwargs):
+            seen["native_topk"] = native_indices
+            return paddle.where(
+                native_indices >= 0,
+                paddle.full_like(native_indices, offset),
+                native_indices,
+            )
+
+        with (
+            patch.object(IND, "cudnn_indexer_topk_fwd", _mock_indexer_topk),
+            patch.object(SA, "flash_mla_sparse_attn", _mock_flash_mla),
+            patch.object(
+                DSA,
+                "sparse_attn_score_recompute_wrapper",
+                _mock_score_recompute,
+            ),
+            patch.object(
+                CompressedSparseAttention,
+                "_postprocess_indexer_replay",
+                side_effect=_replay,
+            ),
+            patch.object(
+                paddlefleet.tilelang_ops,
+                "csa_attn_target_reducesum",
+                side_effect=_record_native_target,
+            ) as fallback,
+        ):
+            output, _ = attn(
+                hidden_states,
+                attention_mask=None,
+                attn_mask_startend_row_indices=startend_row_indices,
+            )
+
+        self.assertTrue(output.isfinite().all().item())
+        self.assertEqual(fallback.call_count, 1)
+        self.assertTrue(
+            paddle.equal_all(
+                seen["target_topk"], seen["native_topk"]
+            ).item()
+        )
+        target_reference = _compute_attn_target_on_selected_set(
+            seen["target_query"],
+            seen["target_key"],
+            seen["target_topk"],
+            seen["target_scale"],
+        )
+        self.assertTrue(
+            paddle.allclose(
+                seen["target"].cast("float32"),
+                target_reference.cast("float32"),
+                rtol=6e-2,
+                atol=2e-2,
+            ).item()
+        )
+        self.assertFalse(
+            paddle.equal_all(
+                seen["attention_topk"], seen["native_topk"]
+            ).item()
+        )
 
 
 class TestDSv4HybridAttentionConstructor(unittest.TestCase):


### PR DESCRIPTION
### PR Category

Distributed Strategy

### PR Types

New features

### Description

This PR adds training-side IndexCache support for DSV4 compressed sparse
attention.

Main changes:

- Add producer/served IndexCache state handling for DSV4 CSA layers.
- Propagate compact top-k and distillation state across Transformer and
  pipeline boundaries.
- Add a pipeline adapter that preserves differentiable IndexCache state during
  recompute and pipeline transport.
- Support multi-layer selected-set distillation with compact probability and
  top-k state.
- Support context-parallel IndexCache with TileLang, cuDNN, and unfused
  indexer paths while preserving the current CSA phase semantics.
- Allow weight-only MTP with CP IndexCache distillation, while continuing to
  reject active MTP forward in the unsupported configuration.
- Expose a post-indexer Replay hook so training integrations can replace only
  the final attention indices without changing IndexCache state or the loss
  lifecycle.
- Add fail-closed validation and focused unit tests for F/S patterns, pipeline
  state, recompute, CP compatibility, weight-only MTP, and gradient routing.

Compatibility:

- The feature is disabled unless `index_topk_pattern` is configured.
- Existing behavior is unchanged when IndexCache is disabled.
- The CP helper keeps the legacy three-value return contract when no
  `indexcache_action` is supplied and uses the extended six-value contract for
  IndexCache integration.
- The existing public `TileLangCSAIndexerLossAutoScaler` argument order is
  preserved for current CSA/MQA callers.

Validation:

- `git diff --check`: passed.
- Python `compileall` / `py_compile`: passed.
- Focused `pyflakes`: passed.
- IndexCache focused tests: 44 passed.
- Related CSA loss-mask and train-indexer-only regression tests: 35 passed.

The local machine has an older installed Paddle/PaddleFleetOps ABI, so direct
test collection misses several APIs that are present in this source checkout.
The test counts above were obtained with process-local compatibility shims only;
no repository source or installed package was modified. CI should run the same
tests with the matching Paddle/PaddleFleetOps baseline.

### 是否引起精度变化

否。IndexCache 默认关闭；未配置 `index_topk_pattern` 时保留现有训练路径。
