### PR TITLE
[Recompute] Address layers logically and split the DSv4 attention int…

### DIFF
--- a/src/paddlefleet/models/gpt/gpt_layer_specs.py
+++ b/src/paddlefleet/models/gpt/gpt_layer_specs.py
@@ -49,6 +49,7 @@ from paddlefleet.models.gpt.moe_layer_specs import (
     get_moe_layer_spec_for_backend,
 )
 from paddlefleet.models.gpt.mtp_embedding_layer import MTPEmbeddingLayer
+from paddlefleet.recompute_utils import effective_mtp_layers
 from paddlefleet.transformer.attention import (
     SelfAttention,
     SelfAttentionSublayersSpec,
@@ -116,24 +117,7 @@ LNImpl = WrappedPaddleNorm
 
 
 def _get_effective_mtp_layers(config: TransformerConfig) -> int:
-    mtp_num_layers = getattr(config, "mtp_num_layers", 0) or 0
-    nextn_num_layers = getattr(config, "num_nextn_predict_layers", 0) or 0
-    if not isinstance(mtp_num_layers, int) or isinstance(mtp_num_layers, bool):
-        mtp_num_layers = 0
-    if not isinstance(nextn_num_layers, int) or isinstance(
-        nextn_num_layers, bool
-    ):
-        nextn_num_layers = 0
-    if (
-        mtp_num_layers > 0
-        and nextn_num_layers > 0
-        and mtp_num_layers != nextn_num_layers
-    ):
-        raise ValueError(
-            "mtp_num_layers and num_nextn_predict_layers must be equal when "
-            f"both are positive, got {mtp_num_layers} and {nextn_num_layers}"
-        )
-    return mtp_num_layers if mtp_num_layers > 0 else nextn_num_layers
+    return effective_mtp_layers(config)
 
 
 def _get_dsv4_hybrid_attention_layer_type(

--- a/src/paddlefleet/recompute_utils.py
+++ b/src/paddlefleet/recompute_utils.py
@@ -221,6 +221,36 @@ REFINED_RECOMPUTE_MODULES = frozenset({"flash_attn", "moe_combine"})
 """RR modules: count-based selectors always use ``first_n``."""
 
 
+def effective_mtp_layers(config):
+    """MTP layer count the model actually builds."""
+    mtp_num_layers = getattr(config, "mtp_num_layers", 0) or 0
+    nextn_num_layers = getattr(config, "num_nextn_predict_layers", 0) or 0
+    if not isinstance(mtp_num_layers, int) or isinstance(mtp_num_layers, bool):
+        mtp_num_layers = 0
+    if not isinstance(nextn_num_layers, int) or isinstance(
+        nextn_num_layers, bool
+    ):
+        nextn_num_layers = 0
+    if (
+        mtp_num_layers > 0
+        and nextn_num_layers > 0
+        and mtp_num_layers != nextn_num_layers
+    ):
+        raise ValueError(
+            "mtp_num_layers and num_nextn_predict_layers must be equal when "
+            f"both are positive, got {mtp_num_layers} and {nextn_num_layers}"
+        )
+    return mtp_num_layers if mtp_num_layers > 0 else nextn_num_layers
+
+
+def logical_layer_index(config, layer_number, is_mtp_layer=False):
+    """Map a physical ``layer_number`` to the config-facing layer index."""
+    if is_mtp_layer:
+        return config.num_hidden_layers + layer_number
+    head_offset = getattr(config, "num_empty_layers_add_in_head", 0) or 0
+    return layer_number - head_offset
+
+
 def _get_module_recompute_config(module_name, config):
     """Return whether ``module_name`` is configured, and its layer selector.
 
@@ -268,12 +298,14 @@ def _selector_matches_layer(
     config,
     module_name,
     defer_if_layer_unknown=False,
+    is_mtp_layer=False,
 ):
     """Whether ``layer_selector`` selects ``layer_number``.
 
     Selectors: ``None`` / ``"all"`` / negative int mean every layer; a list of
-    ints means those global 0-based layer ids; a non-negative int is a layer
-    count resolved through ``config.recompute_method``.
+    ints means those layer ids in the ``logical_layer_index`` space (the one
+    ``csa_compress_ratios`` uses); a non-negative int is a layer count resolved
+    through ``config.recompute_method`` over the physical layer number.
 
     ``layer_number`` is ``None`` for layer-agnostic modules and for MoE
     submodules before ``set_layer_number()``. A count then means every layer.
@@ -294,7 +326,9 @@ def _selector_matches_layer(
                 "layer number to filter on. Use "
                 f"'{RECOMPUTE_ALL_LAYERS}' to enable it everywhere."
             )
-        return layer_number in layer_ids
+        return (
+            logical_layer_index(config, layer_number, is_mtp_layer) in layer_ids
+        )
 
     if isinstance(layer_selector, bool) or not isinstance(layer_selector, int):
         raise ValueError(
@@ -320,13 +354,17 @@ def _selector_matches_layer(
 _logged_recompute_decisions = set()
 
 
-def _log_recompute_decision(kind, module_name, layer_number, enabled):
+def _log_recompute_decision(
+    kind, module_name, layer_number, enabled, is_mtp_layer=False
+):
     """Log one decision, deduped: MoE resolves its flags twice."""
-    key = (kind, module_name, layer_number)
+    key = (kind, module_name, layer_number, is_mtp_layer)
     if key in _logged_recompute_decisions:
         return
     _logged_recompute_decisions.add(key)
     layer_text = "n/a" if layer_number is None else str(layer_number)
+    if is_mtp_layer:
+        layer_text = f"mtp{layer_text}"
     logger.info(
         f"[RECOMPUTE-DECISION] kind={kind} module={module_name} "
         f"layer={layer_text} enabled={enabled}"
@@ -334,13 +372,20 @@ def _log_recompute_decision(kind, module_name, layer_number, enabled):
 
 
 def module_needs_recompute(
-    module_name, layer_number, config, defer_if_layer_unknown=False
+    module_name,
+    layer_number,
+    config,
+    defer_if_layer_unknown=False,
+    is_mtp_layer=False,
 ):
     """Whether ``module_name`` should be recomputed on layer ``layer_number``.
 
     Single entry point for every ``recompute_modules`` lookup. Only meaningful
     under ``recompute_granularity == "selective"``; ``lm_head`` and ``loss_fn``
     keep ignoring the granularity, as they always did.
+
+    ``layer_number`` is physical; ``is_mtp_layer`` routes layer lists through
+    ``logical_layer_index`` so MTP layers do not collide with backbone layer 0.
 
     Pass ``defer_if_layer_unknown=True`` when ``layer_number=None`` just means
     "not yet known" and the caller will ask again: a layer list then resolves to
@@ -362,12 +407,17 @@ def module_needs_recompute(
         config,
         module_name,
         defer_if_layer_unknown=defer_if_layer_unknown,
+        is_mtp_layer=is_mtp_layer,
     )
-    _log_recompute_decision("plain", module_name, layer_number, enabled)
+    _log_recompute_decision(
+        "plain", module_name, layer_number, enabled, is_mtp_layer
+    )
     return enabled
 
 
-def module_needs_refined_recompute(module_name, layer_number, config):
+def module_needs_refined_recompute(
+    module_name, layer_number, config, is_mtp_layer=False
+):
     """Whether ``module_name`` should use refined recompute (RR) on this layer.
 
     RR inverts the selector: selected layers keep the plain recompute path, RR
@@ -384,10 +434,14 @@ def module_needs_refined_recompute(module_name, layer_number, config):
     if not module_configured:
         return False
     if not isinstance(config.recompute_modules, dict):
-        _log_recompute_decision("rr", module_name, layer_number, True)
+        _log_recompute_decision(
+            "rr", module_name, layer_number, True, is_mtp_layer
+        )
         return True
     if layer_selector is None or layer_selector == RECOMPUTE_ALL_LAYERS:
-        _log_recompute_decision("rr", module_name, layer_number, False)
+        _log_recompute_decision(
+            "rr", module_name, layer_number, False, is_mtp_layer
+        )
         return False
     if isinstance(layer_selector, (list, tuple, set, frozenset)):
         layer_ids = normalize_recompute_layer_ids(layer_selector, module_name)
@@ -396,8 +450,13 @@ def module_needs_refined_recompute(module_name, layer_number, config):
                 f"recompute_modules['{module_name}'] was given an explicit "
                 f"layer list but no layer number is available"
             )
-        enabled = layer_number not in layer_ids
-        _log_recompute_decision("rr", module_name, layer_number, enabled)
+        enabled = (
+            logical_layer_index(config, layer_number, is_mtp_layer)
+            not in layer_ids
+        )
+        _log_recompute_decision(
+            "rr", module_name, layer_number, enabled, is_mtp_layer
+        )
         return enabled
     if isinstance(layer_selector, bool) or not isinstance(layer_selector, int):
         raise ValueError(
@@ -408,12 +467,16 @@ def module_needs_refined_recompute(module_name, layer_number, config):
         # Same as "all"/None. Handled here because need_recompute_in_first_n
         # selects no layer for a negative count, which would invert into "RR
         # everywhere" -- the exact opposite.
-        _log_recompute_decision("rr", module_name, layer_number, False)
+        _log_recompute_decision(
+            "rr", module_name, layer_number, False, is_mtp_layer
+        )
         return False
     enabled = not need_recompute_in_first_n(
         layer_number, config, layer_selector
     )
-    _log_recompute_decision("rr", module_name, layer_number, enabled)
+    _log_recompute_decision(
+        "rr", module_name, layer_number, enabled, is_mtp_layer
+    )
     return enabled
 
 
@@ -440,11 +503,9 @@ def validate_recompute_modules(config):
             f"{type(recompute_modules).__name__}"
         )
 
-    total_num_hidden_layers = (
-        config.num_empty_layers_add_in_head
-        + config.num_hidden_layers
-        + config.num_empty_layers_add_in_tail
-    )
+    # Layer lists live in the logical_layer_index space: backbone layers then
+    # MTP layers. Empty head/tail layers hold no module and are not addressable.
+    num_layer_ids = config.num_hidden_layers + effective_mtp_layers(config)
     for module_name, layer_selector in recompute_modules.items():
         if not isinstance(module_name, str):
             raise ValueError(
@@ -465,14 +526,15 @@ def validate_recompute_modules(config):
             out_of_range_layer_ids = [
                 layer_id
                 for layer_id in sorted(layer_ids)
-                if layer_id >= total_num_hidden_layers
+                if layer_id >= num_layer_ids
             ]
             if out_of_range_layer_ids:
                 raise ValueError(
                     f"recompute_modules['{module_name}'] layer ids "
                     f"{out_of_range_layer_ids} are "
-                    f"out of range for {total_num_hidden_layers} layers "
-                    "(global, 0-based, including empty head/tail layers)"
+                    f"out of range for {num_layer_ids} layer ids (0-based: "
+                    f"backbone layers 0..{config.num_hidden_layers - 1} "
+                    "excluding empty head/tail layers, then the MTP layers)"
                 )
             continue
         if isinstance(layer_selector, bool) or not isinstance(

--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -355,7 +355,10 @@ class Attention(FleetLayer, ABC):
         self.recompute_core_attention = False
         if self.config.recompute_granularity == "selective":
             self.recompute_core_attention = module_needs_recompute(
-                "core_attn", self.layer_number, self.config
+                "core_attn",
+                self.layer_number,
+                self.config,
+                is_mtp_layer=self.is_mtp_layer,
             )
         if (
             self.config.recompute_modules is not None
@@ -365,7 +368,10 @@ class Attention(FleetLayer, ABC):
                 "rr must be used when recompute is enabled"
             )
             self.use_rr_flash_attention = module_needs_refined_recompute(
-                "flash_attn", self.layer_number, self.config
+                "flash_attn",
+                self.layer_number,
+                self.config,
+                is_mtp_layer=self.is_mtp_layer,
             )
         # Output.
         self.o_proj = build_spec_layer(
@@ -384,7 +390,10 @@ class Attention(FleetLayer, ABC):
         self.recompute_gated_attn = (
             self.config.recompute_granularity == "selective"
             and module_needs_recompute(
-                "gated_attn", self.layer_number, self.config
+                "gated_attn",
+                self.layer_number,
+                self.config,
+                is_mtp_layer=self.is_mtp_layer,
             )
         )
 

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -347,32 +347,29 @@ class DSv4HybridSelfAttentionSublayersSpec:
 
 
 class _FixedOrderQKV(paddle.autograd.PyLayer):
-    """Q and KV read separate graph inputs so the two gradients into
-    ``hidden_states`` are summed in a fixed order, i.e. bitwise-stable replay."""
+    """Q and KV behind one autograd node, so their gradients into
+    ``hidden_states`` merge as they do under replay, i.e. bitwise-stable."""
 
     @staticmethod
     def forward(
         ctx, module, hidden_states, position_offset, docmask_meta, build_graph
     ):
-        q_input = hidden_states.detach()
-        kv_input = hidden_states.detach()
-        q_input.stop_gradient = hidden_states.stop_gradient
-        kv_input.stop_gradient = hidden_states.stop_gradient
+        segment_input = hidden_states.detach()
+        segment_input.stop_gradient = hidden_states.stop_gradient
 
         with paddle.set_grad_enabled(build_graph):
             query, key, _value, q_compressed, _kv_compressed = (
                 module.get_query_key_value_tensors(
-                    q_input,
+                    segment_input,
                     position_offset=position_offset,
                     docmask_meta=docmask_meta,
-                    kv_hidden_states=kv_input,
                 )
             )
 
         ctx.hidden_stop_gradient = hidden_states.stop_gradient
         ctx.build_graph = build_graph
         if build_graph:
-            ctx.save_for_backward(q_input, kv_input, query, key, q_compressed)
+            ctx.save_for_backward(segment_input, query, key, q_compressed)
         return query.detach(), key.detach(), q_compressed.detach()
 
     @staticmethod
@@ -380,7 +377,7 @@ class _FixedOrderQKV(paddle.autograd.PyLayer):
         if ctx.hidden_stop_gradient or not ctx.build_graph:
             return None
 
-        q_input, kv_input, *outputs = ctx.saved_tensor()
+        segment_input, *outputs = ctx.saved_tensor()
         pairs = [
             (output, grad)
             for output, grad in zip(outputs, output_grads)
@@ -393,13 +390,7 @@ class _FixedOrderQKV(paddle.autograd.PyLayer):
                     [grad for _, grad in pairs],
                 )
 
-        q_grad = q_input.grad
-        kv_grad = kv_input.grad
-        if q_grad is None:
-            return kv_grad
-        if kv_grad is None:
-            return q_grad
-        return q_grad + kv_grad
+        return segment_input.grad
 
 
 # ---------------------------------------------------------------------------
@@ -1483,7 +1474,6 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         startend_row_indices: Tensor | None = None,
         position_offset: int = 0,
         docmask_meta: CSADocMaskMetadata | None = None,
-        kv_hidden_states: Tensor | None = None,
     ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
         """Derive query, key, value from hidden_states.
 
@@ -1505,8 +1495,6 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             kv_compressed: [b, sq, hidden_size] (== hidden_states)
         """
         b, sq, _ = hidden_states.shape
-        if kv_hidden_states is None:
-            kv_hidden_states = hidden_states
 
         # Q path
         q_compressed, _ = deferrable_linear(
@@ -1539,7 +1527,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
 
         # KV path
         kv, _ = deferrable_linear(
-            self.config, "attn_kv_proj", self.linear_kv_proj, kv_hidden_states
+            self.config, "attn_kv_proj", self.linear_kv_proj, hidden_states
         )  # [b, sq, v_head_dim]
 
         if self.config.swa_high_precision_norm:

--- a/src/paddlefleet/transformer/dsv4_hybrid_attention.py
+++ b/src/paddlefleet/transformer/dsv4_hybrid_attention.py
@@ -346,6 +346,62 @@ class DSv4HybridSelfAttentionSublayersSpec:
     gate_proj: type | LayerSpec | None = None
 
 
+class _FixedOrderQKV(paddle.autograd.PyLayer):
+    """Q and KV read separate graph inputs so the two gradients into
+    ``hidden_states`` are summed in a fixed order, i.e. bitwise-stable replay."""
+
+    @staticmethod
+    def forward(
+        ctx, module, hidden_states, position_offset, docmask_meta, build_graph
+    ):
+        q_input = hidden_states.detach()
+        kv_input = hidden_states.detach()
+        q_input.stop_gradient = hidden_states.stop_gradient
+        kv_input.stop_gradient = hidden_states.stop_gradient
+
+        with paddle.set_grad_enabled(build_graph):
+            query, key, _value, q_compressed, _kv_compressed = (
+                module.get_query_key_value_tensors(
+                    q_input,
+                    position_offset=position_offset,
+                    docmask_meta=docmask_meta,
+                    kv_hidden_states=kv_input,
+                )
+            )
+
+        ctx.hidden_stop_gradient = hidden_states.stop_gradient
+        ctx.build_graph = build_graph
+        if build_graph:
+            ctx.save_for_backward(q_input, kv_input, query, key, q_compressed)
+        return query.detach(), key.detach(), q_compressed.detach()
+
+    @staticmethod
+    def backward(ctx, *output_grads):
+        if ctx.hidden_stop_gradient or not ctx.build_graph:
+            return None
+
+        q_input, kv_input, *outputs = ctx.saved_tensor()
+        pairs = [
+            (output, grad)
+            for output, grad in zip(outputs, output_grads)
+            if grad is not None
+        ]
+        if pairs:
+            with paddle.amp.auto_cast(enable=False):
+                paddle.autograd.backward(
+                    [output for output, _ in pairs],
+                    [grad for _, grad in pairs],
+                )
+
+        q_grad = q_input.grad
+        kv_grad = kv_input.grad
+        if q_grad is None:
+            return kv_grad
+        if kv_grad is None:
+            return q_grad
+        return q_grad + kv_grad
+
+
 # ---------------------------------------------------------------------------
 # DSv4HybridAttention
 # ---------------------------------------------------------------------------
@@ -552,15 +608,52 @@ class DSv4HybridAttention(Attention):
 
         self.recompute_gated_attn = (
             config.recompute_granularity == "selective"
-            and module_needs_recompute("gated_attn", self.layer_number, config)
+            and module_needs_recompute(
+                "gated_attn",
+                self.layer_number,
+                config,
+                is_mtp_layer=self.is_mtp_layer,
+            )
         )
 
         self.recompute_full_attn = (
             config.recompute_granularity == "selective"
-            and module_needs_recompute("full_attn", self.layer_number, config)
+            and module_needs_recompute(
+                "full_attn",
+                self.layer_number,
+                config,
+                is_mtp_layer=self.is_mtp_layer,
+            )
+        )
+        # The qkv segment alone, the DSv4 counterpart of MLA's
+        # "mla_qkv_recompute". Separate from full_attn, whose price is dominated
+        # by core_attention: the qkv chain saves far more per millisecond
+        # (profiled: 1.67GB/3.99ms vs core_attn 0.54GB/4.14ms).
+        self.recompute_qkv = (
+            config.recompute_granularity == "selective"
+            and module_needs_recompute(
+                "dsv4_hybrid_attn_qkv",
+                self.layer_number,
+                config,
+                is_mtp_layer=self.is_mtp_layer,
+            )
+        )
+        # Inverse RoPE + VHA postmix + grouped output projection. One switch for
+        # all three because the inverse RoPE and the postmix fuse into a single
+        # kernel when `fuse_inv_rope_into_vha_postmix` is on.
+        self.recompute_post_core = (
+            config.recompute_granularity == "selective"
+            and module_needs_recompute(
+                "dsv4_hybrid_attn_post_core",
+                self.layer_number,
+                config,
+                is_mtp_layer=self.is_mtp_layer,
+            )
         )
         self._full_attn_recompute = None
         self._gate_recompute = None
+        self._qkv_recompute = None
+        self._post_core_recompute = None
 
         # VHA postmix: low-rank cross-head mixing of the attention output, applied
         # after inverse RoPE (head space) and before the grouped output projection.
@@ -617,7 +710,12 @@ class DSv4HybridAttention(Attention):
         # configured like every other selective submodule.
         self.recompute_vha_postmix = (
             config.recompute_granularity == "selective"
-            and module_needs_recompute("vha_postmix", self.layer_number, config)
+            and module_needs_recompute(
+                "vha_postmix",
+                self.layer_number,
+                config,
+                is_mtp_layer=self.is_mtp_layer,
+            )
         )
 
     def forward(
@@ -756,6 +854,24 @@ class DSv4HybridAttention(Attention):
                 self.config, "attn_out_proj", self.o_proj, core_attn_out
             )
 
+            # Registered BEFORE the gated_attn one: with gated_attn_use_q_lora
+            # that segment saves q_compressed, which this segment produces and
+            # clears, so this one must replay first. Paddle fires the hooks on a
+            # tensor in registration order.
+            if self._qkv_recompute is not None:
+                self._qkv_recompute.discard_output_and_register_recompute(
+                    output
+                )
+                self._qkv_recompute = None
+
+            # Before the gated_attn one too: that segment saves this segment's
+            # output as its input.
+            if self._post_core_recompute is not None:
+                self._post_core_recompute.discard_output_and_register_recompute(
+                    output
+                )
+                self._post_core_recompute = None
+
             # Discard gated_attn output if it was independently recomputed
             if (
                 hasattr(self, "_gate_recompute")
@@ -787,13 +903,29 @@ class DSv4HybridAttention(Attention):
         and will be freed after this function returns during forward, then recomputed
         during backward.
         """
-        query, key, value, q_compressed, kv_compressed = (
-            self.get_query_key_value_tensors(
-                hidden_states=hidden_states,
-                position_offset=position_offset,
-                docmask_meta=docmask_meta,
+        if self.recompute_qkv and self.training and not _in_full_recompute:
+            self._qkv_recompute = RecomputeWithoutOutput()
+            query, key, q_compressed = self._qkv_recompute.recompute(
+                self._qkv_forward,
+                # As with full_attn: this segment feeds core_attention, whose CSA
+                # Indexer has a side-attached loss. A detached hidden_states
+                # would make q_compressed non-differentiable and silently starve
+                # the Indexer of gradient.
+                keep_indexer_grad_path(hidden_states, self.config),
+                position_offset,
+                docmask_meta,
+                preserve_rng_state=False,
+                share_grad_holder=True,
             )
-        )
+            # value is an alias of key, checked in _qkv_forward.
+            value = key
+        else:
+            query, key, q_compressed = self._qkv_forward(
+                hidden_states,
+                position_offset,
+                docmask_meta,
+            )
+            value = key
 
         # Core attention (CompressedSparseAttention)
         core_attn_out = self.core_attention(
@@ -808,7 +940,86 @@ class DSv4HybridAttention(Attention):
         )
         # core_attn_out: [b, sq, np * v_head_dim]
 
-        # Inverse RoPE on last qk_pos_emb_head_dim of each head
+        if (
+            self.recompute_post_core
+            and self.training
+            and not _in_full_recompute
+        ):
+            self._post_core_recompute = RecomputeWithoutOutput()
+            core_attn_out = self._post_core_recompute.recompute(
+                self._post_core_forward,
+                core_attn_out,
+                position_offset,
+                docmask_meta,
+                True,  # in_outer_recompute
+                preserve_rng_state=False,
+                share_grad_holder=True,
+            )
+        else:
+            core_attn_out = self._post_core_forward(
+                core_attn_out,
+                position_offset,
+                docmask_meta,
+                _in_full_recompute,
+            )
+
+        # Apply gated attention
+        if self.gated_attention:
+            gate_source = (
+                q_compressed if self.gated_attn_use_q_lora else hidden_states
+            )
+            # When NOT inside full_attn recompute, gated_attn can have its own
+            # independent RecomputeWithoutOutput wrapper for lighter memory saving.
+            if (
+                self.recompute_gated_attn
+                and self.training
+                and not _in_full_recompute
+            ):
+                self._gate_recompute = RecomputeWithoutOutput()
+                core_attn_out = self._gate_recompute.recompute(
+                    self._gate,
+                    gate_source,
+                    core_attn_out,
+                    preserve_rng_state=False,
+                    share_grad_holder=True,
+                )
+            else:
+                core_attn_out = self._gate(gate_source, core_attn_out)
+
+        return core_attn_out
+
+    def _post_core_forward(
+        self,
+        core_attn_out: Tensor,
+        position_offset: int,
+        docmask_meta: CSADocMaskMetadata | None,
+        in_outer_recompute: bool = False,
+    ) -> Tensor:
+        """Core attention output -> gate input, the ``post_core`` segment.
+
+        Inverse RoPE, the VHA postmix and the grouped output projection. One
+        input, one output, no aliasing: unlike the qkv segment this can be handed
+        to ``RecomputeWithoutOutput`` as is. The CSA Indexer lives upstream in
+        ``core_attention``, so ``keep_indexer_grad_path`` is not needed here.
+
+        ``in_outer_recompute`` says an outer wrapper already replays everything
+        in here, so the nested per-block switches must stand down.
+        """
+        core_attn_out = self._inv_rope_postmix_forward(
+            core_attn_out, position_offset, docmask_meta, in_outer_recompute
+        )
+        return self._o_group_proj_forward(core_attn_out)
+
+    def _inv_rope_postmix_forward(
+        self,
+        core_attn_out: Tensor,
+        position_offset: int,
+        docmask_meta: CSADocMaskMetadata | None,
+        in_outer_recompute: bool,
+    ) -> Tensor:
+        """Inverse RoPE on the last ``qk_pos_emb_head_dim`` of each head, then
+        the VHA postmix. One method because the two can fuse into a single
+        kernel, in which case ``postmix_done`` is already set."""
         b, sq, _ = core_attn_out.shape
         pos_dim = self.qk_pos_emb_head_dim
         nope_dim = self.v_head_dim - pos_dim
@@ -827,7 +1038,7 @@ class DSv4HybridAttention(Attention):
             # DSv4 reference uses pure norm-preserving RoPE; YaRN's mscale is not applied.
             mscale = 1.0
 
-            if self._can_fuse_inv_rope_postmix(_in_full_recompute):
+            if self._can_fuse_inv_rope_postmix(in_outer_recompute):
                 # Fused inverse RoPE + ungrouped VHA postmix. Bitwise identical
                 # to running the two separately, but never materialises the
                 # full-width rotated output. It consumes the postmix, so the
@@ -869,22 +1080,28 @@ class DSv4HybridAttention(Attention):
 
         # VHA postmix: low-rank cross-head mixing while still in head space
         # ([b, sq, nh, v_head_dim]), after inverse RoPE and before the grouped
-        # output projection. When the whole block is already wrapped in a
-        # full_attn RecomputeWithoutOutput, skip the nested selective recompute
-        # (the full block recompute already frees these activations).
+        # output projection. Skipped when an outer wrapper already replays this,
+        # since that wrapper has freed these activations anyway.
         if self.use_vha_postmix and not postmix_done:
             if (
                 self.recompute_vha_postmix
                 and self.training
-                and not _in_full_recompute
+                and not in_outer_recompute
             ):
                 core_attn_out = recompute(
                     self._apply_vha_postmix, core_attn_out
                 )
             else:
                 core_attn_out = self._apply_vha_postmix(core_attn_out)
+        return core_attn_out
 
-        # Grouped output projection
+    def _o_group_proj_forward(self, core_attn_out: Tensor) -> Tensor:
+        """The grouped output projection.
+
+        ``core_attn_out`` may arrive 3D or 4D depending on which inverse-RoPE
+        branch ran, so b/sq are read by index rather than unpacked.
+        """
+        b, sq = core_attn_out.shape[0], core_attn_out.shape[1]
         core_attn_out = core_attn_out.reshape([b, sq, self.o_local_groups, -1])
         group_shape = [
             self.o_local_groups,
@@ -910,32 +1127,35 @@ class DSv4HybridAttention(Attention):
                 dw_accumulator=dw_acc,
                 group_shape=group_shape,
             )
-        core_attn_out = core_attn_out.reshape([b, sq, -1])
+        return core_attn_out.reshape([b, sq, -1])
 
-        # Apply gated attention
-        if self.gated_attention:
-            gate_source = (
-                q_compressed if self.gated_attn_use_q_lora else hidden_states
-            )
-            # When NOT inside full_attn recompute, gated_attn can have its own
-            # independent RecomputeWithoutOutput wrapper for lighter memory saving.
-            if (
-                self.recompute_gated_attn
-                and self.training
-                and not _in_full_recompute
-            ):
-                self._gate_recompute = RecomputeWithoutOutput()
-                core_attn_out = self._gate_recompute.recompute(
-                    self._gate,
-                    gate_source,
-                    core_attn_out,
-                    preserve_rng_state=False,
-                    share_grad_holder=True,
+    def _qkv_forward(self, hidden_states, position_offset, docmask_meta):
+        """The qkv segment, for the ``dsv4_hybrid_attn_qkv`` recompute switch."""
+        if hidden_states.stop_gradient:
+            query, key, _value, q_compressed, _kv_compressed = (
+                self.get_query_key_value_tensors(
+                    hidden_states=hidden_states,
+                    position_offset=position_offset,
+                    docmask_meta=docmask_meta,
                 )
-            else:
-                core_attn_out = self._gate(gate_source, core_attn_out)
+            )
+        else:
+            query, key, q_compressed = _FixedOrderQKV.apply(
+                self,
+                hidden_states,
+                position_offset,
+                docmask_meta,
+                paddle.is_grad_enabled(),
+            )
+            _value = key
 
-        return core_attn_out
+        if _value is not key:
+            raise ValueError(
+                f"{type(self).__name__}.get_query_key_value_tensors returned a "
+                "`value` that is not `key`; dsv4_hybrid_attn_qkv recompute "
+                "rebuilds the alias outside the segment and must be updated"
+            )
+        return query, key, q_compressed
 
     def _gate(self, gate_source: Tensor, core_attn_out: Tensor) -> Tensor:
         gate, _ = deferrable_linear(
@@ -1263,6 +1483,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
         startend_row_indices: Tensor | None = None,
         position_offset: int = 0,
         docmask_meta: CSADocMaskMetadata | None = None,
+        kv_hidden_states: Tensor | None = None,
     ) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
         """Derive query, key, value from hidden_states.
 
@@ -1284,6 +1505,8 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
             kv_compressed: [b, sq, hidden_size] (== hidden_states)
         """
         b, sq, _ = hidden_states.shape
+        if kv_hidden_states is None:
+            kv_hidden_states = hidden_states
 
         # Q path
         q_compressed, _ = deferrable_linear(
@@ -1316,7 +1539,7 @@ class DSv4HybridSelfAttention(DSv4HybridAttention):
 
         # KV path
         kv, _ = deferrable_linear(
-            self.config, "attn_kv_proj", self.linear_kv_proj, hidden_states
+            self.config, "attn_kv_proj", self.linear_kv_proj, kv_hidden_states
         )  # [b, sq, v_head_dim]
 
         if self.config.swa_high_precision_norm:

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -278,7 +278,7 @@ class GroupedMLPExpert(FleetLayer):
         self.weight1.is_distributed = self.expert_parallel
         self.weight2.is_distributed = self.expert_parallel
 
-    def update_activation_recompute(self, layer_number):
+    def update_activation_recompute(self, layer_number, is_mtp_layer=False):
         """Resolve the ``moe_act`` flag; re-called once the layer id is known.
 
         ``layer_number=None`` (construction time) means a count-based selector
@@ -291,6 +291,7 @@ class GroupedMLPExpert(FleetLayer):
                 layer_number,
                 self.config,
                 defer_if_layer_unknown=True,
+                is_mtp_layer=is_mtp_layer,
             )
         )
         if self.activation_recompute and self.config.fp8:

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -625,6 +625,7 @@ class MoELayer(nn.Layer):
         list resolves to False; the second call settles both.
         """
         layer_number = getattr(self, "layer_number", None)
+        is_mtp_layer = getattr(self, "is_mtp_layer", False)
         selective = self.config.recompute_granularity == "selective"
         self.recompute_moe_gate_up = getattr(
             self.config, "recompute_moe_gate_up", False
@@ -635,6 +636,7 @@ class MoELayer(nn.Layer):
                 layer_number,
                 self.config,
                 defer_if_layer_unknown=True,
+                is_mtp_layer=is_mtp_layer,
             )
         )
         self.recompute_moe_premute = getattr(
@@ -646,13 +648,16 @@ class MoELayer(nn.Layer):
                 layer_number,
                 self.config,
                 defer_if_layer_unknown=True,
+                is_mtp_layer=is_mtp_layer,
             )
         )
         experts = getattr(self, "grouped_gemm_experts", None)
         if experts is not None and hasattr(
             experts, "update_activation_recompute"
         ):
-            experts.update_activation_recompute(layer_number)
+            experts.update_activation_recompute(
+                layer_number, is_mtp_layer=is_mtp_layer
+            )
 
     def rr_recompute_update(self, in_full_recompute, in_mlp_recompute):
         if (
@@ -687,7 +692,10 @@ class MoELayer(nn.Layer):
                         "Ensure set_layer_number() is called first."
                     )
             self.use_rr_deepep_combine = module_needs_refined_recompute(
-                "moe_combine", getattr(self, "layer_number", None), self.config
+                "moe_combine",
+                getattr(self, "layer_number", None),
+                self.config,
+                is_mtp_layer=getattr(self, "is_mtp_layer", False),
             )
         if (
             (not in_full_recompute)

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -625,14 +625,20 @@ class MultiLatentAttention(Attention):
         self.recompute_gated_attn = (
             self.config.recompute_granularity == "selective"
             and module_needs_recompute(
-                "gated_attn", self.layer_number, self.config
+                "gated_attn",
+                self.layer_number,
+                self.config,
+                is_mtp_layer=self.is_mtp_layer,
             )
         )
 
         self.recompute_qkv_up_porj_and_rope = (
             self.config.recompute_granularity == "selective"
             and module_needs_recompute(
-                "mla_qkv_recompute", self.layer_number, self.config
+                "mla_qkv_recompute",
+                self.layer_number,
+                self.config,
+                is_mtp_layer=self.is_mtp_layer,
             )
         )
 
@@ -677,7 +683,10 @@ class MultiLatentAttention(Attention):
         self.recompute_vha_postmix = (
             self.config.recompute_granularity == "selective"
             and module_needs_recompute(
-                "vha_postmix", self.layer_number, self.config
+                "vha_postmix",
+                self.layer_number,
+                self.config,
+                is_mtp_layer=self.is_mtp_layer,
             )
         )
 

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -735,11 +735,19 @@ class TransformerConfig(ModelParallelConfig):
     ``list[str]``: every listed submodule shares the layers picked by
     ``recompute_num_layers`` + ``recompute_method`` (all layers if the count is
     None). ``dict[str, spec]``: per-submodule, where ``spec`` is ``"all"``
-    (negative int / None equivalent), a list of global 0-based layer ids
-    (empty head/tail layers included), or a count resolved through
-    ``recompute_method``::
+    (negative int / None equivalent), a list of layer ids, or a count resolved
+    through ``recompute_method``::
 
         recompute_modules: {core_attn: [0, 1, 2], mlp: 2, moe_gate_up: all}
+
+    Layer ids are 0-based in the same space ``csa_compress_ratios`` indexes:
+    ``0 .. num_hidden_layers - 1`` are the backbone layers, then
+    ``num_hidden_layers + i`` addresses MTP layer ``i``. The
+    ``num_empty_layers_add_in_head`` / ``_tail`` layers hold no submodule and
+    are not addressable, so they take up no ids -- an id is a real layer.
+
+    A count selector is resolved over the physical layer number instead, which
+    is how ``recompute_method`` has always counted, empty layers included.
 
     ``flash_attn`` / ``moe_combine`` are refined-recompute entries and invert
     the spec: selected layers keep plain recompute, RR runs on the rest.

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -364,7 +364,12 @@ class TransformerLayer(nn.Layer):
                 self.layer_number, self.config
             )
         elif self.config.recompute_granularity == "selective":
-            if module_needs_recompute("norm", self.layer_number, self.config):
+            if module_needs_recompute(
+                "norm",
+                self.layer_number,
+                self.config,
+                is_mtp_layer=self.is_mtp_layer,
+            ):
                 # Both norms share the "norm" entry; each is skipped when it has
                 # been specialised away to an IdentityOp.
                 self.recompute_input_layernorm = not isinstance(
@@ -374,7 +379,10 @@ class TransformerLayer(nn.Layer):
                     self.post_attention_layernorm, IdentityOp
                 )
             self.recompute_mlp = module_needs_recompute(
-                "mlp", self.layer_number, self.config
+                "mlp",
+                self.layer_number,
+                self.config,
+                is_mtp_layer=self.is_mtp_layer,
             )
 
         # [Layer 10: Block Attention Residuals] Optional
@@ -1338,7 +1346,12 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         # mHC forward recompute config
         self.recompute_mhc_forward = (
             config.recompute_granularity == "selective"
-            and module_needs_recompute("mhc_forward", self.layer_number, config)
+            and module_needs_recompute(
+                "mhc_forward",
+                self.layer_number,
+                config,
+                is_mtp_layer=self.is_mtp_layer,
+            )
         )
 
     def _fused_h_res_h_post_bda(

--- a/tests/single_card_tests/ai_edited_test/transformer/test_ai_dsv4_hybrid_attention_recompute.py
+++ b/tests/single_card_tests/ai_edited_test/transformer/test_ai_dsv4_hybrid_attention_recompute.py
@@ -98,7 +98,15 @@ def _make_dsv4_instance(
         and recompute_modules is not None
         and "full_attn" in recompute_modules
     )
+    inst.recompute_qkv = (
+        recompute_granularity == "selective"
+        and recompute_modules is not None
+        and "dsv4_hybrid_attn_qkv" in recompute_modules
+    )
+    inst.recompute_post_core = False
     inst._full_attn_recompute = None
+    inst._qkv_recompute = None
+    inst._post_core_recompute = None
     inst._gate_recompute = None
 
     # VHA postmix disabled for these recompute-path tests (forward() reads
@@ -168,7 +176,7 @@ def _make_dsv4_instance(
         b, s, _ = hidden_states.shape
         q = paddle.randn([b, s, np_, v_dim])
         k = paddle.randn([b, s, 1, v_dim])
-        v_ = paddle.randn([b, s, 1, v_dim])
+        v_ = k
         q_compressed = paddle.randn([b, s, config.q_lora_rank])
         kv_compressed = paddle.randn([b, s, v_dim])
         return q, k, v_, q_compressed, kv_compressed
@@ -179,6 +187,16 @@ def _make_dsv4_instance(
     inst.forward = types.MethodType(DSv4HybridAttention.forward, inst)
     inst._full_attn_forward = types.MethodType(
         DSv4HybridAttention._full_attn_forward, inst
+    )
+    inst._qkv_forward = types.MethodType(DSv4HybridAttention._qkv_forward, inst)
+    inst._post_core_forward = types.MethodType(
+        DSv4HybridAttention._post_core_forward, inst
+    )
+    inst._inv_rope_postmix_forward = types.MethodType(
+        DSv4HybridAttention._inv_rope_postmix_forward, inst
+    )
+    inst._o_group_proj_forward = types.MethodType(
+        DSv4HybridAttention._o_group_proj_forward, inst
     )
     inst._gate = types.MethodType(DSv4HybridAttention._gate, inst)
     # _full_attn_forward consults this before the inverse-RoPE block. Bind the

--- a/tests/single_card_tests/test_recompute_module_spec.py
+++ b/tests/single_card_tests/test_recompute_module_spec.py
@@ -139,14 +139,108 @@ class TestDictLayerList(unittest.TestCase):
             config = _config(recompute_modules={"mlp": spec})
             self.assertEqual(_hits("mlp", config), [1, 2], f"spec={spec!r}")
 
-    def test_layer_ids_are_global(self):
-        # Empty head layers shift every backbone layer id.
+    def test_layer_ids_skip_empty_head_layers(self):
+        # Layer ids are logical: id 0 is the first real backbone layer, whatever
+        # num_empty_layers_add_in_head is. Physical layer numbers are shifted.
         config = _config(
             num_hidden_layers=6,
             num_empty_layers_add_in_head=2,
             recompute_modules={"mlp": [0, 2]},
         )
-        self.assertEqual(_hits("mlp", config), [0, 2])
+        self.assertEqual(_hits("mlp", config, num_layers=8), [2, 4])
+
+    def test_layer_ids_match_csa_compress_ratios_indexing(self):
+        # The same index space per-layer model_config fields use, so
+        # csa_compress_ratios[i] and a layer id of i mean the same layer.
+        config = _config(num_hidden_layers=6, recompute_modules={"mlp": [0, 5]})
+        self.assertEqual(_hits("mlp", config, num_layers=6), [0, 5])
+
+
+class TestMTPLayers(unittest.TestCase):
+    """MTP layers are addressed after the backbone, not aliased onto layer 0.
+
+    An MTP layer is built with ``layer_number=i`` within the MTP block, so
+    without the logical mapping it would collide with backbone layer ``i``.
+    """
+
+    def test_mtp_layer_id_follows_the_backbone(self):
+        config = _config(
+            num_hidden_layers=6,
+            mtp_num_layers=1,
+            recompute_modules={"mlp": [6]},
+        )
+        self.assertTrue(
+            module_needs_recompute("mlp", 0, config, is_mtp_layer=True)
+        )
+        self.assertFalse(module_needs_recompute("mlp", 0, config))
+
+    def test_backbone_layer_zero_does_not_select_mtp(self):
+        config = _config(
+            num_hidden_layers=6,
+            mtp_num_layers=1,
+            recompute_modules={"mlp": [0]},
+        )
+        self.assertTrue(module_needs_recompute("mlp", 0, config))
+        self.assertFalse(
+            module_needs_recompute("mlp", 0, config, is_mtp_layer=True)
+        )
+
+    def test_multiple_mtp_layers_are_addressed_independently(self):
+        config = _config(
+            num_hidden_layers=6,
+            mtp_num_layers=2,
+            recompute_modules={"mlp": [7]},
+        )
+        self.assertFalse(
+            module_needs_recompute("mlp", 0, config, is_mtp_layer=True)
+        )
+        self.assertTrue(
+            module_needs_recompute("mlp", 1, config, is_mtp_layer=True)
+        )
+
+    def test_empty_head_layers_do_not_shift_mtp_ids(self):
+        config = _config(
+            num_hidden_layers=6,
+            num_empty_layers_add_in_head=2,
+            mtp_num_layers=1,
+            recompute_modules={"mlp": [6]},
+        )
+        self.assertTrue(
+            module_needs_recompute("mlp", 0, config, is_mtp_layer=True)
+        )
+
+    def test_rr_list_inverts_on_the_logical_id(self):
+        config = _config(
+            num_hidden_layers=6,
+            mtp_num_layers=1,
+            recompute_modules={"flash_attn": [6]},
+        )
+        self.assertFalse(
+            module_needs_refined_recompute(
+                "flash_attn", 0, config, is_mtp_layer=True
+            )
+        )
+        self.assertTrue(module_needs_refined_recompute("flash_attn", 0, config))
+
+    def test_mtp_id_is_valid_at_startup(self):
+        _config(
+            num_hidden_layers=6,
+            mtp_num_layers=1,
+            recompute_modules={"mlp": [6]},
+        )
+        with self.assertRaises(ValueError):
+            _config(
+                num_hidden_layers=6,
+                mtp_num_layers=1,
+                recompute_modules={"mlp": [7]},
+            )
+
+    def test_num_nextn_predict_layers_is_the_fallback(self):
+        _config(
+            num_hidden_layers=6,
+            num_nextn_predict_layers=1,
+            recompute_modules={"mlp": [6]},
+        )
 
 
 class TestRefinedRecompute(unittest.TestCase):
@@ -301,11 +395,21 @@ class TestValidation(unittest.TestCase):
         with self.assertRaises(ValueError):
             _config(num_hidden_layers=4, recompute_modules={"mlp": [0, 4]})
 
-    def test_empty_head_layers_extend_the_range(self):
-        # 4 backbone + 2 head layers -> id 4 is now valid.
+    def test_empty_head_layers_do_not_extend_the_range(self):
+        # Empty layers hold no recomputable module, so they are not addressable:
+        # 4 backbone layers means ids 0..3 whatever the head layer count is.
+        with self.assertRaises(ValueError):
+            _config(
+                num_hidden_layers=4,
+                num_empty_layers_add_in_head=2,
+                recompute_modules={"mlp": [0, 4]},
+            )
+
+    def test_mtp_layers_extend_the_range(self):
+        # 4 backbone + 1 MTP layer -> id 4 is the MTP layer.
         _config(
             num_hidden_layers=4,
-            num_empty_layers_add_in_head=2,
+            mtp_num_layers=1,
             recompute_modules={"mlp": [0, 4]},
         )
 

--- a/tests/single_card_tests/test_rr_deepep_combine_config.py
+++ b/tests/single_card_tests/test_rr_deepep_combine_config.py
@@ -241,6 +241,10 @@ class TestRRRecomputeUpdate(unittest.TestCase):
             "shared_expert_overlap", True
         )
         mock.use_rr_deepep_combine = False
+        # MagicMock auto-creates any attribute, so the production getattr
+        # default never applies and an unset one would read as a truthy MTP
+        # layer, shifting every logical layer id by num_hidden_layers.
+        mock.is_mtp_layer = overrides.get("is_mtp_layer", False)
         mock.config = MagicMock()
         mock.config.recompute_modules = overrides.get(
             "recompute_modules", ["moe_combine"]
@@ -251,6 +255,11 @@ class TestRRRecomputeUpdate(unittest.TestCase):
         mock.config.recompute_method = overrides.get(
             "recompute_method", "first_n"
         )
+        # Layer lists resolve through logical_layer_index, which reads these two
+        # off the config; a MagicMock stand-in would make the arithmetic return
+        # another mock.
+        mock.config.num_empty_layers_add_in_head = 0
+        mock.config.num_hidden_layers = overrides.get("num_hidden_layers", 8)
         if "layer_number" in overrides:
             mock.layer_number = overrides["layer_number"]
         return mock
@@ -393,7 +402,9 @@ class TestRRRecomputeUpdate(unittest.TestCase):
             mock, in_full_recompute=True, in_mlp_recompute=False
         )
         self.assertTrue(mock.use_rr_deepep_combine)
-        mock_needs_rr.assert_called_once_with("moe_combine", 5, mock.config)
+        mock_needs_rr.assert_called_once_with(
+            "moe_combine", 5, mock.config, is_mtp_layer=False
+        )
 
     def test_dict_mode_layer_list_needs_no_method(self):
         """A layer list selects the non-RR layers directly; method is unused."""

--- a/tests/single_card_tests/transformer/test_doc_mask_meta_registry.py
+++ b/tests/single_card_tests/transformer/test_doc_mask_meta_registry.py
@@ -888,6 +888,11 @@ class _DSv4SharedSlotProbe(DSv4HybridAttention):
         self.config = config
         self.layer_number = 1
         self.recompute_full_attn = False
+        # forward closes every selective span it may have opened, so it reads
+        # these two holders whether or not the switches are on. The gated_attn
+        # one is behind a hasattr and needs no stand-in.
+        self._qkv_recompute = None
+        self._post_core_recompute = None
         self.csa_mask_group = ("main",)
         self.core_attention = SimpleNamespace(compress_ratio=4)
         self.o_proj = lambda out: (out, None)

--- a/tests/single_card_tests/transformer/test_dsv4_attn_segment_recompute_parity.py
+++ b/tests/single_card_tests/transformer/test_dsv4_attn_segment_recompute_parity.py
@@ -1,0 +1,302 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``dsv4_hybrid_attn_qkv`` / ``_post_core`` must be invisible from outside.
+
+Both switches move a real forward/backward boundary: the segment runs under
+``no_grad``, its outputs are freed, and the replay rebuilds the graph from the
+saved inputs. Everything reachable from outside the segment must not notice --
+same output, same ``dx``, same gradient for every parameter, bit for bit.
+
+Driven through the real ``DSv4HybridSelfAttention.forward``, against a baseline
+with the switch off. Bitwise (``assert_array_equal``) rather than a tolerance:
+the point of the fixed-order node in the qkv path is that replay does not cost
+even an ULP, and a tolerance would hide exactly the regression it prevents.
+
+Covered per config combination: each switch alone, both together, and both plus
+``gated_attn`` (whose own span hooks the same tensor, so its replay order
+relative to these two is what the registration order in ``forward`` pins down).
+The combinations vary ``gated_attn_use_q_lora`` -- it decides whether the gate
+consumes ``q_compressed``, i.e. whether it reads a tensor the qkv segment
+produces and clears -- and the VHA postmix, which sits inside the post-core
+segment and brings its own parameters.
+
+Also asserted, since a leak here is silent: the spans are actually taken (the
+flags are on and the holders were populated), and every holder is back to None
+when ``forward`` returns, so nothing keeps a cleared buffer alive.
+"""
+
+import unittest
+
+import numpy as np
+import paddle
+from paddle.distributed.fleet.meta_parallel import build_spec_layer
+
+from paddlefleet.models.gpt.gpt_layer_specs import get_attention_spec
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+_SEED = 42
+_BATCH, _SEQ, _HIDDEN = 1, 64, 256
+# csa_compress_ratios[1] == 4, so layer 1 is a CSA layer: compressor + Lightning
+# Indexer, i.e. the qkv segment's outputs feed a side-attached loss too.
+_LAYER = 1
+_RATIOS = [0, 4, 128, 4]
+
+_REQUIRES_CUDA = unittest.skipUnless(
+    paddle.is_compiled_with_cuda(), "requires CUDA for the CSA/Triton kernels"
+)
+
+_SPAN_HOLDERS = ("_qkv_recompute", "_post_core_recompute", "_gate_recompute")
+
+
+def _make_config(recompute_modules, **overrides):
+    kwargs = {
+        "num_hidden_layers": len(_RATIOS),
+        "hidden_size": _HIDDEN,
+        "num_attention_heads": 8,
+        "params_dtype": paddle.bfloat16,
+        "bf16": True,
+        "use_bias": False,
+        "multi_latent_attention": True,
+        "experimental_attention_variant": "dsv4_hybrid",
+        "q_lora_rank": 64,
+        "kv_lora_rank": 16,
+        "qk_nope_head_dim": 16,
+        "qk_rope_head_dim": 16,
+        "qk_pos_emb_head_dim": 16,
+        "v_head_dim": 32,
+        "o_groups": 4,
+        "o_lora_rank": 32,
+        "rope_type": "rope",
+        "rotary_base": 10000.0,
+        "rotary_percent": 1.0,
+        "normalization": "RMSNorm",
+        "use_qk_norm": True,
+        "csa_compress_ratios": list(_RATIOS),
+        "csa_window_size": 16,
+        "dsa_index_n_heads": 4,
+        "dsa_index_head_dim": 32,
+        "dsa_index_topk": 8,
+        # Non-zero: the Indexer's side-attached loss is a second consumer of the
+        # qkv segment's outputs, and it must survive the replay too.
+        "dsa_indexer_loss_coeff": 1.0,
+        "dsa_indexer_rotary_interleaved": False,
+        "apply_rope_fusion": True,
+        "attention_dropout": 0.0,
+        "attention_softmax_in_fp32": True,
+        "masked_softmax_fusion": False,
+        "softmax_type": "vanilla",
+        "csa_indexer_backend": "unfused",
+        "csa_sparse_attn_backend": "unfused",
+        "mqa_sparse_attn_backward_backend": "cudnn",
+        "gated_attention": True,
+        "gated_attn_use_q_lora": True,
+    }
+    kwargs.update(overrides)
+    config = TransformerConfig(**kwargs)
+    # Assigned rather than passed: with granularity "selective" the config
+    # validates the module names against this release's table, and these two are
+    # what this test is here to exercise.
+    config.recompute_granularity = "selective" if recompute_modules else None
+    config.recompute_modules = recompute_modules
+    return config
+
+
+def _build(config):
+    paddle.seed(_SEED)
+    model_parallel_cuda_manual_seed(_SEED)
+    spec = get_attention_spec(
+        config=config,
+        attention_layer_type="dsv4_hybrid_attention",
+        attn_mask_type=AttnMaskType.causal,
+    )
+    attn = build_spec_layer(spec, config=config, layer_number=_LAYER)
+    _fix_vha_param_dtype(attn, config)
+    attn.train()
+    return attn
+
+
+def _fix_vha_param_dtype(attn, config):
+    """Put the VHA parameters in ``params_dtype``, which the module does not.
+
+    ``vha_postmix_U`` / ``_V`` / ``vha_premix_weight`` are created without a
+    ``dtype``, so they land on paddle's fp32 default while every projection in
+    the same layer follows ``params_dtype`` -- and ``_apply_vha_postmix`` then
+    multiplies an fp32 matrix by a bf16 activation. That is a pre-existing DSv4
+    defect, unrelated to the recompute segments this file tests, and it makes
+    bf16 + VHA unable to run at all; the existing VHA coverage misses it by
+    staying in fp32 on a window-only layer. Cast here rather than fix it in
+    production so this file stays inside its own scope; drop this once the
+    parameters carry a dtype.
+    """
+    for name in ("vha_postmix_U", "vha_postmix_V", "vha_premix_weight"):
+        parameter = getattr(attn, name, None)
+        if parameter is None or parameter.dtype == config.params_dtype:
+            continue
+        casted = parameter.astype(config.params_dtype)
+        casted.stop_gradient = parameter.stop_gradient
+        attn.__dict__.pop(name, None)
+        attn._parameters.pop(name, None)
+        setattr(
+            attn,
+            name,
+            attn.create_parameter(
+                shape=casted.shape,
+                dtype=config.params_dtype,
+                default_initializer=paddle.nn.initializer.Assign(casted),
+            ),
+        )
+
+
+def _collect(attn, hidden_np):
+    """One forward/backward pass; everything observable from outside the spans."""
+    hidden = paddle.to_tensor(hidden_np, dtype="bfloat16")
+    hidden.stop_gradient = False
+    paddle.seed(_SEED)
+    model_parallel_cuda_manual_seed(_SEED)
+
+    output, _bias = attn(hidden_states=hidden, attention_mask=None)
+    # Weight by position so a mix-up between rows cannot cancel out.
+    weights = paddle.arange(1, output.shape[1] + 1, dtype="float32").reshape(
+        [1, -1, 1]
+    )
+    (output.astype("float32") * weights).sum().backward()
+
+    # The holders are consumed by discard_output_and_register_recompute, so a
+    # non-None one here means a span was opened and never closed: its output
+    # buffer stays cleared and the replay never runs.
+    leaked = [
+        name for name in _SPAN_HOLDERS if getattr(attn, name, None) is not None
+    ]
+    return {
+        "output": output.astype("float32").numpy().copy(),
+        "hidden_grad": hidden.grad.astype("float32").numpy().copy(),
+        "param_grads": {
+            name: parameter.grad.astype("float32").numpy().copy()
+            for name, parameter in attn.named_parameters()
+            if parameter.grad is not None
+        },
+        "leaked_holders": leaked,
+    }
+
+
+_QKV = "dsv4_hybrid_attn_qkv"
+_POST = "dsv4_hybrid_attn_post_core"
+_GATE = "gated_attn"
+
+# Which switches each case turns on, and which per-layer flags that must set.
+_CASES = {
+    "qkv": ([_QKV], {"recompute_qkv"}),
+    "post_core": ([_POST], {"recompute_post_core"}),
+    "qkv+post_core": ([_QKV, _POST], {"recompute_qkv", "recompute_post_core"}),
+    "qkv+post_core+gate": (
+        [_QKV, _POST, _GATE],
+        {"recompute_qkv", "recompute_post_core", "recompute_gated_attn"},
+    ),
+}
+
+# The config axes that change what the segments contain or who reads their
+# outputs. VHA adds parameters inside the post-core segment; use_q_lora decides
+# whether the gate reads q_compressed, which the qkv segment clears.
+_VARIANTS = {
+    "q_lora_gate": {"gated_attn_use_q_lora": True},
+    "hidden_gate": {"gated_attn_use_q_lora": False},
+    "vha_postmix": {
+        "gated_attn_use_q_lora": True,
+        "use_vha_attention": True,
+        "vha_postmix_rank": 4,
+    },
+    "vha_postmix_fused_inv_rope": {
+        "gated_attn_use_q_lora": True,
+        "use_vha_attention": True,
+        "vha_postmix_rank": 4,
+        # Folds the inverse RoPE into the postmix GEMM, so the post-core segment
+        # holds one fused op instead of two.
+        "fuse_inv_rope_into_vha_postmix": True,
+    },
+}
+
+
+@_REQUIRES_CUDA
+class TestDSv4AttnSegmentRecomputeParity(unittest.TestCase):
+    """Each selective attention segment must be bitwise-invisible."""
+
+    @classmethod
+    def setUpClass(cls):
+        paddle.set_device("gpu")
+
+    def _assert_identical(self, baseline, recomputed, label):
+        np.testing.assert_array_equal(
+            baseline["output"],
+            recomputed["output"],
+            err_msg=f"{label}: output",
+        )
+        np.testing.assert_array_equal(
+            baseline["hidden_grad"],
+            recomputed["hidden_grad"],
+            err_msg=f"{label}: hidden_states.grad",
+        )
+        self.assertEqual(
+            set(baseline["param_grads"]),
+            set(recomputed["param_grads"]),
+            f"{label}: a parameter lost its gradient",
+        )
+        for name, expected in baseline["param_grads"].items():
+            np.testing.assert_array_equal(
+                expected,
+                recomputed["param_grads"][name],
+                err_msg=f"{label}: grad of {name}",
+            )
+
+    def test_segments_match_the_no_recompute_baseline(self):
+        hidden_np = (
+            np.random.RandomState(0)
+            .randn(_BATCH, _SEQ, _HIDDEN)
+            .astype("float32")
+        )
+        for variant, overrides in _VARIANTS.items():
+            baseline = _collect(
+                _build(_make_config(None, **overrides)), hidden_np
+            )
+            self.assertEqual(
+                baseline["leaked_holders"],
+                [],
+                f"{variant}: baseline leaked a span holder",
+            )
+            for case, (modules, expected_flags) in _CASES.items():
+                label = f"{variant}/{case}"
+                with self.subTest(variant=variant, case=case):
+                    config = _make_config(
+                        {name: [_LAYER] for name in modules}, **overrides
+                    )
+                    attn = _build(config)
+                    for flag in expected_flags:
+                        self.assertTrue(
+                            getattr(attn, flag),
+                            f"{label}: {flag} did not turn on, so this "
+                            "comparison would be vacuous",
+                        )
+                    recomputed = _collect(attn, hidden_np)
+                    self.assertEqual(
+                        recomputed["leaked_holders"],
+                        [],
+                        f"{label}: span holder still set after forward",
+                    )
+                    self._assert_identical(baseline, recomputed, label)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_dsv4_qkv_fixed_grad_order.py
+++ b/tests/single_card_tests/transformer/test_dsv4_qkv_fixed_grad_order.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import os
 import sys
 import unittest
@@ -31,6 +32,11 @@ from paddlefleet.transformer.dsv4_hybrid_attention import (
 
 
 class _QKVProbe(paddle.nn.Layer):
+    """A qkv segment whose ``get_query_key_value_tensors`` takes exactly the
+    parameters ``DSv4HybridAttention`` declares -- no ``**kwargs`` to absorb an
+    extra keyword. Both branches read ``hidden_states``, which is what makes the
+    summation order into its gradient observable."""
+
     def __init__(self, width):
         super().__init__()
         self.q_weight = self.create_parameter([width, width], dtype="bfloat16")
@@ -39,15 +45,13 @@ class _QKVProbe(paddle.nn.Layer):
     def get_query_key_value_tensors(
         self,
         hidden_states,
+        startend_row_indices=None,
         position_offset=0,
         docmask_meta=None,
-        kv_hidden_states=None,
     ):
-        del position_offset, docmask_meta
-        if kv_hidden_states is None:
-            kv_hidden_states = hidden_states
+        del startend_row_indices, position_offset, docmask_meta
         query = paddle.matmul(hidden_states, self.q_weight)
-        key = paddle.matmul(kv_hidden_states, self.kv_weight).unsqueeze(2)
+        key = paddle.matmul(hidden_states, self.kv_weight).unsqueeze(2)
         q_compressed = hidden_states * 3
         return query, key, key, q_compressed, hidden_states
 
@@ -100,7 +104,7 @@ class TestDSv4FixedOrderQKV(unittest.TestCase):
 
     def test_recompute_replay_is_bitwise_identical(self):
         paddle.seed(2026)
-        module = _QKVProbe(32).astype("bfloat16")
+        module = _QKVProbe(32)
         hidden_states = paddle.randn([3, 2, 32]).astype("bfloat16")
         hidden_states.stop_gradient = False
 
@@ -120,6 +124,41 @@ class TestDSv4FixedOrderQKV(unittest.TestCase):
                     )
             else:
                 np.testing.assert_array_equal(direct_values, recomputed_values)
+
+    def test_segment_passes_only_the_declared_parameters(self):
+        """The segment must call the override through the base contract.
+
+        A subclass implementing exactly ``DSv4HybridAttention``'s signature has
+        no ``**kwargs`` to swallow an extra keyword, so an added one is a
+        TypeError -- on every differentiable call, since ``_qkv_forward``
+        branches on ``stop_gradient`` rather than on the recompute switch.
+        """
+        declared = set(
+            inspect.signature(
+                DSv4HybridAttention.get_query_key_value_tensors
+            ).parameters
+        )
+        probed = set(
+            inspect.signature(_QKVProbe.get_query_key_value_tensors).parameters
+        )
+        self.assertEqual(probed, declared)
+
+        seen = []
+        module = _QKVProbe(32)
+        original = module.get_query_key_value_tensors
+
+        def _recording(*args, **kwargs):
+            seen.append(set(kwargs))
+            return original(*args, **kwargs)
+
+        module.get_query_key_value_tensors = _recording
+
+        hidden_states = paddle.randn([3, 2, 32]).astype("bfloat16")
+        hidden_states.stop_gradient = False
+        module._qkv_forward(hidden_states, 0, None)
+
+        self.assertEqual(len(seen), 1)
+        self.assertLessEqual(seen[0], declared - {"self", "hidden_states"})
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/transformer/test_dsv4_qkv_fixed_grad_order.py
+++ b/tests/single_card_tests/transformer/test_dsv4_qkv_fixed_grad_order.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+
+import numpy as np
+import paddle
+
+_REPO_ROOT = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+sys.path.insert(0, os.path.join(_REPO_ROOT, "src"))
+
+from paddlefleet.tensor_parallel import RecomputeWithoutOutput
+from paddlefleet.transformer.dsv4_hybrid_attention import (
+    DSv4HybridAttention,
+)
+
+
+class _QKVProbe(paddle.nn.Layer):
+    def __init__(self, width):
+        super().__init__()
+        self.q_weight = self.create_parameter([width, width], dtype="bfloat16")
+        self.kv_weight = self.create_parameter([width, width], dtype="bfloat16")
+
+    def get_query_key_value_tensors(
+        self,
+        hidden_states,
+        position_offset=0,
+        docmask_meta=None,
+        kv_hidden_states=None,
+    ):
+        del position_offset, docmask_meta
+        if kv_hidden_states is None:
+            kv_hidden_states = hidden_states
+        query = paddle.matmul(hidden_states, self.q_weight)
+        key = paddle.matmul(kv_hidden_states, self.kv_weight).unsqueeze(2)
+        q_compressed = hidden_states * 3
+        return query, key, key, q_compressed, hidden_states
+
+    def _qkv_forward(self, hidden_states, position_offset, docmask_meta):
+        return DSv4HybridAttention._qkv_forward(
+            self, hidden_states, position_offset, docmask_meta
+        )
+
+
+@unittest.skipUnless(paddle.is_compiled_with_cuda(), "requires CUDA")
+class TestDSv4FixedOrderQKV(unittest.TestCase):
+    def _run_direct(self, module, hidden_states):
+        query, key, q_compressed = module._qkv_forward(hidden_states, 0, None)
+        loss = query.sum() + 2 * key.sum() + 3 * q_compressed.sum()
+        loss.backward()
+        return (
+            tuple(
+                output.numpy().copy() for output in (query, key, q_compressed)
+            ),
+            hidden_states.grad.numpy().copy(),
+            tuple(
+                parameter.grad.numpy().copy()
+                for parameter in module.parameters()
+            ),
+        )
+
+    def _run_recompute(self, module, hidden_states):
+        span = RecomputeWithoutOutput()
+        query, key, q_compressed = span.recompute(
+            module._qkv_forward,
+            hidden_states,
+            0,
+            None,
+            preserve_rng_state=False,
+            share_grad_holder=True,
+        )
+        loss = query.sum() + 2 * key.sum() + 3 * q_compressed.sum()
+        span.discard_output_and_register_recompute(loss)
+        loss.backward()
+        return (
+            tuple(
+                output.numpy().copy() for output in (query, key, q_compressed)
+            ),
+            hidden_states.grad.numpy().copy(),
+            tuple(
+                parameter.grad.numpy().copy()
+                for parameter in module.parameters()
+            ),
+        )
+
+    def test_recompute_replay_is_bitwise_identical(self):
+        paddle.seed(2026)
+        module = _QKVProbe(32).astype("bfloat16")
+        hidden_states = paddle.randn([3, 2, 32]).astype("bfloat16")
+        hidden_states.stop_gradient = False
+
+        direct = self._run_direct(module, hidden_states)
+        for parameter in module.parameters():
+            parameter.clear_gradient()
+        hidden_states.clear_gradient()
+
+        recomputed = self._run_recompute(module, hidden_states)
+        for direct_values, recomputed_values in zip(direct, recomputed):
+            if isinstance(direct_values, tuple):
+                for direct_value, recomputed_value in zip(
+                    direct_values, recomputed_values
+                ):
+                    np.testing.assert_array_equal(
+                        direct_value, recomputed_value
+                    )
+            else:
+                np.testing.assert_array_equal(direct_values, recomputed_values)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Performance Optimization

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->

  1. 重计算层编号                                                                                                  
                                                                                                                                                                                                                                                                                                                                      
  recompute_modules 中的显式 layer ID 统一改为逻辑编号：
                                                                                                                                                                                                                                                                                                                                      
  - Backbone layer：[0, num_hidden_layers)                                                                          
  - MTP layer i：num_hidden_layers + i
  - 空的 head/tail layer 不占用编号

  这样可与 csa_compress_ratios 等按层配置保持一致，并避免 backbone 与 MTP 的 layer ID 冲突。所有重计算判断路径（包括 MoE 子模块）均透传 is_mtp_layer。

  2. DSv4 选择性重计算

  新增两个选择性重计算模块：

  - dsv4_hybrid_attn_qkv：Q/KV 投影
  - dsv4_hybrid_attn_post_core：inverse RoPE、VHA postmix 和 grouped output projection

  QKV 路径通过 _FixedOrderQKV 统一 autograd 边界，使普通执行与重计算 replay 使用相同的梯度聚合拓扑，从而保证 BF16 梯度逐位一致。

  当 gated_attn_use_q_lora 开启时，gated_attn 会使用 QKV 段产生的 q_compressed，因此 QKV 的重计算 hook 必须先于 gated-attention hook 注册。

Merged in dev: #1956

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是