### PR TITLE
[release/0.4][Deps] Bump Paddle to `e4e12582077`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260901+160041a4134",
+    "paddlepaddle-gpu==3.4.0.post20260903+e4e12582077",
     "ruamel.yaml>=0.17",
     "tilelang-paddle==0.1.12",
 ]


### PR DESCRIPTION
### PR Category
Environment Adaptation

### PR Types
Others

### Description
Bump the pinned CUDA 12.9 Paddle dependency to `paddlepaddle-gpu==3.4.0.post20260903+e4e12582077`.

Develop PR: [#1943](https://github.com/PaddlePaddle/PaddleFleet/pull/1943) (merged).

Target Paddle release: `release/3.4`.
Target Paddle commit: [`e4e12582077cffa5250218d13f185758fca88cbc`](https://github.com/PaddlePaddle/Paddle/commit/e4e12582077cffa5250218d13f185758fca88cbc).

This release PR is rebuilt from the latest `PaddleFleet/release/0.4` base commit `2e1e6f8f3bcc88e1eba9cb9ebb2996a5711e4e43`.

### 是否引起精度变化
否