### PR TITLE
[DSA] Vendor the SM100-family v2 indexer backward and use it where accepted

### DIFF
--- a/src/paddlefleet/cudnn_ops/indexer/csa_indexer_bwd_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/indexer/csa_indexer_bwd_cudnn.py
@@ -25,13 +25,123 @@ Returns d_index_q / d_weights / d_index_k_comp matching input dtypes/shapes.
 
 from __future__ import annotations
 
+import functools
+import inspect
+import logging
+
 import paddle
 from paddlefleet_ops import CUDNN_FRONTEND_HINT, is_cudnn_frontend_available
+
+logger = logging.getLogger(__name__)
+
+# cuDNN 1.28 added a second GEMM stage for this kernel, selected by
+# ``backend="sm100_v2"``. It keeps kernel 1 (the score-grad precompute)
+# verbatim and replaces the GEMM: ``weights`` are upcast to fp32 exactly and the
+# per-slot gradient matrix ``A = grad_signal * weights`` is split into a
+# two-term bf16 expansion before the MMA, with a deterministic in-CTA
+# ``d_weights`` reduction. Measured on an SM103 part at ``S=8192 H=64 D=128 topk=2048``,
+# relative L2 against an fp64 evaluation of the kernel's documented contract:
+# ``d_index_q`` 2.32e-03 -> 1.66e-03, ``d_index_k`` 1.52e-03 -> 1.21e-05, and
+# ``d_weights`` 1.66e-03 -> 1.70e-07 once it is handed an fp32 buffer (below).
+# Nothing regresses, so this is selected automatically rather than exposed as a
+# switch.
+#
+# The cost is speed at the top of the topk range: the two-term expansion doubles
+# the GEMM work, so it wins where the GEMM does not dominate and loses where it
+# does. Measured on an idle SM103 part at the shape above, min of 3 alternating rounds
+# of 20 iterations (spread within a round < 1.5%):
+#
+#     topk    default    v2       speedup
+#      128     0.457     0.293     1.559x
+#      256     0.643     0.537     1.197x
+#      512     0.909     0.879     1.035x
+#     1024     1.550     1.579     0.982x
+#     2048     2.910     2.984     0.975x
+#
+# The crossover sits between 512 and 1024, so production (topk=2048) pays about
+# 2.5% on this kernel. That is deliberately *not* gated on topk: two orders of
+# magnitude on ``d_index_k`` is worth 2.5% of one backward kernel, and a
+# topk-dependent backend would make the numerics a function of the sequence
+# budget, which is worse to reason about than a uniform 2.5%.
+_V2_BACKEND = "sm100_v2"
+
+# The two refusals cuDNN raises for this backend when the device is not one it
+# accepts. Matched by message because cuDNN has no dedicated exception type for
+# them: ``check_support`` raises ``RuntimeError("backend='sm100_v2' requires an
+# SM100 device ...")`` and the kernel factory raises
+# ``RuntimeError("indexer_backward_v2_sm100 requires SM100 ...")``. Both fire
+# strictly before ``execute`` -- ``check_support`` at plan construction and the
+# factory from ``compile`` (api.py:475, inside ``compile`` at :457, while
+# ``execute`` starts at :534) -- so the score buffers are still untouched when
+# either is seen and retrying on the generic backend is exact, not approximate.
+#
+# The match is deliberately narrow. Catching ``RuntimeError`` broadly would also
+# swallow a compile or launch failure raised *after* kernel 1 had already
+# overwritten ``attn_score`` with the grad signal, and the retry would then
+# compute gradients from a consumed buffer -- silently wrong, and with the real
+# error permanently downgraded to a fallback.
+_V2_REFUSAL_MARKERS = (
+    "backend='sm100_v2' requires an SM100",
+    "indexer_backward_v2_sm100 requires SM100",
+)
+
+# Latched once cuDNN has refused, so the refusal costs one plan construction per
+# process rather than one per step.
+_V2_REFUSED = False
+
+
+def _is_v2_device_refusal(exc: BaseException) -> bool:
+    return isinstance(exc, RuntimeError) and any(
+        marker in str(exc) for marker in _V2_REFUSAL_MARKERS
+    )
+
+
+def _latch_v2_refused() -> None:
+    global _V2_REFUSED
+    _V2_REFUSED = True
 
 
 def _require_cudnn_frontend():
     if not is_cudnn_frontend_available():
         raise ImportError(CUDNN_FRONTEND_HINT)
+
+
+@functools.cache
+def _select_backend(
+    heads: int, head_dim: int, topk: int, block_I: int
+) -> str | None:
+    """The cuDNN backend to request, or ``None`` for the architecture-generic one.
+
+    Every condition here is one cuDNN enforces itself, and it enforces them by
+    raising: the backend is **request-or-fail**, so asking outside the envelope
+    aborts the step instead of selecting a slower kernel. The predicate is
+    therefore evaluated up front rather than caught, and it has to track the
+    *vendored* cuDNN -- which is why this commit moves the submodule and this
+    check together. The vendored version gates the device on the SM100 family
+    (``capability[0] == 10``), so SM100 and SM103 both qualify; an older
+    vendored cuDNN gated on an exact ``(10, 0)``, hence the pairing.
+
+    Cached because it would otherwise re-run on every indexer backward of every
+    layer.
+    """
+    from paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_backward.api import (
+        indexer_backward_wrapper,
+    )
+
+    # An installed ``paddlefleet_ops`` wheel can predate the vendored cuDNN bump
+    # that introduced the parameter, in which case passing it would be a
+    # TypeError rather than a slower kernel.
+    if "backend" not in inspect.signature(indexer_backward_wrapper).parameters:
+        return None
+    if paddle.device.cuda.get_device_capability()[0] != 10:
+        return None
+    if heads != 64 or head_dim != 128:
+        return None
+    if block_I != 128:
+        return None
+    if topk % 128 != 0 or not (128 <= topk <= 2048):
+        return None
+    return _V2_BACKEND
 
 
 def _to_bf16(t: paddle.Tensor) -> paddle.Tensor:
@@ -110,37 +220,95 @@ def csa_indexer_bwd(
         indexer_backward_wrapper,
     )
 
-    out = indexer_backward_wrapper(
-        index_q_bf,
-        weights_bf,
-        index_k_bf,
-        target_buf,
-        predict_buf,
-        topk_indices,
-        sm_scale=float(index_q_bf.shape[-1]) ** -0.5,
-        loss_coeff=float(loss_coeff),
-        grad_loss=grad_loss_paddle,
-        block_I=int(block_I),
-        # dK is reduced with fp32 atomics whatever the buffer dtype, so the dtype
-        # only selects *how* the result lands. Left to allocate its own bf16
-        # buffer, the wrapper takes a branch ending in
-        # ``dIndexK.copy_(dIndexK_f32.astype(...))``, and Paddle's blocking
-        # ``copy_`` lowers to ``GpuMemcpySync`` on the CUDA *legacy default*
-        # stream -- a bidirectional full-device barrier, so every later kernel
-        # waits for whatever is in flight. Under
-        # ``dsa_indexer_loss_bwd_p2p_overlap`` that pushed the whole indexer
-        # projection backward out past the pipeline send/recv it was supposed to
-        # hide behind.
-        #
-        # A pre-zeroed fp32 buffer takes the wrapper's in-place path instead:
-        # same kernel, same fp32 atomicAdd, same single fp32 -> bf16 rounding,
-        # except the rounding is now the asynchronous ``grad_k.cast`` below and
-        # there is no barrier. ``zeros`` rather than ``empty`` is load-bearing --
-        # the kernel only accumulates, and on this sparse path nothing else
-        # zeroes the buffer. Same reason as the dense KL path
-        # (``dense_indexer_kl_cudnn.py``).
-        d_index_k=paddle.zeros(index_k_bf.shape, dtype=paddle.float32),
+    def _call(backend):
+        extra: dict = {}
+        if backend is not None:
+            extra["backend"] = backend
+            # The accumulator is fp32 on both backends, so a bf16 buffer would
+            # round the whole accuracy gain back to the bf16 representation
+            # floor -- with the buffer the wrapper allocates by default,
+            # ``d_weights`` measured 1.66e-03, identical to the generic backend.
+            # fp32 is only accepted on this backend; the generic one takes bf16
+            # alone. The trailing casts restore the caller's dtypes either way,
+            # so the buffer dtype stays an internal detail.
+            extra["d_weights"] = paddle.empty(
+                weights_bf.shape, dtype=paddle.float32
+            )
+            # This backend owns a per-plan workspace (a self-resetting ticket
+            # counter), so two executions of one plan must never be in flight on
+            # the device at once. That holds today because every launch lands on
+            # the calculation stream in issue order -- including under
+            # ``dsa_indexer_loss_bwd_p2p_overlap``, which defers the launch on
+            # the host and owns no side stream. Wrapping this call in a side
+            # stream or a CUDA-graph capture would break it *silently*: the
+            # ticket counter races and the gradients come out wrong with nothing
+            # raised.
+        return indexer_backward_wrapper(
+            index_q_bf,
+            weights_bf,
+            index_k_bf,
+            target_buf,
+            predict_buf,
+            topk_indices,
+            sm_scale=float(index_q_bf.shape[-1]) ** -0.5,
+            loss_coeff=float(loss_coeff),
+            grad_loss=grad_loss_paddle,
+            block_I=int(block_I),
+            # dK is reduced with fp32 atomics whatever the buffer dtype, so the
+            # dtype only selects *how* the result lands. Left to allocate its own
+            # bf16 buffer, the wrapper takes a branch ending in
+            # ``dIndexK.copy_(dIndexK_f32.astype(...))``, and Paddle's blocking
+            # ``copy_`` lowers to ``GpuMemcpySync`` on the CUDA *legacy default*
+            # stream -- a bidirectional full-device barrier, so every later
+            # kernel waits for whatever is in flight. Under
+            # ``dsa_indexer_loss_bwd_p2p_overlap`` that pushed the whole indexer
+            # projection backward out past the pipeline send/recv it was supposed
+            # to hide behind.
+            #
+            # A pre-zeroed fp32 buffer takes the wrapper's in-place path instead:
+            # same kernel, same fp32 atomicAdd, same single fp32 -> bf16
+            # rounding, except the rounding is now the asynchronous
+            # ``grad_k.cast`` below and there is no barrier. ``zeros`` rather
+            # than ``empty`` is load-bearing -- the kernel only accumulates, and
+            # on this sparse path nothing else zeroes the buffer. Same reason as
+            # the dense KL path (``dense_indexer_kl_cudnn.py``).
+            d_index_k=paddle.zeros(index_k_bf.shape, dtype=paddle.float32),
+            **extra,
+        )
+
+    backend = (
+        None
+        if _V2_REFUSED
+        else _select_backend(
+            int(index_q_bf.shape[-2]),
+            int(index_q_bf.shape[-1]),
+            int(topk_indices.shape[-1]),
+            int(block_I),
+        )
     )
+    if backend is None:
+        out = _call(None)
+    else:
+        try:
+            out = _call(backend)
+        except RuntimeError as exc:
+            if not _is_v2_device_refusal(exc):
+                raise
+            # The installed ``paddlefleet_ops`` can be older than the vendored
+            # cuDNN this checkout points at -- a stale wheel is the normal state
+            # between a submodule bump and a rebuild -- and then cuDNN's own gate
+            # is narrower than the one above. Fall back rather than abort the
+            # step; the gradients stay correct, only less accurate.
+            _latch_v2_refused()
+            logger.warning(
+                "cuDNN refused backend=%r for the sparse indexer backward "
+                "(%s); using the architecture-generic backend for the rest of "
+                "this process. Rebuild paddlefleet_ops against the vendored "
+                "cuDNN to get the higher-precision gradients.",
+                backend,
+                exc,
+            )
+            out = _call(None)
 
     grad_q = out["d_index_q"]
     grad_weights = out["d_weights"]

--- a/tests/single_card_tests/custom_ops/test_cudnn_dsa_indexer_bwd_backend.py
+++ b/tests/single_card_tests/custom_ops/test_cudnn_dsa_indexer_bwd_backend.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Automatic use of cuDNN's high-precision sparse indexer backward.
+
+There is no config switch: ``csa_indexer_bwd`` requests the v2 GEMM stage
+whenever the vendored cuDNN accepts it, because it is strictly more accurate.
+``_select_backend`` therefore carries the whole contract, and it fails quietly in
+both directions -- requesting outside cuDNN's envelope aborts the step (the
+backend is request-or-fail, it does not degrade to a slower kernel), while
+failing to request inside it silently keeps the old accuracy. So every condition
+is tested on both sides of its boundary, including the device family and a
+wrapper that predates the ``backend`` parameter.
+
+The rest pins the argument contract: an accepted call must hand cuDNN an fp32
+``d_weights`` buffer -- without it the fp32 accumulator is rounded straight back
+to the bf16 floor, which is what made an earlier version of this change a no-op
+on that output -- a rejected call must be argument-for-argument what it was
+before, and either way the caller gets its own dtypes back.
+
+Host-side only: the wrapper is mocked, so no cuDNN build and no kernel launch.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import paddle
+
+from paddlefleet.cudnn_ops.indexer import csa_indexer_bwd_cudnn as mod
+
+_API_PATH = (
+    "paddlefleet_ops.cudnn.deepseek_sparse_attention.indexer_backward.api"
+)
+_SM100 = (10, 0)
+_SM103 = (10, 3)
+
+
+def _with_backend(*args, backend="default", **kwargs):
+    """Stand-in for a cuDNN wrapper that accepts ``backend``."""
+    raise AssertionError("not meant to be called")
+
+
+def _without_backend(*args, **kwargs):
+    """Stand-in for a wheel that predates the vendored bump."""
+    raise AssertionError("not meant to be called")
+
+
+def _api(wrapper):
+    return type("_Api", (), {"indexer_backward_wrapper": staticmethod(wrapper)})
+
+
+class _Base(unittest.TestCase):
+    def setUp(self):
+        # Cached on shape; the device query and wrapper signature are ambient, so
+        # a decision cached under one patch would leak into the next test.
+        mod._select_backend.cache_clear()
+        self.addCleanup(mod._select_backend.cache_clear)
+        self._refused = mod._V2_REFUSED
+        mod._V2_REFUSED = False
+        self.addCleanup(lambda: setattr(mod, "_V2_REFUSED", self._refused))
+
+
+class TestSelectBackend(_Base):
+    """``_select_backend(heads, head_dim, topk, block_I)``."""
+
+    IN = (64, 128, 2048, 128)
+
+    def _select(self, args, capability=_SM100, wrapper=_with_backend):
+        with (
+            patch.dict("sys.modules", {_API_PATH: _api(wrapper)}),
+            patch.object(
+                paddle.device.cuda,
+                "get_device_capability",
+                lambda *a, **k: capability,
+            ),
+        ):
+            return mod._select_backend(*args)
+
+    def test_production_shape_selects_v2(self):
+        self.assertEqual(self._select(self.IN), "sm100_v2")
+
+    def test_sm100_family_all_qualify(self):
+        """The vendored cuDNN gates on the family, so SM103 qualifies too."""
+        for capability in (_SM100, _SM103, (10, 7)):
+            with self.subTest(capability=capability):
+                self.assertEqual(
+                    self._select(self.IN, capability=capability), "sm100_v2"
+                )
+
+    def test_other_families_do_not(self):
+        for capability in ((9, 0), (8, 0), (12, 0)):
+            with self.subTest(capability=capability):
+                self.assertIsNone(self._select(self.IN, capability=capability))
+
+    def test_wrapper_without_backend_parameter(self):
+        """Passing ``backend=`` to an older wrapper is a TypeError, not a fallback."""
+        self.assertIsNone(self._select(self.IN, wrapper=_without_backend))
+
+    def test_head_and_dim_specialization(self):
+        for heads, head_dim in ((32, 128), (128, 128), (64, 64), (64, 576)):
+            with self.subTest(heads=heads, head_dim=head_dim):
+                self.assertIsNone(self._select((heads, head_dim, 2048, 128)))
+
+    def test_block_i_must_be_128(self):
+        for block_I in (64, 256):
+            with self.subTest(block_I=block_I):
+                self.assertIsNone(self._select((64, 128, 2048, block_I)))
+
+    def test_topk_boundaries(self):
+        # 2048 fills the SM100 dynamic-smem budget exactly; 128 is the 1-tile floor.
+        for topk in (128, 256, 1024, 2048):
+            with self.subTest(inside=topk):
+                self.assertEqual(self._select((64, 128, topk, 128)), "sm100_v2")
+        for topk in (0, 64, 1000, 2176, 4096):
+            with self.subTest(outside=topk):
+                self.assertIsNone(self._select((64, 128, topk, 128)))
+
+
+class TestCall(_Base):
+    """What ``csa_indexer_bwd`` forwards, per selection outcome."""
+
+    B, S, H, D, TOPK, SCOMP = 1, 8, 64, 128, 2048, 8
+
+    def _inputs(self):
+        paddle.seed(7)
+        return {
+            "index_q": paddle.randn(
+                [self.B, self.S, self.H, self.D], dtype="float32"
+            ).cast("bfloat16"),
+            "weights": paddle.randn(
+                [self.B, self.S, self.H], dtype="float32"
+            ).cast("bfloat16"),
+            "index_k_comp": paddle.randn(
+                [self.B, self.SCOMP, self.D], dtype="float32"
+            ).cast("bfloat16"),
+            "target": paddle.nn.functional.softmax(
+                paddle.randn([self.B, self.S, self.TOPK], dtype="float32"),
+                axis=-1,
+            ),
+            "topk_probs": paddle.nn.functional.softmax(
+                paddle.randn([self.B, self.S, self.TOPK], dtype="float32"),
+                axis=-1,
+            ),
+            "topk_indices": paddle.zeros(
+                [self.B, self.S, self.TOPK], dtype="int32"
+            ),
+            "loss_coeff": 0.01,
+        }
+
+    def _outs(self, kwargs, echo=False):
+        dw = kwargs.get(
+            "d_weights",
+            paddle.zeros([self.B, self.S, self.H], dtype="bfloat16"),
+        )
+        dk = kwargs["d_index_k"]
+        return {
+            "d_index_q": paddle.zeros(
+                [self.B, self.S, self.H, self.D], dtype="bfloat16"
+            ),
+            "d_weights": dw,
+            "d_index_k": dk if echo else dk.cast("bfloat16"),
+        }
+
+    def _run(self, capability, inputs=None, echo=False, raise_on_v2=None):
+        seen = []
+
+        def wrapper(*args, backend="default", **kwargs):
+            seen.append((backend, args[3].clone(), args[4].clone(), kwargs))
+            if backend == "sm100_v2" and raise_on_v2 is not None:
+                raise raise_on_v2
+            return self._outs(kwargs, echo=echo)
+
+        with (
+            patch.dict("sys.modules", {_API_PATH: _api(wrapper)}),
+            patch.object(
+                paddle.device.cuda,
+                "get_device_capability",
+                lambda *a, **k: capability,
+            ),
+            patch.object(mod, "_require_cudnn_frontend", lambda: None),
+        ):
+            grads = mod.csa_indexer_bwd(**(inputs or self._inputs()))
+        return seen, grads
+
+    def test_accepted_call_passes_backend_and_fp32_d_weights(self):
+        for capability in (_SM100, _SM103):
+            with self.subTest(capability=capability):
+                mod._select_backend.cache_clear()
+                seen, _ = self._run(capability)
+                self.assertEqual(len(seen), 1)
+                backend, _, _, kwargs = seen[0]
+                self.assertEqual(backend, "sm100_v2")
+                self.assertEqual(kwargs["d_weights"].dtype, paddle.float32)
+                self.assertEqual(
+                    list(kwargs["d_weights"].shape),
+                    [self.B, self.S, self.H],
+                )
+                # fp32 d_index_k predates this change and must stay fp32.
+                self.assertEqual(kwargs["d_index_k"].dtype, paddle.float32)
+
+    def test_rejected_call_is_unchanged(self):
+        """The pre-existing call: no ``backend=``, no ``d_weights`` buffer."""
+        seen, _ = self._run((9, 0))
+        self.assertEqual(len(seen), 1)
+        self.assertEqual(seen[0][0], "default")
+        self.assertNotIn("d_weights", seen[0][3])
+        self.assertEqual(seen[0][3]["d_index_k"].dtype, paddle.float32)
+
+    def test_shape_outside_envelope_is_also_unchanged(self):
+        inputs = self._inputs()
+        # 1000 is not a multiple of 128, so the envelope rejects it.
+        for key in ("target", "topk_probs", "topk_indices"):
+            inputs[key] = inputs[key][..., :1000].contiguous()
+        seen, _ = self._run(_SM103, inputs=inputs)
+        self.assertEqual(seen[0][0], "default")
+        self.assertNotIn("d_weights", seen[0][3])
+
+    def test_caller_dtypes_are_restored(self):
+        """The fp32 buffers are internal: bf16 in, bf16 out."""
+        _, (grad_q, grad_weights, grad_k) = self._run(_SM103, echo=True)
+        self.assertEqual(grad_q.dtype, paddle.bfloat16)
+        self.assertEqual(grad_weights.dtype, paddle.bfloat16)
+        self.assertEqual(grad_k.dtype, paddle.bfloat16)
+        self.assertEqual(list(grad_weights.shape), [self.B, self.S, self.H])
+
+    def test_device_refusal_falls_back_with_intact_buffers(self):
+        """A stale wheel refuses; the retry must see byte-identical score buffers.
+
+        cuDNN raises this from ``check_support`` / ``compile``, both before
+        ``execute`` consumes the buffers, which is what makes the retry exact.
+        """
+        refusal = RuntimeError(
+            "backend='sm100_v2' requires an SM100 device (capability (10, 0)); "
+            "the plan device reports (10, 3) (use backend='default' on non-SM100)"
+        )
+        seen, grads = self._run(_SM103, raise_on_v2=refusal)
+        self.assertEqual([s[0] for s in seen], ["sm100_v2", "default"])
+        for i in (1, 2):
+            self.assertTrue(
+                bool(
+                    (
+                        seen[0][i].cast("float32") == seen[1][i].cast("float32")
+                    ).all()
+                ),
+                f"score buffer {i} differed between attempt and retry",
+            )
+        self.assertNotIn("d_weights", seen[1][3])
+        self.assertEqual(len(grads), 3)
+        self.assertTrue(mod._V2_REFUSED)
+
+    def test_factory_refusal_is_also_recognised(self):
+        refusal = RuntimeError(
+            "indexer_backward_v2_sm100 requires SM100; "
+            "use backend='default' elsewhere"
+        )
+        seen, _ = self._run(_SM103, raise_on_v2=refusal)
+        self.assertEqual([s[0] for s in seen], ["sm100_v2", "default"])
+
+    def test_other_runtime_errors_propagate(self):
+        """The narrow match: a real failure must not be downgraded to a fallback.
+
+        Anything raised after kernel 1 has overwritten ``attn_score`` would make
+        a retry silently wrong, so only the two device refusals are caught.
+        """
+        for exc in (
+            RuntimeError(
+                "CUDA error: an illegal memory access was encountered"
+            ),
+            RuntimeError("cuTe compilation failed"),
+            ValueError("d_weights must be bfloat16"),
+        ):
+            with self.subTest(exc=type(exc).__name__ + ": " + str(exc)[:24]):
+                mod._select_backend.cache_clear()
+                mod._V2_REFUSED = False
+                with self.assertRaises(type(exc)):
+                    self._run(_SM103, raise_on_v2=exc)
+                self.assertFalse(mod._V2_REFUSED)
+
+    def test_refusal_is_latched_for_the_process(self):
+        refusal = RuntimeError("backend='sm100_v2' requires an SM100 device")
+        seen1, _ = self._run(_SM103, raise_on_v2=refusal)
+        seen2, _ = self._run(_SM103, raise_on_v2=refusal)
+        self.assertEqual([s[0] for s in seen1], ["sm100_v2", "default"])
+        self.assertEqual([s[0] for s in seen2], ["default"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Improvements

### Description

Two changes that only make sense together.

**Vendor cuDNN `3e27c995`** (`packages/paddlefleet_ops/third_party/cudnn-frontend`,
`6956336f` -> `3e27c995`, PFCCLab `paddle/v1.28.0`). The only delta is
`PFCCLab/cudnn-frontend#14`, which widens the two capability gates on the v2
sparse indexer backward from an exact `(10, 0)` to the SM100 family
(`capability[0] == 10`). The narrow gates refused SM103 parts even though the DSA
compile path already targets `sm_103a` (`utils/compiler.py::_ARCH_MAP`) and the
kernel runs there correctly, and sibling code in that repository already treats
SM103 as SM100-family (`sdpa/fwd/api_dsl.py`'s `_allowed_cc`,
`linear_attention/frost/engine.py`'s "SM100-SM103 or SM107"). Nothing else in the
submodule moves: the two pinned trees differ only in those gates and the test
helper that skipped the v2 suite outside `(10, 0)`.

**Reach the backend from PaddleFleet.** cuDNN 1.28's second GEMM stage for this
kernel keeps kernel 1 (the score-grad precompute) verbatim and replaces the GEMM:
`weights` are upcast to fp32 exactly, the per-slot gradient matrix
`A = grad_signal * weights` is split into a two-term bf16 expansion before the
MMA, and `d_weights` is reduced deterministically in-CTA. `csa_indexer_bwd` never
passed `backend=`, so it was unreachable. It is strictly more accurate, so there
is no switch: the backend is requested whenever the vendored cuDNN accepts it.

Measured on an SM103 part, `S=8192 H=64 D=128 topk=2048`, relative L2 against an
fp64 evaluation of the kernel's documented contract -- taken from the grad_signal
the generic backend leaves in `attn_score`, so the shared kernel 1 is factored out
and only the GEMM stage is judged:

| output | generic | v2 |
|---|---|---|
| `d_index_q` (bf16) | 2.321e-03 | 1.659e-03 |
| `d_weights` | 1.655e-03 (bf16) | 1.697e-07 (fp32) |
| `d_index_k` (fp32) | 1.517e-03 | 1.207e-05 |

The `d_weights` row is why the selected path also hands cuDNN an fp32
`d_weights` buffer. The accumulator is fp32 on both backends, so the bf16 buffer
the wrapper allocates by default rounds the entire gain back to the bf16
representation floor: with it, `d_weights` measured 1.655e-03, i.e. identical to
the generic backend. fp32 is only accepted on this backend, and the trailing
`grad_weights.cast` restores the caller's dtype, so the buffer dtype stays an
internal detail.

The cost is speed, and only at the top of the topk range: the two-term expansion
doubles the GEMM work, so it wins where the GEMM does not dominate and loses
where it does. Swept on an idle SM103 part at the shape above, min of 3
alternating rounds of 20 iterations, spread within a round under 1.5%:

| topk | generic | v2 | speedup |
|---|---|---|---|
| 128 | 0.457 ms | 0.293 ms | 1.559x |
| 256 | 0.643 ms | 0.537 ms | 1.197x |
| 512 | 0.909 ms | 0.879 ms | 1.035x |
| 1024 | 1.550 ms | 1.579 ms | 0.982x |
| 2048 | 2.910 ms | 2.984 ms | 0.975x |

The crossover sits between 512 and 1024, so a `topk=2048` configuration pays
about 2.5% on this one kernel. That is deliberately not gated on topk: two orders
of magnitude on `d_index_k` is worth 2.5% of one backward kernel, and a
topk-dependent backend would make the numerics a function of the sequence budget,
which is harder to reason about than a uniform 2.5%.

`_select_backend` mirrors the vendored cuDNN's envelope -- the `backend`
parameter must exist on the installed wrapper, capability major 10, `H == 64`,
`D == 128`, `block_I == 128`, `topk % 128 == 0` with `128 <= topk <= 2048` -- and
is `lru_cache`d on the shape because it would otherwise re-run on every indexer
backward of every layer. Requesting outside the envelope aborts the step rather
than selecting a slower kernel, which is why the predicate is evaluated up front
instead of caught.

One case cannot be settled up front: **an installed `paddlefleet_ops` older than
this checkout's submodule**, which is the normal state between a bump and a
rebuild. Its cuDNN still has the narrow gate, so it refuses an SM103 device that
the predicate above accepts. That refusal is caught -- narrowly. cuDNN has no
dedicated exception type, so the two refusal messages are matched by substring;
both fire strictly before `execute` (`check_support` at plan construction, and the
kernel factory from `compile`, api.py:475 inside `compile` at :457 while `execute`
starts at :534), so the score buffers are untouched and the retry on the generic
backend is exact rather than approximate. Everything else propagates: catching
`RuntimeError` broadly would also swallow a compile or launch failure raised
*after* kernel 1 had overwritten `attn_score` with the grad signal, and the retry
would then compute gradients from a consumed buffer -- silently wrong, with the
real error permanently downgraded. The refusal is latched so it costs one plan
construction per process, and logged once.

Two consequences worth stating, since neither is visible from the diff:

* **The numerical trajectory changes** wherever the backend is selected. No
  checkpoint format, parameter or `state_dict` key changes -- this is a
  gradient-precision change on the indexer's own five weights per layer, and the
  backbone receives `grad_output` untouched -- but loss curves are no longer
  bit-comparable across this commit.
* **`d_index_k` stays non-deterministic** on both backends (fp32 atomics either
  way). The v2 determinism claim covers `d_weights` and `d_index_q` only, so
  "deterministic v2" must not be read as "bitwise reproducible step".

Tests: `tests/single_card_tests/custom_ops/test_cudnn_dsa_indexer_bwd_backend.py`
(15 tests / 26 subtests, host-side, wrapper mocked, no cuDNN build needed) covers
every envelope condition on both sides of its boundary -- including the device
family, so SM100/SM103/SM107 select and SM90/SM120 do not, and a wrapper that
predates the `backend` parameter -- plus the argument contract (accepted calls
carry `backend=` and an fp32 `d_weights`; rejected calls are argument-for-argument
what they were before; the caller's dtypes come back unchanged) and the fallback:
both refusal messages fall back with the score buffers verified byte-identical to
the first attempt, the refusal latches so the next step does not re-attempt, and
three non-refusal errors (illegal memory access, compile failure, a `ValueError`)
propagate instead of being downgraded.

Existing suites re-run green on an SM103 part against a version-matched tree:
`test_cudnn_dsa_indexer_bwd` 35, `test_cudnn_dsa_indexer_fwd` 29,
`test_cudnn_dsa_indexer_topk_column_mask` 9 + 120 subtests,
`test_cudnn_dsa_indexer_shape_guard` 8, `test_indexer_loss_overlap` 64 + 22
subtests.
