### PR TITLE
[MTP] Slice erndata MTP tensors with the model's cp_balance_mode

### DIFF
--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -521,7 +521,8 @@ class LanguageLoss(FleetLayer):
         rolls labels_ori left ``depth + 1`` times, filling ``ignored_index`` at
         every packed-document boundary (via the stashed cu_seqlens_q) so the
         boundary token is excluded from the loss. Under CP>1 this rank's local
-        zigzag chunk is extracted so the label shape matches the local logits.
+        CP slice is extracted (per config.cp_balance_mode) so the label shape
+        matches the local logits.
 
         Mirrors the megatron branch of ``LanguageLoss.forward`` so the separate
         Main/MTP head-loss path stays consistent with the fused path.
@@ -554,14 +555,15 @@ class LanguageLoss(FleetLayer):
         if get_context_parallel_world_size() > 1:
             from paddlefleet.parallel_state import get_context_parallel_rank
             from paddlefleet.transformer.multi_token_prediction import (
-                extract_local_zigzag_chunks,
+                extract_local_cp_chunks,
             )
 
-            _lbl = extract_local_zigzag_chunks(
+            _lbl = extract_local_cp_chunks(
                 _lbl,
                 get_context_parallel_rank(),
                 get_context_parallel_world_size(),
                 axis=1,
+                mode=self.config.cp_balance_mode,
             )
         return _lbl
 
@@ -582,19 +584,26 @@ class LanguageLoss(FleetLayer):
             # left by (depth+1) positions with -100 fill at the tail.
             _mtp_is_megatron = getattr(self.config, "use_erndata", False)
             # Under CP>1 the megatron path keeps labels_ori full-length on
-            # every rank. Local zigzag chunks must be extracted here so that
-            # shape matches the local logits produced by the embedding branch.
+            # every rank. The rank-local slice must be extracted here so that
+            # shape matches the local logits produced by the embedding branch,
+            # using the model's own CP layout (config.cp_balance_mode).
             _cp_size_for_extract = (
                 get_context_parallel_world_size() if _mtp_is_megatron else 1
             )
             if _cp_size_for_extract > 1:
+                from functools import partial
+
                 from paddlefleet.parallel_state import (
                     get_context_parallel_rank as _get_cp_rank,
                 )
                 from paddlefleet.transformer.multi_token_prediction import (
-                    extract_local_zigzag_chunks as _extract_cp,
+                    extract_local_cp_chunks,
                 )
 
+                _extract_cp = partial(
+                    extract_local_cp_chunks,
+                    mode=self.config.cp_balance_mode,
+                )
                 _cp_rank_for_extract = _get_cp_rank()
             else:
                 _extract_cp = None
@@ -602,7 +611,7 @@ class LanguageLoss(FleetLayer):
             if _mtp_is_megatron:
                 lm_labels = labels_ori
                 if _cp_size_for_extract > 1:
-                    # Extract this rank's local zigzag chunks from full-length labels.
+                    # Extract this rank's local CP slice from full-length labels.
                     lm_labels = _extract_cp(
                         lm_labels,
                         _cp_rank_for_extract,
@@ -674,7 +683,7 @@ class LanguageLoss(FleetLayer):
                             )
                         if _cp_size_for_extract > 1:
                             # Match local logits shape by extracting this
-                            # rank's zigzag chunks.
+                            # rank's CP slice.
                             _lbl = _extract_cp(
                                 _lbl,
                                 _cp_rank_for_extract,
@@ -698,7 +707,7 @@ class LanguageLoss(FleetLayer):
                             # In EB data flow and CP size > 1, since we do not use _forward
                             # we need to scatter labels to cp local here.
                             # Under use_erndata=True labels_cur_depth is
-                            # already local zigzag chunks (extract_local_zigzag_chunks
+                            # already the local CP slice (extract_local_cp_chunks
                             # above), so skip the scatter to avoid double-scatter.
                             labels_cur_depth = ContextParallelScatterOp.apply(
                                 labels_cur_depth,

--- a/src/paddlefleet/models/gpt/gpt_embedding.py
+++ b/src/paddlefleet/models/gpt/gpt_embedding.py
@@ -335,7 +335,7 @@ class GPTEmbedding(FleetLayer):
         deepstack_visual_embeds = None
         visual_pos_mask = None
         mtp_emb_res = None
-        # CP zigzag context of the use_erndata MTP branch below.
+        # CP slicing context of the use_erndata MTP branch below.
         # The branch slices the embeddings itself (no ContextParallelScatterOp,
         # which is gated on experimental_dataflow and therefore never runs for
         # this style), so the RoPE tables have to be sliced with the very same
@@ -433,8 +433,8 @@ class GPTEmbedding(FleetLayer):
                 # place with per-doc boundary zero-fill via cu_seqlens_q.
                 # Under CP>1, each rank holds the full-length embedding (per
                 # PaddleFleet dataloader broadcast) and slices its own
-                # zigzag chunks via extract_local_zigzag_chunks — no
-                # ContextParallelScatterOp needed.
+                # local slice via extract_local_cp_chunks (layout follows
+                # config.cp_balance_mode) — no ContextParallelScatterOp needed.
                 # The ernie5 (default) path in the ``else`` below retains
                 # upstream develop's full logic, including multimodal + MTP.
                 # ------------------------------------------------------------
@@ -444,7 +444,7 @@ class GPTEmbedding(FleetLayer):
                     )
                     from paddlefleet.transformer.multi_token_prediction import (
                         build_startend_row_indices_from_cu_seqlens,
-                        extract_local_zigzag_chunks,
+                        extract_local_cp_chunks,
                         roll_tensor,
                     )
 
@@ -487,10 +487,16 @@ class GPTEmbedding(FleetLayer):
                     mtp_megatron_cp_size = _cp_size
                     mtp_megatron_cp_rank = _cp_rank
 
-                    # Main embedding: [B, L, H] → [B, L/cp_size, H] via zigzag.
+                    # Main embedding: [B, L, H] → [B, L/cp_size, H] with the
+                    # model's own CP layout (zigzag for dualchunk_allgather,
+                    # contiguous slice for contiguous_allgather).
                     if _cp_size > 1:
-                        inputs_embeds = extract_local_zigzag_chunks(
-                            inputs_embeds_ori, _cp_rank, _cp_size, axis=1
+                        inputs_embeds = extract_local_cp_chunks(
+                            inputs_embeds_ori,
+                            _cp_rank,
+                            _cp_size,
+                            axis=1,
+                            mode=self.config.cp_balance_mode,
                         )
                     else:
                         inputs_embeds = inputs_embeds_ori
@@ -514,7 +520,7 @@ class GPTEmbedding(FleetLayer):
                     # Cumulative rolls: depth k uses decoder_input rolled by
                     # (k+1) positions. Roll on the full-length float embedding
                     # (identical on every CP rank), then extract this rank's
-                    # zigzag chunks — avoids a ContextParallelScatterOp per depth.
+                    # local slice — avoids a ContextParallelScatterOp per depth.
                     rolled_embed = inputs_embeds_ori
                     for depth in range(self.config.num_nextn_predict_layers):
                         rolled_embed, _ = roll_tensor(
@@ -526,8 +532,12 @@ class GPTEmbedding(FleetLayer):
                         )
 
                         if _cp_size > 1:
-                            inputs_embeds_mtp = extract_local_zigzag_chunks(
-                                rolled_embed, _cp_rank, _cp_size, axis=1
+                            inputs_embeds_mtp = extract_local_cp_chunks(
+                                rolled_embed,
+                                _cp_rank,
+                                _cp_size,
+                                axis=1,
+                                mode=self.config.cp_balance_mode,
                             )
                         else:
                             inputs_embeds_mtp = rolled_embed
@@ -758,28 +768,29 @@ class GPTEmbedding(FleetLayer):
         swa_rotary_pos_sin = None
 
         def _slice_rope_for_mtp_megatron_cp(rope_table):
-            """Zigzag-slice a RoPE table for use_erndata + CP > 1.
+            """Slice a RoPE table for use_erndata + CP > 1.
 
             ``RotaryEmbedding.get_rotary_seq_len`` scales the rank-local input
             length back up by ``cp_group.world_size``, so the tables below are
             always built for the FULL sequence length L while the hidden states
-            this rank carries are its two zigzag chunks. The generic
+            this rank carries are its local slice. The generic
             ``ContextParallelScatterOp`` further down only runs for
             ``experimental_dataflow``, which megatron style forbids, so the
             slicing has to happen here -- with exactly the layout the megatron
-            MTP branch used for the embeddings.
+            MTP branch used for the embeddings (``config.cp_balance_mode``).
             """
             if mtp_megatron_cp_size == 1 or rope_table is None:
                 return rope_table
             from paddlefleet.transformer.multi_token_prediction import (
-                extract_local_zigzag_chunks,
+                extract_local_cp_chunks,
             )
 
-            return extract_local_zigzag_chunks(
+            return extract_local_cp_chunks(
                 rope_table,
                 mtp_megatron_cp_rank,
                 mtp_megatron_cp_size,
                 axis=1,
+                mode=self.config.cp_balance_mode,
             )
 
         # For MTP mode: truncate position_ids to match the actual sequence length
@@ -793,8 +804,8 @@ class GPTEmbedding(FleetLayer):
             # erndata keeps the main decoder at the full length L (the
             # per-doc shift happens inside the MTP layer), so position_ids
             # already matches. Under CP mtp_emb_res[0] is the rank-local
-            # zigzag slice, whose length must not be mistaken for L - K: a
-            # contiguous prefix of position_ids is not this rank's chunk.
+            # CP slice, whose length must not be mistaken for L - K (and
+            # under dualchunk a prefix of position_ids is not this rank's chunk).
             and not getattr(self.config, "use_erndata", False)
         ):
             # mtp_emb_res[0] has shape [B, seq_len - num_nextn_predict_layers, H]

--- a/src/paddlefleet/models/gpt/gpt_model.py
+++ b/src/paddlefleet/models/gpt/gpt_model.py
@@ -388,9 +388,14 @@ class GPTModel(PipelineLayer):
 
         if spec.mtp:
             for mtp_spec in spec.mtp:
-                if self.config.enable_mtp_magic_send:
-                    desc = LayerDesc(mtp_spec)
-                elif getattr(self.config, "mtp_shared_last_layer", False):
+                # NOTE: test mtp_shared_last_layer FIRST. It used to sit behind
+                # an `enable_mtp_magic_send` branch that short-circuited to a
+                # plain LayerDesc, which meant that with both flags on the tie
+                # silently did nothing. The two are orthogonal: magic send owns
+                # `mtp_embed` (synced via _mtp_embed_global_group below) while
+                # SharedLayerDesc(shared_submodule_weight_only=True) aliases
+                # only the params under `transformer_layer`.
+                if getattr(self.config, "mtp_shared_last_layer", False):
                     desc = SharedLayerDesc(
                         "mtp_reuse_transformer",
                         mtp_spec,

--- a/src/paddlefleet/models/gpt/gpt_model.py
+++ b/src/paddlefleet/models/gpt/gpt_model.py
@@ -399,7 +399,11 @@ class GPTModel(PipelineLayer):
                 #
                 # The pivot for this key is emitted above, on the last backbone
                 # TransformerLayer; aliasing needs both on the same rank (see the
-                # co-location note in transformer_config.py).
+                # co-location note in transformer_config.py). All K descs reuse
+                # the one key, so at K > 1 an off-stage pivot aborts the build
+                # rather than degrading to broadcast -- depth 0 becomes the stored
+                # shared layer and depth 1 aliases against its
+                # `transformer_layer.`-prefixed names.
                 if getattr(self.config, "mtp_shared_last_layer", False):
                     desc = SharedLayerDesc(
                         "mtp_reuse_transformer",

--- a/src/paddlefleet/models/gpt/gpt_model.py
+++ b/src/paddlefleet/models/gpt/gpt_model.py
@@ -390,11 +390,19 @@ class GPTModel(PipelineLayer):
             for mtp_spec in spec.mtp:
                 # NOTE: test mtp_shared_last_layer FIRST. It used to sit behind
                 # an `enable_mtp_magic_send` branch that short-circuited to a
-                # plain LayerDesc, which meant that with both flags on the tie
-                # silently did nothing. The two are orthogonal: magic send owns
-                # `mtp_embed` (synced via _mtp_embed_global_group below) while
-                # SharedLayerDesc(shared_submodule_weight_only=True) aliases
-                # only the params under `transformer_layer`.
+                # plain LayerDesc, so with both flags on the tie silently did
+                # nothing. That was only reachable under `python -O` (the
+                # combination was assert-rejected in TransformerConfig, and
+                # asserts are stripped there), but the rejection is gone now, so
+                # the order matters for real. The two are orthogonal: magic send
+                # owns `mtp_embed` (synced via _mtp_embed_global_group below)
+                # while SharedLayerDesc(shared_submodule_weight_only=True)
+                # aliases only the params under `transformer_layer`.
+                #
+                # The pivot for this key is emitted above, on the last backbone
+                # TransformerLayer. Aliasing needs both on the same rank; see the
+                # co-location note in transformer_config.py for what happens when
+                # a PP boundary splits them.
                 if getattr(self.config, "mtp_shared_last_layer", False):
                     desc = SharedLayerDesc(
                         "mtp_reuse_transformer",

--- a/src/paddlefleet/models/gpt/gpt_model.py
+++ b/src/paddlefleet/models/gpt/gpt_model.py
@@ -388,21 +388,18 @@ class GPTModel(PipelineLayer):
 
         if spec.mtp:
             for mtp_spec in spec.mtp:
-                # NOTE: test mtp_shared_last_layer FIRST. It used to sit behind
-                # an `enable_mtp_magic_send` branch that short-circuited to a
-                # plain LayerDesc, so with both flags on the tie silently did
-                # nothing. That was only reachable under `python -O` (the
-                # combination was assert-rejected in TransformerConfig, and
-                # asserts are stripped there), but the rejection is gone now, so
-                # the order matters for real. The two are orthogonal: magic send
-                # owns `mtp_embed` (synced via _mtp_embed_global_group below)
-                # while SharedLayerDesc(shared_submodule_weight_only=True)
-                # aliases only the params under `transformer_layer`.
+                # NOTE: test mtp_shared_last_layer FIRST. It used to sit behind an
+                # `enable_mtp_magic_send` branch that short-circuited to a plain
+                # LayerDesc, so with both flags on the tie silently did nothing.
+                # The two are orthogonal -- magic send owns `mtp_embed` (synced
+                # via _mtp_embed_global_group below) while SharedLayerDesc(
+                # shared_submodule_weight_only=True) aliases only the params
+                # under `transformer_layer` -- and TransformerConfig no longer
+                # rejects the combination, so the order matters for real.
                 #
                 # The pivot for this key is emitted above, on the last backbone
-                # TransformerLayer. Aliasing needs both on the same rank; see the
-                # co-location note in transformer_config.py for what happens when
-                # a PP boundary splits them.
+                # TransformerLayer; aliasing needs both on the same rank (see the
+                # co-location note in transformer_config.py).
                 if getattr(self.config, "mtp_shared_last_layer", False):
                     desc = SharedLayerDesc(
                         "mtp_reuse_transformer",

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -1532,18 +1532,23 @@ class TopKRouter(StandardMoERouter):
                 # erndata MTP path: PaddleFleet dataloader broadcasts
                 # input_ids full-length [B, L] to every CP rank (unlike
                 # experimental_dataflow which pre-scatters). Embedding was
-                # already zigzag-sliced to [B, L/cp, H] via
-                # extract_local_zigzag_chunks (see gpt_embedding.py). Slice
-                # input_ids to the matching zigzag chunks here — no comm
-                # needed since every rank holds the same [B, L] tensor.
+                # already sliced to [B, L/cp, H] with the model's
+                # cp_balance_mode layout via extract_local_cp_chunks (see
+                # gpt_embedding.py). Slice input_ids with the same layout here
+                # — no comm needed since every rank holds the same [B, L]
+                # tensor.
                 from paddlefleet.transformer.multi_token_prediction import (
-                    extract_local_zigzag_chunks,
+                    extract_local_cp_chunks,
                 )
 
                 _cp_size = get_context_parallel_world_size()
                 _cp_rank = get_context_parallel_rank()
-                input_ids = extract_local_zigzag_chunks(
-                    input_ids, _cp_rank, _cp_size, axis=1
+                input_ids = extract_local_cp_chunks(
+                    input_ids,
+                    _cp_rank,
+                    _cp_size,
+                    axis=1,
+                    mode=self.config.cp_balance_mode,
                 )
             if input_ids is not None:
                 pad_token_id = getattr(self.config, "pad_token_id", 0)

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -351,6 +351,87 @@ def extract_local_zigzag_chunks(tensor_full, cp_rank, cp_size, axis=1):
     return paddle.concat([chunk_start, chunk_end], axis=dim)
 
 
+def extract_local_contiguous_chunk(tensor_full, cp_rank, cp_size, axis=1):
+    """Extract this CP rank's contiguous chunk from a full-length tensor.
+
+    Mirrors PaddleFleet's ``scatter_contiguous`` layout
+    (``context_parallel_utils.py:402-430``): rank ``r`` owns exactly one slice
+    ``tensor_full[..., chunk*r : chunk*(r+1), ...]`` with ``chunk = L / cp_size``.
+
+    Extraction only — no CP communication, same contract as
+    ``extract_local_zigzag_chunks``.
+    """
+    if cp_size == 1:
+        return tensor_full
+    ndim = tensor_full.dim()
+    dim = axis if axis >= 0 else ndim + axis
+    seq_len = tensor_full.shape[dim]
+    if seq_len % cp_size != 0:
+        raise ValueError(
+            f"extract_local_contiguous_chunk: seq_len={seq_len} on axis={axis} "
+            f"is not divisible by cp_size={cp_size}."
+        )
+    chunk = seq_len // cp_size
+    return paddle.slice(
+        tensor_full,
+        axes=[dim],
+        starts=[chunk * cp_rank],
+        ends=[chunk * (cp_rank + 1)],
+    )
+
+
+def extract_local_cp_chunks(
+    tensor_full, cp_rank, cp_size, axis=1, mode="dualchunk_allgather"
+):
+    """Layout-aware local-slice extraction for the ``use_erndata`` MTP path.
+
+    The erndata MTP path keeps int/float tensors full-length on every CP rank
+    and slices them locally instead of calling ``ContextParallelScatterOp``
+    (which would redo the embedding lookup ``cp_size`` times). That slice has to
+    use *exactly* the layout the rest of the model uses for its own scatter,
+    i.e. ``config.cp_balance_mode``:
+
+    * ``dualchunk_allgather``  -> ``scatter_balance``      -> two zigzag chunks
+    * ``contiguous_allgather`` -> ``scatter_contiguous``   -> one contiguous chunk
+
+    ``contiguous_allgather`` is not optional for every model: the DSv4 hybrid
+    attention stack (``dsv4_hybrid_attention.py``, ``mqa_latent_attention.py``)
+    builds its sparse-attention index tables over the *global* sequence and then
+    row-slices this rank's queries, which is only correct under the contiguous
+    layout — those layers assert on it under CP. So the MTP path must follow the
+    model's mode rather than hard-coding zigzag.
+
+    Args:
+        tensor_full: ``[..., L, ...]`` full-length tensor present on every rank.
+        cp_rank: this rank's index inside the CP group.
+        cp_size: CP world size; ``1`` returns ``tensor_full`` unchanged.
+        axis: sequence axis (default 1 for ``[B, L, ...]``).
+        mode: ``config.cp_balance_mode``.
+
+    Returns:
+        ``[..., L / cp_size, ...]`` tensor holding this rank's slice.
+    """
+    if cp_size == 1:
+        return tensor_full
+    if mode == "dualchunk_allgather":
+        return extract_local_zigzag_chunks(
+            tensor_full, cp_rank, cp_size, axis=axis
+        )
+    if mode == "contiguous_allgather":
+        return extract_local_contiguous_chunk(
+            tensor_full, cp_rank, cp_size, axis=axis
+        )
+    # contiguous_a2a (Ulysses) splits the *head* axis inside the attention and
+    # never round-trips through scatter_contiguous at the sequence level, so its
+    # local-slice layout is not established here. Fail loudly instead of
+    # guessing: a wrong layout is a silent-wrong-loss bug.
+    raise ValueError(
+        f"extract_local_cp_chunks: unsupported cp_balance_mode={mode!r} for the "
+        "use_erndata MTP path; expected 'dualchunk_allgather' or "
+        "'contiguous_allgather'."
+    )
+
+
 def build_startend_row_indices_from_cu_seqlens(
     cu_seqlens_q, batch_size, include_position_axis=False, seq_len=None
 ):
@@ -1268,6 +1349,10 @@ class MultiTokenPredictionLayer(FleetLayer):
         # and no L+K token concatenation; instead we shift input_ids /
         # position_ids / labels / loss_mask inside this layer via
         # roll_tensor(cu_seqlens_q=...).
+        #
+        # enable_mtp_magic_send cannot reach here under erndata: TransformerConfig
+        # refuses the combination outright (see the rejection in
+        # transformer_config.py for why it buys nothing on this path).
         if getattr(self.config, "use_erndata", False):
             return self._forward_megatron_style(dict_args)
 
@@ -1381,7 +1466,12 @@ class MultiTokenPredictionLayer(FleetLayer):
                         mtp_input_embeds, input_ids == pad_token_id, 0
                     )
 
-                # Shifted embedding slice for current depth
+                # Shifted embedding slice for current depth. This is the L+K
+                # contract: input_ids is longer than the backbone sequence, so
+                # depth d's embedding is a window offset by d+1. erndata carries
+                # length-L tensors and would need per-document rolls instead,
+                # which is one of the reasons TransformerConfig refuses
+                # use_erndata + enable_mtp_magic_send.
                 decoder_input = mtp_input_embeds[
                     :, (depth + 1) : (depth + 1 + seq_len), :
                 ]

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -373,6 +373,12 @@ def extract_local_contiguous_chunk(tensor_full, cp_rank, cp_size, axis=1):
             f"is not divisible by cp_size={cp_size}."
         )
     chunk = seq_len // cp_size
+    # Deliberately a bare slice, unlike scatter_contiguous's paddle.assign: the
+    # per-depth caller keeps only this result, so a view holds F while a copy
+    # holds F + F/cp until the source is freed. Measured peaks over the roll
+    # loop are (2K+1)F for views vs 2F + K*F + (K+1)F/cp for assign -- worse at
+    # K=1 (every erndata model config here), even at K=3. The dominant term in
+    # both is roll_tensor's own grad-node retention, which neither changes.
     return paddle.slice(
         tensor_full,
         axes=[dim],

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -355,8 +355,10 @@ def extract_local_contiguous_chunk(tensor_full, cp_rank, cp_size, axis=1):
     """Extract this CP rank's contiguous chunk from a full-length tensor.
 
     Mirrors PaddleFleet's ``scatter_contiguous`` layout
-    (``context_parallel_utils.py:402-430``): rank ``r`` owns exactly one slice
-    ``tensor_full[..., chunk*r : chunk*(r+1), ...]`` with ``chunk = L / cp_size``.
+    (``context_parallel_utils.scatter_contiguous``): rank ``r`` owns exactly one
+    slice ``tensor_full[..., chunk*r : chunk*(r+1), ...]`` with
+    ``chunk = L / cp_size``. ``test_extract_local_cp_chunks.py`` pins that parity
+    against the real scatter helper, so a layout change there fails here.
 
     Extraction only — no CP communication, same contract as
     ``extract_local_zigzag_chunks``.
@@ -380,9 +382,7 @@ def extract_local_contiguous_chunk(tensor_full, cp_rank, cp_size, axis=1):
     )
 
 
-def extract_local_cp_chunks(
-    tensor_full, cp_rank, cp_size, axis=1, mode="dualchunk_allgather"
-):
+def extract_local_cp_chunks(tensor_full, cp_rank, cp_size, axis=1, *, mode):
     """Layout-aware local-slice extraction for the ``use_erndata`` MTP path.
 
     The erndata MTP path keeps int/float tensors full-length on every CP rank
@@ -406,7 +406,11 @@ def extract_local_cp_chunks(
         cp_rank: this rank's index inside the CP group.
         cp_size: CP world size; ``1`` returns ``tensor_full`` unchanged.
         axis: sequence axis (default 1 for ``[B, L, ...]``).
-        mode: ``config.cp_balance_mode``.
+        mode: ``config.cp_balance_mode``. Keyword-only and required *on purpose*.
+            The bug this function exists to fix was a call site that assumed a
+            layout instead of reading the config, so a default here would just
+            re-open that door for the next caller: picking the wrong layout is
+            not a crash, it is a silently wrong loss.
 
     Returns:
         ``[..., L / cp_size, ...]`` tensor holding this rank's slice.

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -439,10 +439,10 @@ def extract_local_cp_chunks(tensor_full, cp_rank, cp_size, axis=1, *, mode):
     # is unknown: ContextParallelScatterOp dispatches on
     # mode.startswith("contiguous"), so a2a shards the sequence contiguously and
     # extract_local_contiguous_chunk would be the matching slice. What differs
-    # is the attention-side mask contract (dot_product_attention.py:532 skips
-    # the CP row-index expansion under a2a), and that has not been validated on
-    # this path. Fail loudly instead of assuming: a wrong layout is a
-    # silent-wrong-loss bug.
+    # is the attention-side mask contract (DotProductAttention.forward skips
+    # expand_attn_mask_startend_row_indices_for_cp under a2a), and that has not
+    # been validated on this path. Fail loudly instead of assuming: a wrong
+    # layout is a silent-wrong-loss bug.
     raise ValueError(
         f"extract_local_cp_chunks: unsupported cp_balance_mode={mode!r} for the "
         "use_erndata MTP path; expected 'dualchunk_allgather' or "

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -72,7 +72,8 @@ SUPPORTED_ATTN_MASK = [
 #   * cp_group is None or size==1 → non-CP path.
 #   * cp_group.nranks > 1 with cu_seqlens_q → NotImplementedError; the
 #     mirror-chunk (DualChunkSwap) CP variant is not implemented on this path
-#     (CP is instead handled by extract_local_zigzag_chunks at the call site).
+#     (CP is instead handled by extract_local_cp_chunks at the call site,
+#     which follows config.cp_balance_mode).
 #
 # Note: we consciously do NOT wrap cu_seqlens_q in an MCore-style
 # PackedSeqParams dataclass. ernie5's model backend consumes doc boundaries
@@ -229,8 +230,8 @@ def roll_tensor(
     already holds a full-length ``[B, L]`` copy — no zigzag scatter happens
     before the model. Consequently rolling reduces to standard CP=1
     semantics on the full-length tensor, and callers should invoke
-    ``extract_local_zigzag_chunks`` after ``roll_tensor`` to obtain their
-    local slice before embedding / loss.
+    ``extract_local_cp_chunks`` (which follows ``config.cp_balance_mode``)
+    after ``roll_tensor`` to obtain their local slice before embedding / loss.
 
     Args:
         tensor: input tensor.
@@ -399,7 +400,9 @@ def extract_local_cp_chunks(tensor_full, cp_rank, cp_size, axis=1, *, mode):
     builds its sparse-attention index tables over the *global* sequence and then
     row-slices this rank's queries, which is only correct under the contiguous
     layout — those layers assert on it under CP. So the MTP path must follow the
-    model's mode rather than hard-coding zigzag.
+    model's mode rather than hard-coding zigzag. (Necessary, not sufficient:
+    TransformerConfig separately rejects erndata + MTP + CP for models that build
+    an Indexer, whose loss-mask path still assumes a CP-local ``input_ids``.)
 
     Args:
         tensor_full: ``[..., L, ...]`` full-length tensor present on every rank.
@@ -414,6 +417,13 @@ def extract_local_cp_chunks(tensor_full, cp_rank, cp_size, axis=1, *, mode):
 
     Returns:
         ``[..., L / cp_size, ...]`` tensor holding this rank's slice.
+
+    Note:
+        ``cp_size == 1`` returns ``tensor_full`` *itself*, not a copy — unlike
+        ``scatter_balance`` (which clones) and ``scatter_contiguous`` (which
+        ``paddle.assign``s). Do not write into the result in place. Every call
+        site today guards with ``if cp_size > 1`` and treats the slice as
+        read-only, so this is a documented property rather than a live hazard.
     """
     if cp_size == 1:
         return tensor_full
@@ -425,10 +435,14 @@ def extract_local_cp_chunks(tensor_full, cp_rank, cp_size, axis=1, *, mode):
         return extract_local_contiguous_chunk(
             tensor_full, cp_rank, cp_size, axis=axis
         )
-    # contiguous_a2a (Ulysses) splits the *head* axis inside the attention and
-    # never round-trips through scatter_contiguous at the sequence level, so its
-    # local-slice layout is not established here. Fail loudly instead of
-    # guessing: a wrong layout is a silent-wrong-loss bug.
+    # contiguous_a2a (Ulysses) is refused, but not because its sequence layout
+    # is unknown: ContextParallelScatterOp dispatches on
+    # mode.startswith("contiguous"), so a2a shards the sequence contiguously and
+    # extract_local_contiguous_chunk would be the matching slice. What differs
+    # is the attention-side mask contract (dot_product_attention.py:532 skips
+    # the CP row-index expansion under a2a), and that has not been validated on
+    # this path. Fail loudly instead of assuming: a wrong layout is a
+    # silent-wrong-loss bug.
     raise ValueError(
         f"extract_local_cp_chunks: unsupported cp_balance_mode={mode!r} for the "
         "use_erndata MTP path; expected 'dualchunk_allgather' or "
@@ -1949,7 +1963,8 @@ class MultiTokenPredictionLayer(FleetLayer):
     # Constraints: experimental_dataflow=False and enable_mtp_magic_send
     # disabled (both enforced at TransformerConfig.__post_init__). Context
     # parallelism is handled at the embedding / loss call sites via
-    # extract_local_zigzag_chunks rather than inside roll_tensor.
+    # extract_local_cp_chunks (layout picked by config.cp_balance_mode) rather
+    # than inside roll_tensor.
     # ------------------------------------------------------------------ #
 
     def _forward_megatron_style(self, dict_args: dict) -> dict:

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -355,11 +355,9 @@ def extract_local_zigzag_chunks(tensor_full, cp_rank, cp_size, axis=1):
 def extract_local_contiguous_chunk(tensor_full, cp_rank, cp_size, axis=1):
     """Extract this CP rank's contiguous chunk from a full-length tensor.
 
-    Mirrors PaddleFleet's ``scatter_contiguous`` layout
-    (``context_parallel_utils.scatter_contiguous``): rank ``r`` owns exactly one
-    slice ``tensor_full[..., chunk*r : chunk*(r+1), ...]`` with
-    ``chunk = L / cp_size``. ``test_extract_local_cp_chunks.py`` pins that parity
-    against the real scatter helper, so a layout change there fails here.
+    Mirrors ``context_parallel_utils.scatter_contiguous``: rank ``r`` owns the
+    single slice ``tensor_full[..., chunk*r : chunk*(r+1), ...]`` with
+    ``chunk = L / cp_size``.
 
     Extraction only — no CP communication, same contract as
     ``extract_local_zigzag_chunks``.
@@ -386,44 +384,32 @@ def extract_local_contiguous_chunk(tensor_full, cp_rank, cp_size, axis=1):
 def extract_local_cp_chunks(tensor_full, cp_rank, cp_size, axis=1, *, mode):
     """Layout-aware local-slice extraction for the ``use_erndata`` MTP path.
 
-    The erndata MTP path keeps int/float tensors full-length on every CP rank
-    and slices them locally instead of calling ``ContextParallelScatterOp``
-    (which would redo the embedding lookup ``cp_size`` times). That slice has to
-    use *exactly* the layout the rest of the model uses for its own scatter,
-    i.e. ``config.cp_balance_mode``:
+    That path keeps its tensors full-length on every CP rank and slices them
+    locally instead of calling ``ContextParallelScatterOp`` (which would redo the
+    embedding lookup ``cp_size`` times), so the slice must use the same layout
+    the rest of the model scatters with, i.e. ``config.cp_balance_mode``:
 
-    * ``dualchunk_allgather``  -> ``scatter_balance``      -> two zigzag chunks
-    * ``contiguous_allgather`` -> ``scatter_contiguous``   -> one contiguous chunk
+    * ``dualchunk_allgather``  -> ``scatter_balance``    -> two zigzag chunks
+    * ``contiguous_allgather`` -> ``scatter_contiguous`` -> one contiguous chunk
 
-    ``contiguous_allgather`` is not optional for every model: the DSv4 hybrid
-    attention stack (``dsv4_hybrid_attention.py``, ``mqa_latent_attention.py``)
-    builds its sparse-attention index tables over the *global* sequence and then
-    row-slices this rank's queries, which is only correct under the contiguous
-    layout — those layers assert on it under CP. So the MTP path must follow the
-    model's mode rather than hard-coding zigzag. (Necessary, not sufficient:
-    TransformerConfig separately rejects erndata + MTP + CP for models that build
-    an Indexer, whose loss-mask path still assumes a CP-local ``input_ids``.)
+    ``contiguous_allgather`` is mandatory for the DSv4 hybrid stack, whose
+    attention layers assert on it under CP, so hard-coding zigzag here is wrong.
 
     Args:
         tensor_full: ``[..., L, ...]`` full-length tensor present on every rank.
         cp_rank: this rank's index inside the CP group.
         cp_size: CP world size; ``1`` returns ``tensor_full`` unchanged.
         axis: sequence axis (default 1 for ``[B, L, ...]``).
-        mode: ``config.cp_balance_mode``. Keyword-only and required *on purpose*.
-            The bug this function exists to fix was a call site that assumed a
-            layout instead of reading the config, so a default here would just
-            re-open that door for the next caller: picking the wrong layout is
-            not a crash, it is a silently wrong loss.
+        mode: ``config.cp_balance_mode``. Keyword-only and required: the bug this
+            helper exists to fix was a call site that assumed a layout, and the
+            wrong layout is a silently wrong loss rather than a crash.
 
     Returns:
         ``[..., L / cp_size, ...]`` tensor holding this rank's slice.
 
     Note:
-        ``cp_size == 1`` returns ``tensor_full`` *itself*, not a copy — unlike
-        ``scatter_balance`` (which clones) and ``scatter_contiguous`` (which
-        ``paddle.assign``s). Do not write into the result in place. Every call
-        site today guards with ``if cp_size > 1`` and treats the slice as
-        read-only, so this is a documented property rather than a live hazard.
+        ``cp_size == 1`` returns ``tensor_full`` itself, not a copy — do not
+        write into the result in place.
     """
     if cp_size == 1:
         return tensor_full
@@ -435,14 +421,10 @@ def extract_local_cp_chunks(tensor_full, cp_rank, cp_size, axis=1, *, mode):
         return extract_local_contiguous_chunk(
             tensor_full, cp_rank, cp_size, axis=axis
         )
-    # contiguous_a2a (Ulysses) is refused, but not because its sequence layout
-    # is unknown: ContextParallelScatterOp dispatches on
-    # mode.startswith("contiguous"), so a2a shards the sequence contiguously and
-    # extract_local_contiguous_chunk would be the matching slice. What differs
-    # is the attention-side mask contract (DotProductAttention.forward skips
-    # expand_attn_mask_startend_row_indices_for_cp under a2a), and that has not
-    # been validated on this path. Fail loudly instead of assuming: a wrong
-    # layout is a silent-wrong-loss bug.
+    # contiguous_a2a shards the sequence contiguously too, so the slice would
+    # match, but its mask contract differs (DotProductAttention.forward skips
+    # expand_attn_mask_startend_row_indices_for_cp under a2a) and has never been
+    # run on this path. Refuse rather than guess.
     raise ValueError(
         f"extract_local_cp_chunks: unsupported cp_balance_mode={mode!r} for the "
         "use_erndata MTP path; expected 'dualchunk_allgather' or "
@@ -1369,8 +1351,7 @@ class MultiTokenPredictionLayer(FleetLayer):
         # roll_tensor(cu_seqlens_q=...).
         #
         # enable_mtp_magic_send cannot reach here under erndata: TransformerConfig
-        # refuses the combination outright (see the rejection in
-        # transformer_config.py for why it buys nothing on this path).
+        # rejects the combination.
         if getattr(self.config, "use_erndata", False):
             return self._forward_megatron_style(dict_args)
 
@@ -1484,12 +1465,9 @@ class MultiTokenPredictionLayer(FleetLayer):
                         mtp_input_embeds, input_ids == pad_token_id, 0
                     )
 
-                # Shifted embedding slice for current depth. This is the L+K
-                # contract: input_ids is longer than the backbone sequence, so
-                # depth d's embedding is a window offset by d+1. erndata carries
-                # length-L tensors and would need per-document rolls instead,
-                # which is one of the reasons TransformerConfig refuses
-                # use_erndata + enable_mtp_magic_send.
+                # Shifted embedding slice for current depth: the L+K contract,
+                # where input_ids is longer than the backbone sequence, so
+                # depth d's embedding is a window offset by d+1.
                 decoder_input = mtp_input_embeds[
                     :, (depth + 1) : (depth + 1 + seq_len), :
                 ]

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -2143,11 +2143,21 @@ class TransformerConfig(ModelParallelConfig):
                 "enable_mtp_magic_send with tie_word_embeddings=True is not yet validated. "
                 "Please disable tie_word_embeddings when using magic send MTP."
             )
-            assert not self.mtp_shared_last_layer, (
-                "enable_mtp_magic_send and mtp_shared_last_layer cannot both be True. "
-                "Magic send uses per-layer mtp_embed with broadcast sync, which is "
-                "incompatible with SharedLayerDesc-based last-layer reuse."
-            )
+            # NOTE: mtp_shared_last_layer is deliberately NOT rejected here.
+            # The two mechanisms are orthogonal: SharedLayerDesc with
+            # shared_submodule_weight_only=True (pp_layers.py) aliases only the
+            # parameters under `dest_layer.transformer_layer`, while magic send
+            # owns `mtp_embed` (synced through gpt_model's dedicated
+            # _mtp_embed_global_group). Their parameter sets do not overlap.
+            #
+            # Precondition worth knowing: _alias_shared_layer asserts
+            # `total_params == aliased_count`, i.e. the tie pivot (the last
+            # backbone layer) and the MTP layer must resolve to the *same*
+            # attention parameter set. For dsv4_hybrid models that holds only
+            # while csa_compress_ratios[num_hidden_layers - 1] and
+            # csa_compress_ratios[num_hidden_layers] agree. If someone makes
+            # those two indices diverge, that assert fires with a confusing
+            # message and this is the place to look.
             if self.num_nextn_predict_layers > 1:
                 assert self.variable_seq_lengths, (
                     "enable_mtp_magic_send with num_nextn_predict_layers > 1 requires "
@@ -2183,9 +2193,69 @@ class TransformerConfig(ModelParallelConfig):
         if self.use_erndata and self.num_nextn_predict_layers > 0:
             # erndata + MTP selects the packed-doc (MCore 8c4df6b07) contract.
             if self.enable_mtp_magic_send:
+                # Refused on purpose, and not because it is hard to implement.
+                #
+                # What magic send actually provides is not a transport for
+                # input_ids -- it is a *word-embedding table on the MTP stage*
+                # (`mtp_embed`, created only under this flag). MTP needs
+                # embed(token_{i+k+1}); the hidden_states arriving at the last
+                # PP stage is the post-backbone representation, so nothing local
+                # can be rolled into a substitute, and under PP>1 the real
+                # word embeddings live on stage 0 only.
+                #
+                # On the erndata path the input_ids half is already redundant:
+                # GPTEmbedding puts full-length global input_ids and cu_seqlens_q
+                # into preproc_output, and no backbone layer touches them
+                # (transformer_layer.py only re-slices input_ids when it is
+                # longer than the backbone sequence, which never happens for
+                # length-L erndata tensors). So they reach the MTP layer intact
+                # regardless of this flag.
+                #
+                # That leaves a bad trade. Enabling it swaps a hidden-state P2P
+                # payload of (K+1)x for 1x, and pays for it with a second
+                # *trainable* vocab table on the MTP stage. The table is tied to
+                # the stage-0 embedding -- gpt_model ties the weights inside a
+                # rank (_tie_mtp_embed_weights_intra_rank), broadcasts them from
+                # stage 0 at init, and allreduces the gradient over a dedicated
+                # mtp_embed sub-group -- so it is *logically* shared but, when
+                # stage 0 and the MTP stage are different ranks (i.e. exactly
+                # the PP>1 case this flag exists for), *physically replicated*.
+                #
+                # For V=201216 / H=1024 / K=1 (~206M params, TP=1) the resident
+                # cost on the MTP stage is:
+                #     bf16 weight            412MB  (not sharded)
+                #     gradient               412MB bf16 / 824MB fp32 main_grad
+                #     fp32 master + m + v   2.47GB  / sharding_parallel_size
+                # is_firstly_shared only dedups grad-norm
+                # (hybrid_parallel_optimizer.py), it does not exclude the param
+                # from sharding, so the optimizer slice really is divided:
+                # ~1.1-1.5GB at sharding=8, ~1.4-1.9GB at sharding=4.
+                #
+                # Against that, one saved carrier slot is ~8MB per P2P hop per
+                # micro-batch (B=1, S_local=4096, H=1024, bf16): ~134MB/step at
+                # PP=2/GA=16, ~403MB/step at PP=4/GA=16 -- and that traffic is
+                # already hidden by overlap_p2p_comm. A clear net loss.
+                #
+                # Keep enable_mtp_magic_send=False: the baseline batch-axis
+                # carrier already supports any PP depth on this path. If K ever
+                # grows enough for (K+1)x to matter, the cheaper fix is to carry
+                # the single *un-transformed* inputs_embeds slot and roll it
+                # locally on the MTP stage -- 2x payload regardless of K, and no
+                # extra vocab table. That is not implemented today.
                 raise ValueError(
-                    "use_erndata=True with MTP is incompatible with "
-                    "enable_mtp_magic_send=True."
+                    "use_erndata=True with MTP does not need (and does not "
+                    "support) enable_mtp_magic_send=True. erndata already "
+                    "delivers full-length input_ids and cu_seqlens_q to the "
+                    "MTP stage through the pipeline dict, so magic send would "
+                    "only add a second trainable vocab embedding table there "
+                    "(~V*H params plus grads and a sharded optimizer state: "
+                    "~1.1-1.9GB at V=201216/H=1024 depending on "
+                    "sharding_parallel_size) in order to shrink the "
+                    "hidden-state P2P payload from (K+1)x to 1x (~8MB per hop "
+                    "per micro-batch, already hidden by overlap_p2p_comm) -- a "
+                    "net memory loss at small K. Set "
+                    "enable_mtp_magic_send=False; the default batch-axis MTP "
+                    "carrier works at any pipeline_model_parallel_size."
                 )
             if self.experimental_dataflow:
                 # experimental_dataflow specifically produces
@@ -2209,15 +2279,31 @@ class TransformerConfig(ModelParallelConfig):
                     "the shifted embeddings from hidden_states, not from "
                     "mtp_decoder_inputs)."
                 )
-            # PaddleFleet's `dualchunk_allgather` scatter layout is the only
-            # mode equivalent to MCore's zigzag balancing; the other two
-            # (`contiguous_allgather`, `contiguous_a2a`) are not covered by
-            # this path's MTP roll semantics.
+            # The erndata MTP path keeps its tensors full-length on every CP
+            # rank and slices them locally (extract_local_cp_chunks) instead of
+            # calling ContextParallelScatterOp, so the layout it slices with has
+            # to be one the rest of the model also uses:
+            #   dualchunk_allgather  -> scatter_balance    (zigzag, MCore-like)
+            #   contiguous_allgather -> scatter_contiguous (rank-order slices)
+            # Both are supported. `contiguous_a2a` (Ulysses) is not: it splits
+            # heads inside the attention rather than round-tripping the sequence
+            # through scatter_contiguous, so its local-sequence layout is not
+            # established for this path.
+            #
+            # contiguous_allgather is mandatory — not merely allowed — for the
+            # DSv4 hybrid stack: dsv4_hybrid_attention.py and
+            # mqa_latent_attention.py build their sparse-attention index tables
+            # over the global sequence and then row-slice this rank's queries,
+            # and assert on cp_balance_mode=='contiguous_allgather' under CP.
             if self.context_parallel_size > 1:
-                if self.cp_balance_mode != "dualchunk_allgather":
+                if self.cp_balance_mode not in (
+                    "dualchunk_allgather",
+                    "contiguous_allgather",
+                ):
                     raise ValueError(
                         f"use_erndata=True with MTP + context_parallel_size>1 "
-                        f"requires cp_balance_mode='dualchunk_allgather', got "
+                        f"requires cp_balance_mode in "
+                        f"{{'dualchunk_allgather', 'contiguous_allgather'}}, got "
                         f"{self.cp_balance_mode!r}."
                     )
             # PP>1 is supported without any external dataloader help:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -2150,14 +2150,30 @@ class TransformerConfig(ModelParallelConfig):
             # owns `mtp_embed` (synced through gpt_model's dedicated
             # _mtp_embed_global_group). Their parameter sets do not overlap.
             #
-            # Precondition worth knowing: _alias_shared_layer asserts
-            # `total_params == aliased_count`, i.e. the tie pivot (the last
-            # backbone layer) and the MTP layer must resolve to the *same*
-            # attention parameter set. For dsv4_hybrid models that holds only
-            # while csa_compress_ratios[num_hidden_layers - 1] and
-            # csa_compress_ratios[num_hidden_layers] agree. If someone makes
-            # those two indices diverge, that assert fires with a confusing
-            # message and this is the place to look.
+            # Two preconditions worth knowing before relying on this
+            # combination; neither is asserted anywhere, both were verified by
+            # reading paddle rather than by an end-to-end run.
+            #
+            # 1. Same-rank co-location. PipelineLayer._build_layer_impl fills
+            #    `self.shared_layers` only from descs inside *this* rank's
+            #    [start, end) range, so _alias_shared_layer runs only when the
+            #    tie pivot (the last backbone layer, gpt_model.get_layer_desc_list)
+            #    and the MTP desc land on the same rank. If a PP boundary
+            #    separates them, the MTP desc becomes the first member of the key
+            #    on its own stage and falls back to _construct_shared_comm: two
+            #    parameter copies, broadcast at init and gradient-allreduced
+            #    across stages. Numerically that is still a tie, but the memory
+            #    saving mtp_shared_last_layer exists for is gone -- and PP>1 is
+            #    exactly the case magic send is for.
+            #
+            # 2. Identical parameter sets. _alias_shared_layer asserts
+            #    `total_params == aliased_count`, i.e. the pivot and the MTP
+            #    layer must resolve to the *same* attention parameter set. For
+            #    dsv4_hybrid models that holds only while
+            #    csa_compress_ratios[num_hidden_layers - 1] and
+            #    csa_compress_ratios[num_hidden_layers] agree. If someone makes
+            #    those two indices diverge, that assert fires with a confusing
+            #    message and this is the place to look.
             if self.num_nextn_predict_layers > 1:
                 assert self.variable_seq_lengths, (
                     "enable_mtp_magic_send with num_nextn_predict_layers > 1 requires "
@@ -2221,20 +2237,25 @@ class TransformerConfig(ModelParallelConfig):
                 # stage 0 and the MTP stage are different ranks (i.e. exactly
                 # the PP>1 case this flag exists for), *physically replicated*.
                 #
-                # For V=201216 / H=1024 / K=1 (~206M params, TP=1) the resident
-                # cost on the MTP stage is:
+                # The table costs V*H per copy in weight, the same again in
+                # gradient, and 3x that in fp32 master+m+v divided by
+                # sharding_parallel_size (is_firstly_shared only dedups
+                # grad-norm in hybrid_parallel_optimizer.py; it does not exclude
+                # the param from sharding). The saved carrier slot costs
+                # B*S_local*H bf16 per P2P hop per micro-batch, and that traffic
+                # is already hidden by overlap_p2p_comm.
+                #
+                # Worked example for ONE configuration -- ernielite 4B-A500M,
+                # V=201216 / H=1024 / K=1 / TP=1 (~206M params). Scale it
+                # yourself for any other model; the numbers below describe this
+                # config only:
                 #     bf16 weight            412MB  (not sharded)
                 #     gradient               412MB bf16 / 824MB fp32 main_grad
                 #     fp32 master + m + v   2.47GB  / sharding_parallel_size
-                # is_firstly_shared only dedups grad-norm
-                # (hybrid_parallel_optimizer.py), it does not exclude the param
-                # from sharding, so the optimizer slice really is divided:
-                # ~1.1-1.5GB at sharding=8, ~1.4-1.9GB at sharding=4.
-                #
-                # Against that, one saved carrier slot is ~8MB per P2P hop per
-                # micro-batch (B=1, S_local=4096, H=1024, bf16): ~134MB/step at
-                # PP=2/GA=16, ~403MB/step at PP=4/GA=16 -- and that traffic is
-                # already hidden by overlap_p2p_comm. A clear net loss.
+                #     => ~1.1-1.5GB resident at sharding=8, ~1.4-1.9GB at 4
+                # against ~8MB per hop per micro-batch (B=1, S_local=4096):
+                # ~134MB/step at PP=2/GA=16, ~403MB/step at PP=4/GA=16.
+                # A clear net loss at this scale.
                 #
                 # Keep enable_mtp_magic_send=False: the baseline batch-axis
                 # carrier already supports any PP depth on this path. If K ever
@@ -2247,15 +2268,14 @@ class TransformerConfig(ModelParallelConfig):
                     "support) enable_mtp_magic_send=True. erndata already "
                     "delivers full-length input_ids and cu_seqlens_q to the "
                     "MTP stage through the pipeline dict, so magic send would "
-                    "only add a second trainable vocab embedding table there "
-                    "(~V*H params plus grads and a sharded optimizer state: "
-                    "~1.1-1.9GB at V=201216/H=1024 depending on "
-                    "sharding_parallel_size) in order to shrink the "
-                    "hidden-state P2P payload from (K+1)x to 1x (~8MB per hop "
-                    "per micro-batch, already hidden by overlap_p2p_comm) -- a "
-                    "net memory loss at small K. Set "
+                    "only add a second trainable vocab embedding table on that "
+                    "stage (V*H weights, the same in gradients, plus a sharded "
+                    "fp32 optimizer state) in order to shrink the hidden-state "
+                    "P2P payload from (K+1)x to 1x -- traffic that "
+                    "overlap_p2p_comm already hides. Set "
                     "enable_mtp_magic_send=False; the default batch-axis MTP "
-                    "carrier works at any pipeline_model_parallel_size."
+                    "carrier works at any pipeline_model_parallel_size. See the "
+                    "comment above this check for the memory arithmetic."
                 )
             if self.experimental_dataflow:
                 # experimental_dataflow specifically produces

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -2139,10 +2139,23 @@ class TransformerConfig(ModelParallelConfig):
                 )
 
         if self.enable_mtp_magic_send:
-            assert not getattr(self, "tie_word_embeddings", False), (
-                "enable_mtp_magic_send with tie_word_embeddings=True is not yet validated. "
-                "Please disable tie_word_embeddings when using magic send MTP."
-            )
+            # Raise, not assert, for the same reason as multimodal_embedding
+            # below: stripped by ``python -O``, this one fails silently rather
+            # than loudly. get_layer_desc_list tests tie_word_embeddings before
+            # enable_mtp_magic_send, so the tie wins and `mtp_embed` is never
+            # emitted; _mtp_embed_global_group then collapses to None and
+            # _synchronize_mtp_embed_weight broadcasts a zero buffer from
+            # stage 0 into the MTP stage's real (perform_initialization=False)
+            # table. Training proceeds on an all-zero, never-synced vocab table.
+            if getattr(self, "tie_word_embeddings", False):
+                raise ValueError(
+                    "enable_mtp_magic_send with tie_word_embeddings=True is "
+                    "not yet validated: the embedding desc branch emits the "
+                    "tie and drops magic send's `mtp_embed`, leaving the MTP "
+                    "stage with an all-zero vocab table and no gradient sync. "
+                    "Please disable tie_word_embeddings when using magic send "
+                    "MTP."
+                )
             # NOTE: mtp_shared_last_layer is deliberately NOT rejected here. The
             # two are orthogonal -- SharedLayerDesc with
             # shared_submodule_weight_only=True aliases only the params under
@@ -2156,6 +2169,15 @@ class TransformerConfig(ModelParallelConfig):
             #    descs inside this rank's range, so a PP boundary between them
             #    downgrades _alias_shared_layer to _construct_shared_comm: still
             #    numerically tied, but two copies, so the memory saving is gone.
+            #    At num_nextn_predict_layers > 1 an off-stage pivot is worse than
+            #    that -- it aborts construction. paddle stores the *whole* first
+            #    desc it sees for the key, so on an MTP-only stage depth 0 becomes
+            #    shared_layers['mtp_reuse_transformer'] and depth 1 aliases
+            #    against it: source names carry the `transformer_layer.` prefix,
+            #    dest names (taken from dest_layer.transformer_layer) do not,
+            #    every lookup misses, and the assert below fires with
+            #    "miss parameters:N". Only seg_method="layer:..." keeps them
+            #    co-located; paddle's default is "uniform", which can split them.
             # 2. _alias_shared_layer asserts `total_params == aliased_count`, so
             #    the pivot and the MTP layer must resolve to the same attention
             #    parameter set -- for dsv4_hybrid, csa_compress_ratios at indices
@@ -2273,22 +2295,47 @@ class TransformerConfig(ModelParallelConfig):
                         f"{self.cp_balance_mode!r}."
                     )
                 if self.gpt_model_use_experimental_version:
-                    # GPTEmbedding passes
-                    # include_position_axis=gpt_model_use_experimental_version to
-                    # build_startend_row_indices_from_cu_seqlens, making the mask
-                    # [B, 1, L, 2]. Under CP the mask expansion accepts a
-                    # 2-column mask only when experimental_dataflow is True,
-                    # which this same block forbids; otherwise attention raises
-                    # "Invalid attention mask shape", naming neither flag.
+                    # Not a mask-shape problem, despite what the CP mask
+                    # expansion in DotProductAttention.forward suggests: the
+                    # erndata loader co-emits attn_mask_startend_row_indices
+                    # [B, 1, L, 1] with cu_seqlens (both under pack_by_cu_seqlen,
+                    # which defaults True), so GPTEmbedding's
+                    # include_position_axis branch -- gated on the mask being
+                    # absent -- never fires and no 2-column mask is ever built.
+                    #
+                    # What the flag does change here is the attention entry
+                    # point: it routes query/key through _apply_ec_complex_3d_mrope,
+                    # which indexes position_ids on a 3-way last axis, while
+                    # erndata delivers position_ids as [B, L] and
+                    # transformer_layer leaves it untouched. It also nulls the
+                    # rotary tables, making the CP RoPE slicing this path relies
+                    # on inert. Neither has been run under CP, so refuse rather
+                    # than let it fail deep inside attention.
                     raise ValueError(
                         "use_erndata=True with MTP + context_parallel_size>1 is "
                         "incompatible with "
-                        "gpt_model_use_experimental_version=True: it makes "
-                        "GPTEmbedding emit a 2-column "
-                        "attn_mask_startend_row_indices, which the CP mask "
-                        "expansion only accepts under "
-                        "experimental_dataflow=True (forbidden with erndata). "
-                        "Set gpt_model_use_experimental_version=False."
+                        "gpt_model_use_experimental_version=True: that flag "
+                        "switches attention to the EC 3-axis MRoPE path, which "
+                        "expects position_ids with a mode axis, while erndata "
+                        "delivers [B, L]. Set "
+                        "gpt_model_use_experimental_version=False."
+                    )
+                if self.mtp_distillation_loss:
+                    # LanguageLoss's distillation branch builds lossmask from
+                    # labels_cur_depth, which the erndata path has already sliced
+                    # to L/cp, and then scatters it again -- the sibling
+                    # non-distillation branch skips that second scatter for
+                    # erndata, this one does not. The result is
+                    # [B, L/cp**2, 1] * [B, L/cp, V]. Its `xishu` normaliser is a
+                    # rank-local token count divided into a CP-all-reduced sum on
+                    # top of that. Both are pre-existing; reject the combination
+                    # here rather than ship a broadcast error.
+                    raise ValueError(
+                        "use_erndata=True with MTP + context_parallel_size>1 is "
+                        "incompatible with mtp_distillation_loss=True: the "
+                        "distillation branch double-scatters its loss mask and "
+                        "normalises a CP-reduced sum by a rank-local token "
+                        "count. Set mtp_distillation_loss=False."
                     )
             # PP>1 is supported without any external dataloader help:
             # cu_seqlens_q travels down the pipeline dict (like position_ids)
@@ -2298,6 +2345,33 @@ class TransformerConfig(ModelParallelConfig):
             # writes the same stash on the PP=1 / first stage. If the stash is
             # ever missing on the loss rank, LanguageLoss.forward raises rather
             # than silently rolling labels across packed-doc boundaries.
+
+        if self.use_erndata and self.context_parallel_size > 1:
+            # Under erndata nothing upstream shards by CP: the loader broadcasts
+            # every tensor full-length to the whole CP group
+            # (erndata_paddle_adapter._get_cp_group_and_src) and the model is
+            # expected to take its own slice. The only place that happens is
+            # GPTEmbedding's MTP branch, gated on num_nextn_predict_layers > 0
+            # and not mtp_load_weight_only; the generic
+            # ContextParallelScatterOp fallback beside it is gated on
+            # experimental_dataflow, which the block above forbids. So with MTP
+            # off (or weight-only) the hidden states stay length L while
+            # DotProductAttention computes seq_len = key.shape[1] * cp_size and
+            # expand() fails against an L-row mask -- a shape error naming
+            # neither use_erndata nor cp_balance_mode. Note use_erndata is set
+            # implicitly by erniebot whenever the YAML carries an `erndata:`
+            # section, so this is reachable without any MTP-specific flag.
+            if self.num_nextn_predict_layers <= 0 or self.mtp_load_weight_only:
+                raise ValueError(
+                    "use_erndata=True with context_parallel_size>1 requires "
+                    "MTP (num_nextn_predict_layers>0, mtp_load_weight_only="
+                    "False): the erndata loader hands every CP rank the "
+                    "full-length sequence and only the MTP branch of "
+                    "GPTEmbedding slices it, so with MTP off no CP sharding "
+                    "happens at all. Got num_nextn_predict_layers="
+                    f"{self.num_nextn_predict_layers}, mtp_load_weight_only="
+                    f"{self.mtp_load_weight_only}."
+                )
 
         if self.intermediate_size is None:
             self.intermediate_size = 4 * self.hidden_size

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -2305,16 +2305,27 @@ class TransformerConfig(ModelParallelConfig):
             # to be one the rest of the model also uses:
             #   dualchunk_allgather  -> scatter_balance    (zigzag, MCore-like)
             #   contiguous_allgather -> scatter_contiguous (rank-order slices)
-            # Both are supported. `contiguous_a2a` (Ulysses) is not: it splits
-            # heads inside the attention rather than round-tripping the sequence
-            # through scatter_contiguous, so its local-sequence layout is not
-            # established for this path.
             #
-            # contiguous_allgather is mandatory — not merely allowed — for the
-            # DSv4 hybrid stack: dsv4_hybrid_attention.py and
-            # mqa_latent_attention.py build their sparse-attention index tables
-            # over the global sequence and then row-slice this rank's queries,
-            # and assert on cp_balance_mode=='contiguous_allgather' under CP.
+            # `contiguous_a2a` (Ulysses) is refused, but NOT because its
+            # sequence layout is unknown: ContextParallelScatterOp dispatches on
+            # `mode.startswith("contiguous")` (context_parallel_utils.py:533),
+            # so a2a shards the sequence contiguously too and
+            # extract_local_contiguous_chunk would be the matching local slice.
+            # What differs is the *mask* contract: dot_product_attention.py:532
+            # skips expand_attn_mask_startend_row_indices_for_cp under a2a
+            # because the head-axis all-to-all leaves each rank holding all
+            # sequence positions for a head subset, so the full-length
+            # row-index tensor this path builds is consumed differently. That
+            # combination has never been run end-to-end here, so it is rejected
+            # rather than assumed to work.
+            #
+            # contiguous_allgather is a *necessary* condition for the DSv4
+            # hybrid stack -- dsv4_hybrid_attention.py:997 and
+            # mqa_latent_attention.py:686 assert on it under CP because they
+            # build sparse-attention index tables over the global sequence and
+            # row-slice this rank's queries. It is not a sufficient one: see the
+            # separate erndata + Indexer + CP rejection in the dsv4_hybrid block
+            # below for a path that is still broken downstream.
             if self.context_parallel_size > 1:
                 if self.cp_balance_mode not in (
                     "dualchunk_allgather",
@@ -2325,6 +2336,28 @@ class TransformerConfig(ModelParallelConfig):
                         f"requires cp_balance_mode in "
                         f"{{'dualchunk_allgather', 'contiguous_allgather'}}, got "
                         f"{self.cp_balance_mode!r}."
+                    )
+                if self.gpt_model_use_experimental_version:
+                    # gpt_embedding.py:467 passes
+                    # include_position_axis=gpt_model_use_experimental_version to
+                    # build_startend_row_indices_from_cu_seqlens, so the mask
+                    # becomes [B, 1, L, 2]. Under CP,
+                    # expand_attn_mask_startend_row_indices_for_cp
+                    # (dot_product_attention.py:470-480) accepts a 2-column mask
+                    # only when config.experimental_dataflow is True -- which
+                    # this same block forbids for erndata -- and otherwise
+                    # raises "Invalid attention mask shape" from inside
+                    # attention. Reject here instead, where the offending flag
+                    # is named.
+                    raise ValueError(
+                        "use_erndata=True with MTP + context_parallel_size>1 is "
+                        "incompatible with "
+                        "gpt_model_use_experimental_version=True: it makes "
+                        "GPTEmbedding emit a 2-column "
+                        "attn_mask_startend_row_indices, which the CP mask "
+                        "expansion only accepts under "
+                        "experimental_dataflow=True (forbidden with erndata). "
+                        "Set gpt_model_use_experimental_version=False."
                     )
             # PP>1 is supported without any external dataloader help:
             # cu_seqlens_q travels down the pipeline dict (like position_ids)
@@ -2853,6 +2886,48 @@ class TransformerConfig(ModelParallelConfig):
             has_mqa_indexer = self.hybrid_mla_attention == "mqa_dsa" and any(
                 int(ratio) == -2 for ratio in self.csa_compress_ratios
             )
+            if (
+                (has_csa_indexer or has_mqa_indexer)
+                and self.use_erndata
+                and self.num_nextn_predict_layers > 0
+                and self.context_parallel_size > 1
+            ):
+                # Both Indexers derive their token-count denominator from
+                # input_ids, and both assume input_ids arrives CP-*local*:
+                # csa_attention.py:2884-2911 and
+                # mqa_latent_attention.py:2494-2502 gather it whenever
+                # `cp_world_size > 1 and not experimental_dataflow` and then
+                # reshape to [b, cp_size * s_local].
+                #
+                # That condition is exactly the erndata condition -- erndata
+                # forbids experimental_dataflow -- but the premise is wrong on
+                # this path: erndata hands the model a full-length global
+                # input_ids and nothing trims it (transformer_layer.py:800-811
+                # compares in global units, so its re-slice never fires). The
+                # gather therefore produces b * L * cp_size elements for a
+                # b * L reshape and dies with a shape error deep inside
+                # attention, and the position_offset = cp_rank * sq slice below
+                # it would be wrong even if the reshape were fixed.
+                #
+                # Before cp_balance_mode became configurable on this path the
+                # combination was unreachable: erndata + MTP + CP required
+                # dualchunk_allgather while the DSv4 layers assert
+                # contiguous_allgather. Widening that check made it
+                # config-legal, so keep the rejection explicit here rather than
+                # letting it resurface as a runtime crash. Making it work means
+                # teaching the Indexer loss-mask path that input_ids may already
+                # be global -- not done.
+                raise ValueError(
+                    "use_erndata=True with MTP + context_parallel_size>1 does "
+                    "not support a model that builds an Indexer (CSAIndexer="
+                    f"{has_csa_indexer}, DSAIndexer={has_mqa_indexer}). The "
+                    "Indexer loss-mask path all-gathers input_ids and reshapes "
+                    "to [b, cp_size * s_local], but erndata already delivers "
+                    "input_ids full-length and global, so the gather "
+                    "over-counts by cp_size and fails inside attention. Run "
+                    "this model with context_parallel_size=1, or without "
+                    "use_erndata."
+                )
             if (
                 (has_csa_indexer or has_mqa_indexer)
                 and self.dsa_indexer_use_sparse_loss

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -2143,37 +2143,23 @@ class TransformerConfig(ModelParallelConfig):
                 "enable_mtp_magic_send with tie_word_embeddings=True is not yet validated. "
                 "Please disable tie_word_embeddings when using magic send MTP."
             )
-            # NOTE: mtp_shared_last_layer is deliberately NOT rejected here.
-            # The two mechanisms are orthogonal: SharedLayerDesc with
-            # shared_submodule_weight_only=True (pp_layers.py) aliases only the
-            # parameters under `dest_layer.transformer_layer`, while magic send
-            # owns `mtp_embed` (synced through gpt_model's dedicated
-            # _mtp_embed_global_group). Their parameter sets do not overlap.
+            # NOTE: mtp_shared_last_layer is deliberately NOT rejected here. The
+            # two are orthogonal -- SharedLayerDesc with
+            # shared_submodule_weight_only=True aliases only the params under
+            # `transformer_layer`, while magic send owns `mtp_embed` (synced via
+            # gpt_model's _mtp_embed_global_group) -- so their parameter sets do
+            # not overlap.
             #
-            # Two preconditions worth knowing before relying on this
-            # combination; neither is asserted anywhere, both were verified by
-            # reading paddle rather than by an end-to-end run.
-            #
-            # 1. Same-rank co-location. PipelineLayer._build_layer_impl fills
-            #    `self.shared_layers` only from descs inside *this* rank's
-            #    [start, end) range, so _alias_shared_layer runs only when the
-            #    tie pivot (the last backbone layer, gpt_model.get_layer_desc_list)
-            #    and the MTP desc land on the same rank. If a PP boundary
-            #    separates them, the MTP desc becomes the first member of the key
-            #    on its own stage and falls back to _construct_shared_comm: two
-            #    parameter copies, broadcast at init and gradient-allreduced
-            #    across stages. Numerically that is still a tie, but the memory
-            #    saving mtp_shared_last_layer exists for is gone -- and PP>1 is
-            #    exactly the case magic send is for.
-            #
-            # 2. Identical parameter sets. _alias_shared_layer asserts
-            #    `total_params == aliased_count`, i.e. the pivot and the MTP
-            #    layer must resolve to the *same* attention parameter set. For
-            #    dsv4_hybrid models that holds only while
-            #    csa_compress_ratios[num_hidden_layers - 1] and
-            #    csa_compress_ratios[num_hidden_layers] agree. If someone makes
-            #    those two indices diverge, that assert fires with a confusing
-            #    message and this is the place to look.
+            # Two preconditions the combination relies on, neither asserted:
+            # 1. The tie pivot (last backbone layer) and the MTP desc must land
+            #    on the same rank. PipelineLayer._build_layer_impl registers only
+            #    descs inside this rank's range, so a PP boundary between them
+            #    downgrades _alias_shared_layer to _construct_shared_comm: still
+            #    numerically tied, but two copies, so the memory saving is gone.
+            # 2. _alias_shared_layer asserts `total_params == aliased_count`, so
+            #    the pivot and the MTP layer must resolve to the same attention
+            #    parameter set -- for dsv4_hybrid, csa_compress_ratios at indices
+            #    num_hidden_layers-1 and num_hidden_layers must agree.
             if self.num_nextn_predict_layers > 1:
                 assert self.variable_seq_lengths, (
                     "enable_mtp_magic_send with num_nextn_predict_layers > 1 requires "
@@ -2209,73 +2195,33 @@ class TransformerConfig(ModelParallelConfig):
         if self.use_erndata and self.num_nextn_predict_layers > 0:
             # erndata + MTP selects the packed-doc (MCore 8c4df6b07) contract.
             if self.enable_mtp_magic_send:
-                # Refused on purpose, and not because it is hard to implement.
+                # Refused by design, not for lack of implementation. erndata
+                # already puts full-length input_ids and cu_seqlens_q into
+                # preproc_output and no backbone layer consumes them (
+                # transformer_layer only re-slices input_ids when it is longer
+                # than the backbone sequence, which never happens for length-L
+                # erndata tensors), so they reach the MTP layer intact without
+                # magic send.
                 #
-                # What magic send actually provides is not a transport for
-                # input_ids -- it is a *word-embedding table on the MTP stage*
-                # (`mtp_embed`, created only under this flag). MTP needs
-                # embed(token_{i+k+1}); the hidden_states arriving at the last
-                # PP stage is the post-backbone representation, so nothing local
-                # can be rolled into a substitute, and under PP>1 the real
-                # word embeddings live on stage 0 only.
-                #
-                # On the erndata path the input_ids half is already redundant:
-                # GPTEmbedding puts full-length global input_ids and cu_seqlens_q
-                # into preproc_output, and no backbone layer touches them
-                # (transformer_layer.py only re-slices input_ids when it is
-                # longer than the backbone sequence, which never happens for
-                # length-L erndata tensors). So they reach the MTP layer intact
-                # regardless of this flag.
-                #
-                # That leaves a bad trade. Enabling it swaps a hidden-state P2P
-                # payload of (K+1)x for 1x, and pays for it with a second
-                # *trainable* vocab table on the MTP stage. The table is tied to
-                # the stage-0 embedding -- gpt_model ties the weights inside a
-                # rank (_tie_mtp_embed_weights_intra_rank), broadcasts them from
-                # stage 0 at init, and allreduces the gradient over a dedicated
-                # mtp_embed sub-group -- so it is *logically* shared but, when
-                # stage 0 and the MTP stage are different ranks (i.e. exactly
-                # the PP>1 case this flag exists for), *physically replicated*.
-                #
-                # The table costs V*H per copy in weight, the same again in
-                # gradient, and 3x that in fp32 master+m+v divided by
-                # sharding_parallel_size (is_firstly_shared only dedups
-                # grad-norm in hybrid_parallel_optimizer.py; it does not exclude
-                # the param from sharding). The saved carrier slot costs
-                # B*S_local*H bf16 per P2P hop per micro-batch, and that traffic
-                # is already hidden by overlap_p2p_comm.
-                #
-                # Worked example for ONE configuration -- ernielite 4B-A500M,
-                # V=201216 / H=1024 / K=1 / TP=1 (~206M params). Scale it
-                # yourself for any other model; the numbers below describe this
-                # config only:
-                #     bf16 weight            412MB  (not sharded)
-                #     gradient               412MB bf16 / 824MB fp32 main_grad
-                #     fp32 master + m + v   2.47GB  / sharding_parallel_size
-                #     => ~1.1-1.5GB resident at sharding=8, ~1.4-1.9GB at 4
-                # against ~8MB per hop per micro-batch (B=1, S_local=4096):
-                # ~134MB/step at PP=2/GA=16, ~403MB/step at PP=4/GA=16.
-                # A clear net loss at this scale.
-                #
-                # Keep enable_mtp_magic_send=False: the baseline batch-axis
-                # carrier already supports any PP depth on this path. If K ever
-                # grows enough for (K+1)x to matter, the cheaper fix is to carry
-                # the single *un-transformed* inputs_embeds slot and roll it
-                # locally on the MTP stage -- 2x payload regardless of K, and no
-                # extra vocab table. That is not implemented today.
+                # What the flag would still add is its other half: a second
+                # *trainable* vocab table (`mtp_embed`) on the MTP stage, tied to
+                # the stage-0 embedding logically but physically replicated
+                # whenever stage 0 is a different rank -- exactly the PP>1 case
+                # the flag exists for. That costs V*H in weights, the same in
+                # gradients and 3x in fp32 master+m+v (only the optimizer state
+                # is sharded) to shrink the hidden-state P2P payload from (K+1)x
+                # to 1x, traffic overlap_p2p_comm already hides. Keep the default
+                # batch-axis carrier, which already supports any PP depth here.
                 raise ValueError(
                     "use_erndata=True with MTP does not need (and does not "
                     "support) enable_mtp_magic_send=True. erndata already "
-                    "delivers full-length input_ids and cu_seqlens_q to the "
-                    "MTP stage through the pipeline dict, so magic send would "
-                    "only add a second trainable vocab embedding table on that "
-                    "stage (V*H weights, the same in gradients, plus a sharded "
-                    "fp32 optimizer state) in order to shrink the hidden-state "
-                    "P2P payload from (K+1)x to 1x -- traffic that "
-                    "overlap_p2p_comm already hides. Set "
-                    "enable_mtp_magic_send=False; the default batch-axis MTP "
-                    "carrier works at any pipeline_model_parallel_size. See the "
-                    "comment above this check for the memory arithmetic."
+                    "delivers full-length input_ids and cu_seqlens_q to the MTP "
+                    "stage through the pipeline dict, so magic send would only "
+                    "add a replicated trainable vocab table on that stage in "
+                    "order to shrink a P2P payload that overlap_p2p_comm "
+                    "already hides. Set enable_mtp_magic_send=False; the "
+                    "default batch-axis MTP carrier works at any "
+                    "pipeline_model_parallel_size."
                 )
             if self.experimental_dataflow:
                 # experimental_dataflow specifically produces
@@ -2299,33 +2245,22 @@ class TransformerConfig(ModelParallelConfig):
                     "the shifted embeddings from hidden_states, not from "
                     "mtp_decoder_inputs)."
                 )
-            # The erndata MTP path keeps its tensors full-length on every CP
-            # rank and slices them locally (extract_local_cp_chunks) instead of
-            # calling ContextParallelScatterOp, so the layout it slices with has
-            # to be one the rest of the model also uses:
+            # The erndata MTP path slices its full-length tensors locally
+            # (extract_local_cp_chunks) instead of calling
+            # ContextParallelScatterOp, so cp_balance_mode has to name a layout
+            # the rest of the model also uses:
             #   dualchunk_allgather  -> scatter_balance    (zigzag, MCore-like)
             #   contiguous_allgather -> scatter_contiguous (rank-order slices)
             #
-            # `contiguous_a2a` (Ulysses) is refused, but NOT because its
-            # sequence layout is unknown: ContextParallelScatterOp dispatches on
-            # `mode.startswith("contiguous")`, so a2a shards the sequence
-            # contiguously too and extract_local_contiguous_chunk would be the
-            # matching local slice. What differs is the *mask* contract:
-            # DotProductAttention.forward skips
-            # expand_attn_mask_startend_row_indices_for_cp under a2a
-            # because the head-axis all-to-all leaves each rank holding all
-            # sequence positions for a head subset, so the full-length
-            # row-index tensor this path builds is consumed differently. That
-            # combination has never been run end-to-end here, so it is rejected
-            # rather than assumed to work.
+            # contiguous_a2a shards the sequence contiguously too, but its mask
+            # contract differs (DotProductAttention.forward skips
+            # expand_attn_mask_startend_row_indices_for_cp under a2a) and has
+            # never been run here, so it is refused rather than assumed to work.
             #
-            # contiguous_allgather is a *necessary* condition for the DSv4
-            # hybrid stack -- DSv4HybridAttention.forward and
-            # MQALatentAttention.__init__ assert on it under CP because they
-            # build sparse-attention index tables over the global sequence and
-            # row-slice this rank's queries. It is not a sufficient one: see the
-            # separate erndata + Indexer + CP rejection in the dsv4_hybrid block
-            # below for a path that is still broken downstream.
+            # contiguous_allgather is necessary but not sufficient for the DSv4
+            # hybrid stack: DSv4HybridAttention/MQALatentAttention assert on it
+            # under CP, and the Indexer rejection in the dsv4_hybrid block below
+            # still rules the combination out.
             if self.context_parallel_size > 1:
                 if self.cp_balance_mode not in (
                     "dualchunk_allgather",
@@ -2338,17 +2273,13 @@ class TransformerConfig(ModelParallelConfig):
                         f"{self.cp_balance_mode!r}."
                     )
                 if self.gpt_model_use_experimental_version:
-                    # GPTEmbedding.forward passes
+                    # GPTEmbedding passes
                     # include_position_axis=gpt_model_use_experimental_version to
-                    # build_startend_row_indices_from_cu_seqlens, so the mask
-                    # becomes [B, 1, L, 2]. Under CP,
-                    # DotProductAttention.expand_attn_mask_startend_row_indices_for_cp
-                    # accepts a 2-column mask
-                    # only when config.experimental_dataflow is True -- which
-                    # this same block forbids for erndata -- and otherwise
-                    # raises "Invalid attention mask shape" from inside
-                    # attention. Reject here instead, where the offending flag
-                    # is named.
+                    # build_startend_row_indices_from_cu_seqlens, making the mask
+                    # [B, 1, L, 2]. Under CP the mask expansion accepts a
+                    # 2-column mask only when experimental_dataflow is True,
+                    # which this same block forbids; otherwise attention raises
+                    # "Invalid attention mask shape", naming neither flag.
                     raise ValueError(
                         "use_erndata=True with MTP + context_parallel_size>1 is "
                         "incompatible with "
@@ -2892,31 +2823,21 @@ class TransformerConfig(ModelParallelConfig):
                 and self.num_nextn_predict_layers > 0
                 and self.context_parallel_size > 1
             ):
-                # Both Indexers derive their token-count denominator from
-                # input_ids, and both assume input_ids arrives CP-*local*:
+                # Both Indexers assume input_ids arrives CP-*local*:
                 # CompressedSparseAttention.forward and
-                # MQALatentAttention._indexer_loss_mask gather it whenever
-                # `cp_world_size > 1 and not experimental_dataflow` and then
-                # reshape to [b, cp_size * s_local].
+                # MQALatentAttention._indexer_loss_mask all-gather it whenever
+                # `cp_world_size > 1 and not experimental_dataflow` and reshape
+                # to [b, cp_size * s_local]. That condition is exactly the
+                # erndata condition, but the premise is wrong here -- erndata
+                # hands the model a full-length global input_ids and nothing
+                # trims it -- so the gather over-counts by cp_size and dies on
+                # the reshape, and the position_offset = cp_rank * sq slice below
+                # it would be wrong even with the reshape fixed.
                 #
-                # That condition is exactly the erndata condition -- erndata
-                # forbids experimental_dataflow -- but the premise is wrong on
-                # this path: erndata hands the model a full-length global
-                # input_ids and nothing trims it (TransformerLayer.forward
-                # compares in global units, so its re-slice never fires). The
-                # gather therefore produces b * L * cp_size elements for a
-                # b * L reshape and dies with a shape error deep inside
-                # attention, and the position_offset = cp_rank * sq slice below
-                # it would be wrong even if the reshape were fixed.
-                #
-                # Before cp_balance_mode became configurable on this path the
-                # combination was unreachable: erndata + MTP + CP required
-                # dualchunk_allgather while the DSv4 layers assert
-                # contiguous_allgather. Widening that check made it
-                # config-legal, so keep the rejection explicit here rather than
-                # letting it resurface as a runtime crash. Making it work means
-                # teaching the Indexer loss-mask path that input_ids may already
-                # be global -- not done.
+                # Accepting contiguous_allgather above made this combination
+                # config-legal for the first time (it previously required
+                # dualchunk_allgather, which the DSv4 layers reject), so reject
+                # it here rather than let it resurface as a runtime crash.
                 raise ValueError(
                     "use_erndata=True with MTP + context_parallel_size>1 does "
                     "not support a model that builds an Indexer (CSAIndexer="

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -2346,16 +2346,25 @@ class TransformerConfig(ModelParallelConfig):
             # ever missing on the loss rank, LanguageLoss.forward raises rather
             # than silently rolling labels across packed-doc boundaries.
 
-        if self.use_erndata and self.context_parallel_size > 1:
+        if (
+            self.use_erndata
+            and self.context_parallel_size > 1
+            and not self.experimental_dataflow
+        ):
             # Under erndata nothing upstream shards by CP: the loader broadcasts
             # every tensor full-length to the whole CP group
             # (erndata_paddle_adapter._get_cp_group_and_src) and the model is
-            # expected to take its own slice. The only place that happens is
-            # GPTEmbedding's MTP branch, gated on num_nextn_predict_layers > 0
-            # and not mtp_load_weight_only; the generic
-            # ContextParallelScatterOp fallback beside it is gated on
-            # experimental_dataflow, which the block above forbids. So with MTP
-            # off (or weight-only) the hidden states stay length L while
+            # expected to take its own slice. Exactly two paths do that:
+            #   * GPTEmbedding's MTP branch (extract_local_cp_chunks), gated on
+            #     num_nextn_predict_layers > 0 and not mtp_load_weight_only;
+            #   * the plain-path ContextParallelScatterOp beside it, gated on
+            #     experimental_dataflow, which also scatters the RoPE tables and
+            #     -- in LanguageLoss._forward -- the labels. The MTP block above
+            #     forbids experimental_dataflow whenever
+            #     num_nextn_predict_layers > 0, so this path is only reachable at
+            #     K == 0, and there it is legal: hence the guard is skipped
+            #     rather than applied to it.
+            # With neither active the hidden states stay length L while
             # DotProductAttention computes seq_len = key.shape[1] * cp_size and
             # expand() fails against an L-row mask -- a shape error naming
             # neither use_erndata nor cp_balance_mode. Note use_erndata is set
@@ -2363,12 +2372,13 @@ class TransformerConfig(ModelParallelConfig):
             # section, so this is reachable without any MTP-specific flag.
             if self.num_nextn_predict_layers <= 0 or self.mtp_load_weight_only:
                 raise ValueError(
-                    "use_erndata=True with context_parallel_size>1 requires "
-                    "MTP (num_nextn_predict_layers>0, mtp_load_weight_only="
-                    "False): the erndata loader hands every CP rank the "
-                    "full-length sequence and only the MTP branch of "
-                    "GPTEmbedding slices it, so with MTP off no CP sharding "
-                    "happens at all. Got num_nextn_predict_layers="
+                    "use_erndata=True with context_parallel_size>1 needs some "
+                    "path that slices the loader's full-length sequence: "
+                    "either MTP (num_nextn_predict_layers>0, "
+                    "mtp_load_weight_only=False), which slices in GPTEmbedding, "
+                    "or experimental_dataflow=True, whose plain-path "
+                    "ContextParallelScatterOp does it. With neither, no CP "
+                    "sharding happens at all. Got num_nextn_predict_layers="
                     f"{self.num_nextn_predict_layers}, mtp_load_weight_only="
                     f"{self.mtp_load_weight_only}."
                 )

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -2308,11 +2308,11 @@ class TransformerConfig(ModelParallelConfig):
             #
             # `contiguous_a2a` (Ulysses) is refused, but NOT because its
             # sequence layout is unknown: ContextParallelScatterOp dispatches on
-            # `mode.startswith("contiguous")` (context_parallel_utils.py:533),
-            # so a2a shards the sequence contiguously too and
-            # extract_local_contiguous_chunk would be the matching local slice.
-            # What differs is the *mask* contract: dot_product_attention.py:532
-            # skips expand_attn_mask_startend_row_indices_for_cp under a2a
+            # `mode.startswith("contiguous")`, so a2a shards the sequence
+            # contiguously too and extract_local_contiguous_chunk would be the
+            # matching local slice. What differs is the *mask* contract:
+            # DotProductAttention.forward skips
+            # expand_attn_mask_startend_row_indices_for_cp under a2a
             # because the head-axis all-to-all leaves each rank holding all
             # sequence positions for a head subset, so the full-length
             # row-index tensor this path builds is consumed differently. That
@@ -2320,8 +2320,8 @@ class TransformerConfig(ModelParallelConfig):
             # rather than assumed to work.
             #
             # contiguous_allgather is a *necessary* condition for the DSv4
-            # hybrid stack -- dsv4_hybrid_attention.py:997 and
-            # mqa_latent_attention.py:686 assert on it under CP because they
+            # hybrid stack -- DSv4HybridAttention.forward and
+            # MQALatentAttention.__init__ assert on it under CP because they
             # build sparse-attention index tables over the global sequence and
             # row-slice this rank's queries. It is not a sufficient one: see the
             # separate erndata + Indexer + CP rejection in the dsv4_hybrid block
@@ -2338,12 +2338,12 @@ class TransformerConfig(ModelParallelConfig):
                         f"{self.cp_balance_mode!r}."
                     )
                 if self.gpt_model_use_experimental_version:
-                    # gpt_embedding.py:467 passes
+                    # GPTEmbedding.forward passes
                     # include_position_axis=gpt_model_use_experimental_version to
                     # build_startend_row_indices_from_cu_seqlens, so the mask
                     # becomes [B, 1, L, 2]. Under CP,
-                    # expand_attn_mask_startend_row_indices_for_cp
-                    # (dot_product_attention.py:470-480) accepts a 2-column mask
+                    # DotProductAttention.expand_attn_mask_startend_row_indices_for_cp
+                    # accepts a 2-column mask
                     # only when config.experimental_dataflow is True -- which
                     # this same block forbids for erndata -- and otherwise
                     # raises "Invalid attention mask shape" from inside
@@ -2894,15 +2894,15 @@ class TransformerConfig(ModelParallelConfig):
             ):
                 # Both Indexers derive their token-count denominator from
                 # input_ids, and both assume input_ids arrives CP-*local*:
-                # csa_attention.py:2884-2911 and
-                # mqa_latent_attention.py:2494-2502 gather it whenever
+                # CompressedSparseAttention.forward and
+                # MQALatentAttention._indexer_loss_mask gather it whenever
                 # `cp_world_size > 1 and not experimental_dataflow` and then
                 # reshape to [b, cp_size * s_local].
                 #
                 # That condition is exactly the erndata condition -- erndata
                 # forbids experimental_dataflow -- but the premise is wrong on
                 # this path: erndata hands the model a full-length global
-                # input_ids and nothing trims it (transformer_layer.py:800-811
+                # input_ids and nothing trims it (TransformerLayer.forward
                 # compares in global units, so its re-slice never fires). The
                 # gather therefore produces b * L * cp_size elements for a
                 # b * L reshape and dies with a shape error deep inside

--- a/tests/multi_card_tests/test_gpt_mtp_megatron_cp.py
+++ b/tests/multi_card_tests/test_gpt_mtp_megatron_cp.py
@@ -402,6 +402,41 @@ class TestMTPMegatronCPContiguousRope(unittest.TestCase):
             masks["dualchunk_allgather"], masks["contiguous_allgather"]
         )
 
+    def test_cp_invariant_loss_contiguous(self):
+        """End-to-end loss under ``contiguous_allgather``, not just the layout.
+
+        The layout checks above stop at ``GPTEmbedding``; everything after it --
+        ``roll_tensor`` + ``extract_local_cp_chunks`` per MTP depth, the CP
+        flashmask attention (``FlashMaskContextParallel`` with
+        ``mode="contiguous_allgather"``), and LanguageLoss's per-depth label
+        scatter -- is only exercised by a real forward/backward. Same ``REF_LOSS``
+        as the zigzag test: ``cp_balance_mode`` is a no-op at ``cp_size == 1``, so
+        the single-card reference is shared, and a correct implementation is
+        CP-invariant in either layout.
+        """
+        if (
+            not paddle.device.current_device_is_cpu
+            and paddle.device.get_device_capability()[0] < 9
+        ):
+            self.skipTest("requires SM90+ for the CP flashmask kernels")
+
+        paddle.seed(SEED)
+        model = gpt_builder(
+            _make_config(cp_balance_mode="contiguous_allgather"), num_stages=1
+        )
+        model = paddle.amp.decorate(
+            models=model, optimizers=None, level="O2", dtype="bfloat16"
+        )
+        loss = _forward_backward(model, _make_inputs())
+
+        val = float(loss.astype("float32"))
+        print(
+            f"[MTP-MEGATRON-CP] cp={CP_SIZE} mode=contiguous loss={val}",
+            flush=True,
+        )
+        self.assertTrue(np.isfinite(val), f"loss must be finite, got {val}")
+        np.testing.assert_allclose(val, REF_LOSS, rtol=5e-3, atol=0)
+
 
 class TestMTPMegatronCP(unittest.TestCase):
     def test_cp_invariant_loss(self):

--- a/tests/multi_card_tests/test_gpt_mtp_megatron_cp.py
+++ b/tests/multi_card_tests/test_gpt_mtp_megatron_cp.py
@@ -15,18 +15,29 @@
 """CP-aware ``use_erndata=True`` end-to-end test (CP=1 vs CP=2).
 
 The megatron MTP branch in ``GPTEmbedding`` slices the sequence itself with
-``extract_local_zigzag_chunks`` instead of going through
+``extract_local_cp_chunks`` instead of going through
 ``ContextParallelScatterOp`` (which is gated on ``experimental_dataflow``, a
 flag this style forbids). The RoPE tables are built by
 ``RotaryEmbedding.get_rotary_seq_len``, which scales the rank-local length back
 up by ``cp_group.world_size`` and therefore always yields the FULL length L --
-so they must be zigzag-sliced with the same layout, otherwise every rank
-applies the positions ``0..L/cp-1`` to chunks that actually live at
-``[interval*r, interval*(r+1)) u [L-interval*(r+1), L-interval*r)``.
+so they must be sliced with the same layout as the embeddings, otherwise every
+rank applies the positions ``0..L/cp-1`` to chunks that actually live
+elsewhere in the sequence.
 
-The primary check is a LAYOUT one (``test_rope_matches_zigzag_layout``): the
-``rotary_pos_emb`` the real ``GPTEmbedding`` hands to the decoder must equal the
-zigzag slice of the full-length table this rank's ``RotaryEmbedding`` produces.
+Which layout that is comes from ``config.cp_balance_mode``, and both supported
+values are exercised here:
+
+  ``dualchunk_allgather``  -> two zigzag chunks,
+    ``[interval*r, interval*(r+1)) u [L-interval*(r+1), L-interval*r)``
+    (``TestMTPMegatronCPRope``)
+  ``contiguous_allgather`` -> one rank-order chunk, ``[r*L/cp, (r+1)*L/cp)``
+    (``TestMTPMegatronCPContiguousRope``) -- the layout the DSv4 hybrid stack
+    requires under CP.
+
+The primary check in both is a LAYOUT one: the ``rotary_pos_emb`` the real
+``GPTEmbedding`` hands to the decoder must equal the mode's slice of the
+full-length table this rank's ``RotaryEmbedding`` produces, and must NOT equal
+the other mode's slice.
 
 ``test_cp_invariant_loss`` is a coarse companion: same weights (CPU init, so
 rank-independent) and same data must give the same loss at any ``cp_degree``.
@@ -114,7 +125,7 @@ def setUpModule():
     model_parallel_cuda_manual_seed(SEED)
 
 
-def _make_config():
+def _make_config(cp_balance_mode="dualchunk_allgather"):
     return GPTConfig(
         vocab_size=VOCAB,
         max_sequence_length=SEQ,
@@ -143,7 +154,7 @@ def _make_config():
         use_erndata=True,
         # CP
         context_parallel_size=CP_SIZE,
-        cp_balance_mode="dualchunk_allgather",
+        cp_balance_mode=cp_balance_mode,
         experimental_dataflow=False,
         sequence_parallel=False,
         tensor_model_parallel_size=1,
@@ -295,6 +306,101 @@ class TestMTPMegatronCPRope(unittest.TestCase):
                 ),
                 "rank>0 must not receive the contiguous RoPE prefix",
             )
+
+
+class TestMTPMegatronCPContiguousRope(unittest.TestCase):
+    """Same layout check for ``cp_balance_mode="contiguous_allgather"``.
+
+    Not a duplicate of the zigzag class: ``contiguous_allgather`` is a distinct
+    scatter layout (``scatter_contiguous``) and is *mandatory* for the DSv4
+    hybrid stack, whose attention layers assert on it under CP. Until this
+    class existed the only multi-card evidence for that layout came from
+    end-to-end training runs, which CI never sees -- so a call site that
+    hard-coded zigzag would have passed every test here.
+    """
+
+    def test_rope_matches_contiguous_layout(self):
+        from paddlefleet.parallel_state import get_context_parallel_rank
+        from paddlefleet.transformer.multi_token_prediction import (
+            extract_local_contiguous_chunk,
+            extract_local_zigzag_chunks,
+        )
+
+        paddle.seed(SEED)
+        model = gpt_builder(
+            _make_config(cp_balance_mode="contiguous_allgather"), num_stages=1
+        )
+        emb = _find_embedding(model)
+        raw = _make_inputs()
+
+        out = emb.forward(
+            {
+                "input_ids": raw["input_ids"],
+                "position_ids": raw["position_ids"],
+                "cu_seqlens_q": raw["cu_seqlens_q"],
+            }
+        )
+        rope_local = out["rotary_pos_emb"]
+
+        self.assertEqual(out["hidden_states"].shape[1], SEQ // CP_SIZE)
+        self.assertEqual(rope_local.shape[1], SEQ // CP_SIZE)
+
+        full = emb.rotary_pos_emb(SEQ)
+        cp_rank = get_context_parallel_rank() if CP_SIZE > 1 else 0
+        expected = extract_local_contiguous_chunk(
+            full, cp_rank, CP_SIZE, axis=1
+        )
+        np.testing.assert_array_equal(
+            rope_local.astype("float32").numpy(),
+            expected.astype("float32").numpy(),
+        )
+
+        if CP_SIZE > 1:
+            # And it must NOT be the zigzag slice: at CP=2 the two layouts
+            # differ on both ranks (rank0 [0:8)u[24:32) vs [0:16), rank1
+            # [8:24) vs [16:32) for L=32), so this is what would catch a call
+            # site that ignored cp_balance_mode.
+            zigzag = extract_local_zigzag_chunks(full, cp_rank, CP_SIZE, axis=1)
+            self.assertFalse(
+                bool(
+                    paddle.all(
+                        rope_local.astype("float32") == zigzag.astype("float32")
+                    )
+                ),
+                "contiguous_allgather must not receive the zigzag RoPE slice",
+            )
+
+    def test_derived_mask_stays_global_under_contiguous(self):
+        """The derived flashmask is full-length in BOTH layouts.
+
+        ``build_startend_row_indices_from_cu_seqlens`` is deliberately not
+        sliced: CP attention allgathers KV and remaps the global row values
+        itself. Pinning it per-layout keeps a future "slice the mask too as
+        well" change from passing silently under one mode.
+        """
+        masks = {}
+        for mode in ("dualchunk_allgather", "contiguous_allgather"):
+            paddle.seed(SEED)
+            model = gpt_builder(
+                _make_config(cp_balance_mode=mode), num_stages=1
+            )
+            emb = _find_embedding(model)
+            raw = _make_inputs(with_mask=False)
+            out = emb.forward(
+                {
+                    "input_ids": raw["input_ids"],
+                    "position_ids": raw["position_ids"],
+                    "cu_seqlens_q": raw["cu_seqlens_q"],
+                }
+            )
+            mask = out.get("attn_mask_startend_row_indices")
+            self.assertIsNotNone(mask, f"no derived mask under {mode}")
+            self.assertEqual(list(mask.shape), [BATCH, 1, SEQ, 1])
+            masks[mode] = mask.numpy()
+
+        np.testing.assert_array_equal(
+            masks["dualchunk_allgather"], masks["contiguous_allgather"]
+        )
 
 
 class TestMTPMegatronCP(unittest.TestCase):

--- a/tests/single_card_tests/transformer/test_extract_local_cp_chunks.py
+++ b/tests/single_card_tests/transformer/test_extract_local_cp_chunks.py
@@ -116,9 +116,7 @@ class TestExtractLocalCpChunksDispatch(unittest.TestCase):
             got = extract_local_cp_chunks(
                 t, rank, cp_size, axis=1, mode="contiguous_allgather"
             )
-            expected = extract_local_contiguous_chunk(
-                t, rank, cp_size, axis=1
-            )
+            expected = extract_local_contiguous_chunk(t, rank, cp_size, axis=1)
             self.assertTrue(bool((got == expected).all()))
 
     def test_the_two_layouts_actually_differ(self) -> None:
@@ -162,9 +160,7 @@ class TestExtractLocalCpChunksDispatch(unittest.TestCase):
     def test_contiguous_a2a_raises(self) -> None:
         t = _arange_bl(1, 16)
         with self.assertRaisesRegex(ValueError, r"unsupported cp_balance_mode"):
-            extract_local_cp_chunks(
-                t, 0, 2, axis=1, mode="contiguous_a2a"
-            )
+            extract_local_cp_chunks(t, 0, 2, axis=1, mode="contiguous_a2a")
 
     def test_unknown_mode_raises(self) -> None:
         t = _arange_bl(1, 16)

--- a/tests/single_card_tests/transformer/test_extract_local_cp_chunks.py
+++ b/tests/single_card_tests/transformer/test_extract_local_cp_chunks.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Layout-aware CP slicing for the ``use_erndata`` MTP path.
+
+The erndata MTP path never calls ``ContextParallelScatterOp``: it keeps its
+tensors full-length on every CP rank and slices the local part itself. That
+slice must reproduce, bit for bit, the layout the rest of the model scatters
+with — otherwise the labels/embeddings a rank holds belong to *other* ranks'
+tokens and the loss is silently wrong. So the parity checks here are against
+``context_parallel_utils``' own scatter helpers:
+
+  ``dualchunk_allgather``  -> ``scatter_balance``    (two zigzag chunks)
+  ``contiguous_allgather`` -> ``scatter_contiguous`` (one rank-order chunk)
+
+Covered:
+  1. ``extract_local_contiguous_chunk`` == the slice ``scatter_contiguous``
+     computes, for every rank, and the ranks tile the sequence exactly once.
+  2. ``extract_local_cp_chunks`` dispatch: dualchunk -> zigzag helper,
+     contiguous_allgather -> contiguous helper, ``cp_size == 1`` -> identity.
+  3. Unsupported modes (``contiguous_a2a``, typos) raise ValueError rather than
+     silently defaulting to a layout.
+  4. Divisibility guards.
+  5. Negative ``axis`` and non-sequence axes behave like the zigzag helper.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import paddle
+
+from paddlefleet.transformer.multi_token_prediction import (
+    extract_local_contiguous_chunk,
+    extract_local_cp_chunks,
+    extract_local_zigzag_chunks,
+)
+
+
+def _arange_bl(batch: int, length: int) -> paddle.Tensor:
+    """[B, L] with globally unique values so slices are traceable."""
+    return paddle.arange(batch * length, dtype="int64").reshape([batch, length])
+
+
+class TestExtractLocalContiguousChunk(unittest.TestCase):
+    def test_matches_scatter_contiguous_layout(self) -> None:
+        # scatter_contiguous: rank r gets [r*chunk, (r+1)*chunk).
+        cp_size, length = 4, 16
+        t = _arange_bl(2, length)
+        chunk = length // cp_size
+        for rank in range(cp_size):
+            local = extract_local_contiguous_chunk(t, rank, cp_size, axis=1)
+            expected = t[:, rank * chunk : (rank + 1) * chunk]
+            self.assertEqual(local.shape, [2, chunk])
+            self.assertTrue(bool((local == expected).all()))
+
+    def test_ranks_tile_the_sequence_exactly_once(self) -> None:
+        cp_size, length = 4, 16
+        t = _arange_bl(1, length)
+        rebuilt = paddle.concat(
+            [
+                extract_local_contiguous_chunk(t, r, cp_size, axis=1)
+                for r in range(cp_size)
+            ],
+            axis=1,
+        )
+        self.assertTrue(bool((rebuilt == t).all()))
+
+    def test_cp_size_one_is_identity(self) -> None:
+        t = _arange_bl(2, 7)
+        self.assertIs(extract_local_contiguous_chunk(t, 0, 1, axis=1), t)
+
+    def test_indivisible_length_raises(self) -> None:
+        # scatter_contiguous refuses an uneven split (it would drop the tail
+        # while all_gather_contiguous still reports the shorter length), so the
+        # local-slice twin must refuse it too.
+        t = _arange_bl(1, 10)
+        with self.assertRaisesRegex(ValueError, r"divisible by cp_size"):
+            extract_local_contiguous_chunk(t, 0, 4, axis=1)
+
+    def test_negative_axis(self) -> None:
+        t = _arange_bl(2, 8)
+        self.assertTrue(
+            bool(
+                (
+                    extract_local_contiguous_chunk(t, 1, 2, axis=-1)
+                    == extract_local_contiguous_chunk(t, 1, 2, axis=1)
+                ).all()
+            )
+        )
+
+    def test_slices_only_the_requested_axis(self) -> None:
+        t = paddle.arange(2 * 8 * 3, dtype="int64").reshape([2, 8, 3])
+        local = extract_local_contiguous_chunk(t, 1, 2, axis=1)
+        self.assertEqual(local.shape, [2, 4, 3])
+        self.assertTrue(bool((local == t[:, 4:8, :]).all()))
+
+
+class TestExtractLocalCpChunksDispatch(unittest.TestCase):
+    def test_dualchunk_delegates_to_zigzag(self) -> None:
+        cp_size, length = 2, 16
+        t = _arange_bl(2, length)
+        for rank in range(cp_size):
+            got = extract_local_cp_chunks(
+                t, rank, cp_size, axis=1, mode="dualchunk_allgather"
+            )
+            expected = extract_local_zigzag_chunks(t, rank, cp_size, axis=1)
+            self.assertTrue(bool((got == expected).all()))
+
+    def test_contiguous_delegates_to_contiguous(self) -> None:
+        cp_size, length = 2, 16
+        t = _arange_bl(2, length)
+        for rank in range(cp_size):
+            got = extract_local_cp_chunks(
+                t, rank, cp_size, axis=1, mode="contiguous_allgather"
+            )
+            expected = extract_local_contiguous_chunk(
+                t, rank, cp_size, axis=1
+            )
+            self.assertTrue(bool((got == expected).all()))
+
+    def test_the_two_layouts_actually_differ(self) -> None:
+        # Guards the whole point of this change: if these were equal, routing
+        # the erndata MTP path through the mode would be a no-op and the bug
+        # (zigzag labels vs contiguous logits) would be invisible.
+        t = _arange_bl(1, 16)
+        zig = extract_local_cp_chunks(
+            t, 0, 2, axis=1, mode="dualchunk_allgather"
+        )
+        con = extract_local_cp_chunks(
+            t, 0, 2, axis=1, mode="contiguous_allgather"
+        )
+        self.assertEqual(zig.shape, con.shape)
+        self.assertFalse(bool((zig == con).all()))
+
+    def test_default_mode_is_dualchunk(self) -> None:
+        # Callers that predate the mode argument must keep the old layout.
+        t = _arange_bl(1, 16)
+        self.assertTrue(
+            bool(
+                (
+                    extract_local_cp_chunks(t, 1, 2, axis=1)
+                    == extract_local_zigzag_chunks(t, 1, 2, axis=1)
+                ).all()
+            )
+        )
+
+    def test_cp_size_one_is_identity_for_any_mode(self) -> None:
+        t = _arange_bl(2, 7)
+        for mode in (
+            "dualchunk_allgather",
+            "contiguous_allgather",
+            "contiguous_a2a",
+            "nonsense",
+        ):
+            self.assertIs(
+                extract_local_cp_chunks(t, 0, 1, axis=1, mode=mode), t
+            )
+
+    def test_contiguous_a2a_raises(self) -> None:
+        t = _arange_bl(1, 16)
+        with self.assertRaisesRegex(ValueError, r"unsupported cp_balance_mode"):
+            extract_local_cp_chunks(
+                t, 0, 2, axis=1, mode="contiguous_a2a"
+            )
+
+    def test_unknown_mode_raises(self) -> None:
+        t = _arange_bl(1, 16)
+        with self.assertRaisesRegex(ValueError, r"unsupported cp_balance_mode"):
+            extract_local_cp_chunks(t, 0, 2, axis=1, mode="zigzag")
+
+    def test_float_tensors_pass_through_both_modes(self) -> None:
+        # The embedding call sites slice [B, L, H] float tensors.
+        t = paddle.randn([2, 8, 4], dtype="float32")
+        for mode in ("dualchunk_allgather", "contiguous_allgather"):
+            local = extract_local_cp_chunks(t, 1, 2, axis=1, mode=mode)
+            self.assertEqual(local.shape, [2, 4, 4])
+            self.assertEqual(local.dtype, t.dtype)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_extract_local_cp_chunks.py
+++ b/tests/single_card_tests/transformer/test_extract_local_cp_chunks.py
@@ -9,21 +9,28 @@ The erndata MTP path never calls ``ContextParallelScatterOp``: it keeps its
 tensors full-length on every CP rank and slices the local part itself. That
 slice must reproduce, bit for bit, the layout the rest of the model scatters
 with — otherwise the labels/embeddings a rank holds belong to *other* ranks'
-tokens and the loss is silently wrong. So the parity checks here are against
-``context_parallel_utils``' own scatter helpers:
+tokens and the loss is silently wrong. So the parity checks here call
+``context_parallel_utils``' own scatter helpers directly:
 
   ``dualchunk_allgather``  -> ``scatter_balance``    (two zigzag chunks)
   ``contiguous_allgather`` -> ``scatter_contiguous`` (one rank-order chunk)
 
+Both helpers only read ``group.nranks`` and ``group.rank``, so ``_FakeGroup``
+below is enough to exercise them single-card with no distributed init. That
+matters: comparing against a hand-written slice would pass forever while the
+real scatter drifted underneath us, which is precisely the failure this whole
+change is about.
+
 Covered:
-  1. ``extract_local_contiguous_chunk`` == the slice ``scatter_contiguous``
-     computes, for every rank, and the ranks tile the sequence exactly once.
-  2. ``extract_local_cp_chunks`` dispatch: dualchunk -> zigzag helper,
-     contiguous_allgather -> contiguous helper, ``cp_size == 1`` -> identity.
-  3. Unsupported modes (``contiguous_a2a``, typos) raise ValueError rather than
+  1. ``extract_local_contiguous_chunk`` == ``scatter_contiguous`` for every
+     rank, and the ranks tile the sequence exactly once.
+  2. ``extract_local_cp_chunks`` == ``scatter_balance`` / ``scatter_contiguous``
+     for the mode each one implements.
+  3. ``mode`` is required and keyword-only — no default layout to fall into.
+  4. Unsupported modes (``contiguous_a2a``, typos) raise ValueError rather than
      silently defaulting to a layout.
-  4. Divisibility guards.
-  5. Negative ``axis`` and non-sequence axes behave like the zigzag helper.
+  5. Divisibility guards.
+  6. Negative ``axis`` and non-sequence axes behave like the zigzag helper.
 """
 
 from __future__ import annotations
@@ -32,11 +39,27 @@ import unittest
 
 import paddle
 
+from paddlefleet.context_parallel_utils import (
+    scatter_balance,
+    scatter_contiguous,
+)
 from paddlefleet.transformer.multi_token_prediction import (
     extract_local_contiguous_chunk,
     extract_local_cp_chunks,
     extract_local_zigzag_chunks,
 )
+
+
+class _FakeGroup:
+    """Minimal stand-in for a paddle CP group.
+
+    ``scatter_balance`` and ``scatter_contiguous`` touch nothing but these two
+    attributes, so this keeps the parity checks single-card.
+    """
+
+    def __init__(self, rank: int, nranks: int) -> None:
+        self.rank = rank
+        self.nranks = nranks
 
 
 def _arange_bl(batch: int, length: int) -> paddle.Tensor:
@@ -46,14 +69,15 @@ def _arange_bl(batch: int, length: int) -> paddle.Tensor:
 
 class TestExtractLocalContiguousChunk(unittest.TestCase):
     def test_matches_scatter_contiguous_layout(self) -> None:
-        # scatter_contiguous: rank r gets [r*chunk, (r+1)*chunk).
+        # Parity against the real scatter, not a re-derivation of it.
         cp_size, length = 4, 16
         t = _arange_bl(2, length)
-        chunk = length // cp_size
         for rank in range(cp_size):
             local = extract_local_contiguous_chunk(t, rank, cp_size, axis=1)
-            expected = t[:, rank * chunk : (rank + 1) * chunk]
-            self.assertEqual(local.shape, [2, chunk])
+            expected = scatter_contiguous(
+                t, group=_FakeGroup(rank, cp_size), axis=1
+            )
+            self.assertEqual(local.shape, expected.shape)
             self.assertTrue(bool((local == expected).all()))
 
     def test_ranks_tile_the_sequence_exactly_once(self) -> None:
@@ -99,6 +123,32 @@ class TestExtractLocalContiguousChunk(unittest.TestCase):
 
 
 class TestExtractLocalCpChunksDispatch(unittest.TestCase):
+    def test_dualchunk_matches_scatter_balance(self) -> None:
+        cp_size, length = 2, 16
+        t = _arange_bl(2, length)
+        for rank in range(cp_size):
+            got = extract_local_cp_chunks(
+                t, rank, cp_size, axis=1, mode="dualchunk_allgather"
+            )
+            expected = scatter_balance(
+                t, group=_FakeGroup(rank, cp_size), axis=1
+            )
+            self.assertEqual(got.shape, expected.shape)
+            self.assertTrue(bool((got == expected).all()))
+
+    def test_contiguous_matches_scatter_contiguous(self) -> None:
+        cp_size, length = 2, 16
+        t = _arange_bl(2, length)
+        for rank in range(cp_size):
+            got = extract_local_cp_chunks(
+                t, rank, cp_size, axis=1, mode="contiguous_allgather"
+            )
+            expected = scatter_contiguous(
+                t, group=_FakeGroup(rank, cp_size), axis=1
+            )
+            self.assertEqual(got.shape, expected.shape)
+            self.assertTrue(bool((got == expected).all()))
+
     def test_dualchunk_delegates_to_zigzag(self) -> None:
         cp_size, length = 2, 16
         t = _arange_bl(2, length)
@@ -133,17 +183,20 @@ class TestExtractLocalCpChunksDispatch(unittest.TestCase):
         self.assertEqual(zig.shape, con.shape)
         self.assertFalse(bool((zig == con).all()))
 
-    def test_default_mode_is_dualchunk(self) -> None:
-        # Callers that predate the mode argument must keep the old layout.
+    def test_mode_is_required(self) -> None:
+        # No default layout on purpose. The defect this function fixes was a
+        # call site that assumed zigzag instead of reading cp_balance_mode; a
+        # default would hand the next caller the same silent-wrong-loss bug
+        # instead of a TypeError at import-time-obvious call sites.
         t = _arange_bl(1, 16)
-        self.assertTrue(
-            bool(
-                (
-                    extract_local_cp_chunks(t, 1, 2, axis=1)
-                    == extract_local_zigzag_chunks(t, 1, 2, axis=1)
-                ).all()
-            )
-        )
+        with self.assertRaises(TypeError):
+            extract_local_cp_chunks(t, 1, 2, axis=1)
+
+    def test_mode_is_keyword_only(self) -> None:
+        # Positional passing would let `axis` and `mode` be swapped silently.
+        t = _arange_bl(1, 16)
+        with self.assertRaises(TypeError):
+            extract_local_cp_chunks(t, 1, 2, 1, "dualchunk_allgather")
 
     def test_cp_size_one_is_identity_for_any_mode(self) -> None:
         t = _arange_bl(2, 7)

--- a/tests/single_card_tests/transformer/test_extract_local_cp_chunks.py
+++ b/tests/single_card_tests/transformer/test_extract_local_cp_chunks.py
@@ -5,32 +5,22 @@
 
 """Layout-aware CP slicing for the ``use_erndata`` MTP path.
 
-The erndata MTP path never calls ``ContextParallelScatterOp``: it keeps its
-tensors full-length on every CP rank and slices the local part itself. That
-slice must reproduce, bit for bit, the layout the rest of the model scatters
-with — otherwise the labels/embeddings a rank holds belong to *other* ranks'
-tokens and the loss is silently wrong. So the parity checks here call
-``context_parallel_utils``' own scatter helpers directly:
+That path never calls ``ContextParallelScatterOp``: it keeps its tensors
+full-length on every CP rank and slices the local part itself. The slice must
+reproduce the layout the rest of the model scatters with, or a rank holds
+*other* ranks' tokens and the loss is silently wrong. So the parity checks call
+``context_parallel_utils``' own scatter helpers rather than a hand-written
+slice, which would keep passing while the real scatter drifted underneath:
 
   ``dualchunk_allgather``  -> ``scatter_balance``    (two zigzag chunks)
   ``contiguous_allgather`` -> ``scatter_contiguous`` (one rank-order chunk)
 
-Both helpers only read ``group.nranks`` and ``group.rank``, so ``_FakeGroup``
-below is enough to exercise them single-card with no distributed init. That
-matters: comparing against a hand-written slice would pass forever while the
-real scatter drifted underneath us, which is precisely the failure this whole
-change is about.
+Both helpers read only ``group.nranks`` / ``group.rank``, so ``_FakeGroup``
+below is enough to exercise them single-card with no distributed init.
 
-Covered:
-  1. ``extract_local_contiguous_chunk`` == ``scatter_contiguous`` for every
-     rank, and the ranks tile the sequence exactly once.
-  2. ``extract_local_cp_chunks`` == ``scatter_balance`` / ``scatter_contiguous``
-     for the mode each one implements.
-  3. ``mode`` is required and keyword-only — no default layout to fall into.
-  4. Unsupported modes (``contiguous_a2a``, typos) raise ValueError rather than
-     silently defaulting to a layout.
-  5. Divisibility guards.
-  6. Negative ``axis`` and non-sequence axes behave like the zigzag helper.
+Also covered: ``mode`` is required and keyword-only, unsupported modes raise
+instead of defaulting to a layout, divisibility guards, and negative /
+non-sequence axes.
 """
 
 from __future__ import annotations
@@ -187,10 +177,8 @@ class TestExtractLocalCpChunksDispatch(unittest.TestCase):
         self.assertFalse(bool((zig == con).all()))
 
     def test_mode_is_required(self) -> None:
-        # No default layout on purpose. The defect this function fixes was a
-        # call site that assumed zigzag instead of reading cp_balance_mode; a
-        # default would hand the next caller the same silent-wrong-loss bug
-        # instead of a TypeError at import-time-obvious call sites.
+        # No default layout on purpose: the defect this helper fixes was a call
+        # site that assumed zigzag instead of reading cp_balance_mode.
         t = _arange_bl(1, 16)
         with self.assertRaises(TypeError):
             extract_local_cp_chunks(t, 1, 2, axis=1)
@@ -202,11 +190,10 @@ class TestExtractLocalCpChunksDispatch(unittest.TestCase):
             extract_local_cp_chunks(t, 1, 2, 1, "dualchunk_allgather")
 
     def test_cp_size_one_is_identity_for_any_mode(self) -> None:
-        # Identity, not a copy: this deliberately differs from scatter_balance
-        # (clone) and scatter_contiguous (paddle.assign), so an in-place write
-        # on the result would reach the caller's full-length tensor. Pinned here
-        # because it is a property callers rely on for the cheap CP=1 path, not
-        # an accident -- see the Note in extract_local_cp_chunks' docstring.
+        # Identity, not a copy -- unlike scatter_balance (clone) and
+        # scatter_contiguous (paddle.assign), so an in-place write on the result
+        # would reach the caller's full-length tensor. Pinned because callers
+        # rely on it for the cheap CP=1 path.
         t = _arange_bl(2, 7)
         for mode in (
             "dualchunk_allgather",

--- a/tests/single_card_tests/transformer/test_extract_local_cp_chunks.py
+++ b/tests/single_card_tests/transformer/test_extract_local_cp_chunks.py
@@ -124,7 +124,10 @@ class TestExtractLocalContiguousChunk(unittest.TestCase):
 
 class TestExtractLocalCpChunksDispatch(unittest.TestCase):
     def test_dualchunk_matches_scatter_balance(self) -> None:
-        cp_size, length = 2, 16
+        # cp_size=4: with only two ranks the zigzag layout degenerates to
+        # "first quarter + last quarter", which several wrong implementations
+        # also produce. Four ranks pin the interleaving.
+        cp_size, length = 4, 16
         t = _arange_bl(2, length)
         for rank in range(cp_size):
             got = extract_local_cp_chunks(
@@ -137,7 +140,7 @@ class TestExtractLocalCpChunksDispatch(unittest.TestCase):
             self.assertTrue(bool((got == expected).all()))
 
     def test_contiguous_matches_scatter_contiguous(self) -> None:
-        cp_size, length = 2, 16
+        cp_size, length = 4, 16
         t = _arange_bl(2, length)
         for rank in range(cp_size):
             got = extract_local_cp_chunks(
@@ -199,6 +202,11 @@ class TestExtractLocalCpChunksDispatch(unittest.TestCase):
             extract_local_cp_chunks(t, 1, 2, 1, "dualchunk_allgather")
 
     def test_cp_size_one_is_identity_for_any_mode(self) -> None:
+        # Identity, not a copy: this deliberately differs from scatter_balance
+        # (clone) and scatter_contiguous (paddle.assign), so an in-place write
+        # on the result would reach the caller's full-length tensor. Pinned here
+        # because it is a property callers rely on for the cheap CP=1 path, not
+        # an accident -- see the Note in extract_local_cp_chunks' docstring.
         t = _arange_bl(2, 7)
         for mode in (
             "dualchunk_allgather",

--- a/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
+++ b/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
@@ -70,7 +70,7 @@ def _make_embedding(K, B, L, H, *, use_erndata=True, magic_send=False):
     cfg.pad_token_id = 0
     cfg.experimental_dataflow = False
     cfg.apply_rope_fusion = False
-    cfg.cp_balance_mode = "zigzag"
+    cfg.cp_balance_mode = "dualchunk_allgather"
     cfg.clone_scatter_output_in_embedding = False
     cfg.layer_types = []  # -> has_kda_layer property returns False
     emb.config = cfg
@@ -98,7 +98,7 @@ def _make_embedding(K, B, L, H, *, use_erndata=True, magic_send=False):
 def _fake_cp(cp_size=2):
     """Force ``get_context_parallel_world_size`` -> cp_size and rank -> 0 in
     the gpt_embedding namespace so ``if _cp_size > 1`` branches execute.
-    ``extract_local_zigzag_chunks`` is left REAL (pure slicing) so shapes stay
+    ``extract_local_cp_chunks`` is left REAL (pure slicing) so shapes stay
     correct; feed a seq length divisible by 2*cp_size.
     """
     with contextlib.ExitStack() as stack:
@@ -207,7 +207,7 @@ class TestGptEmbeddingMegatronCPSP(unittest.TestCase):
         LanguageLoss._cu_seqlens_q_stash = None
 
     def test_megatron_cp_extract(self) -> None:
-        # cp_size=2 -> real extract_local_zigzag_chunks halves the seq len
+        # cp_size=2 -> real extract_local_cp_chunks halves the seq len
         # (lines 457 and 494). L must be divisible by 2*cp_size.
         K, B, L, H = 2, 1, 8, 4
         emb = _make_embedding(K, B, L, H)

--- a/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
+++ b/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
@@ -46,9 +46,21 @@ import paddle
 import paddlefleet.models.gpt.gpt_embedding as ge
 from paddlefleet.models.common.language_loss.language_loss import LanguageLoss
 from paddlefleet.models.gpt.gpt_embedding import GPTEmbedding
+from paddlefleet.transformer.multi_token_prediction import (
+    extract_local_cp_chunks,
+)
 
 
-def _make_embedding(K, B, L, H, *, use_erndata=True, magic_send=False):
+def _make_embedding(
+    K,
+    B,
+    L,
+    H,
+    *,
+    use_erndata=True,
+    magic_send=False,
+    cp_balance_mode="dualchunk_allgather",
+):
     emb = GPTEmbedding.__new__(GPTEmbedding)
     cfg = MagicMock()
     cfg.gpt_model_use_experimental_version = True
@@ -70,7 +82,7 @@ def _make_embedding(K, B, L, H, *, use_erndata=True, magic_send=False):
     cfg.pad_token_id = 0
     cfg.experimental_dataflow = False
     cfg.apply_rope_fusion = False
-    cfg.cp_balance_mode = "dualchunk_allgather"
+    cfg.cp_balance_mode = cp_balance_mode
     cfg.clone_scatter_output_in_embedding = False
     cfg.layer_types = []  # -> has_kda_layer property returns False
     emb.config = cfg
@@ -95,9 +107,9 @@ def _make_embedding(K, B, L, H, *, use_erndata=True, magic_send=False):
 
 
 @contextlib.contextmanager
-def _fake_cp(cp_size=2):
-    """Force ``get_context_parallel_world_size`` -> cp_size and rank -> 0 in
-    the gpt_embedding namespace so ``if _cp_size > 1`` branches execute.
+def _fake_cp(cp_size=2, cp_rank=0):
+    """Force ``get_context_parallel_world_size`` -> cp_size and rank -> cp_rank
+    in the gpt_embedding namespace so ``if _cp_size > 1`` branches execute.
     ``extract_local_cp_chunks`` is left REAL (pure slicing) so shapes stay
     correct; feed a seq length divisible by 2*cp_size.
     """
@@ -108,7 +120,7 @@ def _fake_cp(cp_size=2):
             )
         )
         stack.enter_context(
-            mock.patch.object(ge, "get_context_parallel_rank", lambda: 0)
+            mock.patch.object(ge, "get_context_parallel_rank", lambda: cp_rank)
         )
         yield
 
@@ -218,6 +230,47 @@ class TestGptEmbeddingMegatronCPSP(unittest.TestCase):
         # Each of the K+1 chunks is zigzag-halved to L/2 on axis 1.
         self.assertEqual(
             list(out["hidden_states"].shape), [(K + 1) * B, L // 2, H]
+        )
+
+    def test_megatron_cp_slice_follows_cp_balance_mode(self) -> None:
+        # The defect this whole change exists to fix: the megatron branch used
+        # to hard-code the zigzag slice instead of reading cp_balance_mode, so a
+        # contiguous_allgather model got labels/embeddings belonging to other
+        # ranks' tokens -- a silently wrong loss, not a crash.
+        #
+        # test_megatron_cp_extract above only asserts the *shape*, which the
+        # zigzag and contiguous layouts share, and every other CP test in this
+        # repo configures dualchunk. So this is the only assertion that fails if
+        # the mode is ignored: it pins the actual values against the mode the
+        # config asked for, at a rank where the two layouts disagree.
+        K, B, L, H = 2, 1, 8, 4
+        cp_size, cp_rank = 2, 1
+        full = paddle.arange(B * L * H, dtype="float32").reshape([B, L, H])
+        sliced = {}
+        for mode in ("dualchunk_allgather", "contiguous_allgather"):
+            emb = _make_embedding(K, B, L, H, cp_balance_mode=mode)
+            input_ids = (
+                paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+            )
+            cu = paddle.to_tensor([0, 3, 8], dtype="int32")
+            with _fake_cp(cp_size=cp_size, cp_rank=cp_rank):
+                out = emb.forward({"input_ids": input_ids, "cu_seqlens_q": cu})
+            # hidden_states is the (K+1) chunks concatenated on axis 0; the
+            # first B rows are the main (unrolled) embedding.
+            main = out["hidden_states"][:B]
+            expected = extract_local_cp_chunks(
+                full, cp_rank, cp_size, axis=1, mode=mode
+            )
+            np.testing.assert_array_equal(main.numpy(), expected.numpy())
+            sliced[mode] = main.numpy()
+
+        # Guard the guard: if the two layouts happened to agree at this
+        # (L, cp_size, cp_rank) the loop above would pass with the mode ignored.
+        self.assertFalse(
+            np.array_equal(
+                sliced["dualchunk_allgather"], sliced["contiguous_allgather"]
+            ),
+            "the two CP layouts must differ here or this test proves nothing",
         )
 
     def test_megatron_sequence_parallel(self) -> None:
@@ -349,6 +402,35 @@ class TestGptEmbeddingMegatronCPRope(unittest.TestCase):
         self.assertEqual(
             out["rotary_pos_emb"].shape[1], out["hidden_states"].shape[1]
         )
+
+    def test_rope_slice_follows_cp_balance_mode(self) -> None:
+        # _slice_rope_for_mtp_megatron_cp is a second, independent call site of
+        # extract_local_cp_chunks. Every channel of the stub table holds the
+        # global position index, so the sliced table reads out directly as the
+        # position set this rank owns -- and the two layouts disagree at rank 1
+        # of 2 with L=8 (zigzag [2,3,4,5] vs contiguous [4,5,6,7]).
+        K, B, L, H, D = 2, 1, 8, 4, 4
+        expected_positions = {
+            "dualchunk_allgather": [2, 3, 4, 5],
+            "contiguous_allgather": [4, 5, 6, 7],
+        }
+        for mode, positions in expected_positions.items():
+            emb = _enable_rope(
+                _make_embedding(K, B, L, H, cp_balance_mode=mode),
+                cp_size=2,
+                dim=D,
+            )
+            input_ids = (
+                paddle.arange(B * L, dtype="int64").reshape([B, L]).cuda()
+            )
+            cu = paddle.to_tensor([0, 3, 8], dtype="int32")
+            with _fake_cp(cp_size=2, cp_rank=1):
+                out = emb.forward({"input_ids": input_ids, "cu_seqlens_q": cu})
+            np.testing.assert_array_equal(
+                out["rotary_pos_emb"][0, :, 0, 0].numpy(),
+                np.array(positions, dtype="float32"),
+                err_msg=f"rope slice ignored cp_balance_mode={mode!r}",
+            )
 
     def test_rope_untouched_without_cp(self) -> None:
         K, B, L, H, D = 2, 1, 8, 4, 4

--- a/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
+++ b/tests/single_card_tests/transformer/test_gpt_embedding_megatron.py
@@ -233,16 +233,14 @@ class TestGptEmbeddingMegatronCPSP(unittest.TestCase):
         )
 
     def test_megatron_cp_slice_follows_cp_balance_mode(self) -> None:
-        # The defect this whole change exists to fix: the megatron branch used
-        # to hard-code the zigzag slice instead of reading cp_balance_mode, so a
-        # contiguous_allgather model got labels/embeddings belonging to other
-        # ranks' tokens -- a silently wrong loss, not a crash.
+        # The defect this change fixes: the megatron branch hard-coded the zigzag
+        # slice instead of reading cp_balance_mode, so a contiguous_allgather
+        # model got embeddings belonging to other ranks' tokens -- a silently
+        # wrong loss, not a crash.
         #
-        # test_megatron_cp_extract above only asserts the *shape*, which the
-        # zigzag and contiguous layouts share, and every other CP test in this
-        # repo configures dualchunk. So this is the only assertion that fails if
-        # the mode is ignored: it pins the actual values against the mode the
-        # config asked for, at a rank where the two layouts disagree.
+        # test_megatron_cp_extract above only asserts the *shape*, which both
+        # layouts share, so this is the only assertion that fails when the mode
+        # is ignored: it pins values at a rank where the layouts disagree.
         K, B, L, H = 2, 1, 8, 4
         cp_size, cp_rank = 2, 1
         full = paddle.arange(B * L * H, dtype="float32").reshape([B, L, H])

--- a/tests/single_card_tests/transformer/test_language_loss_megatron_labels.py
+++ b/tests/single_card_tests/transformer/test_language_loss_megatron_labels.py
@@ -26,7 +26,7 @@ are exercised on a single GPU (CP=1, TP=1):
 
 The CP>1 sublines (515/518/522/530/603/771) are covered single-card by
 monkeypatching ``get_context_parallel_world_size`` -> 2, faking the CP rank,
-and replacing ``extract_local_zigzag_chunks`` / the CP comm ops with
+and replacing ``extract_local_cp_chunks`` / the CP comm ops with
 identities (see TestLanguageLossMegatronCP).
 """
 
@@ -66,7 +66,7 @@ def _make_loss(K, *, distill, use_erndata=True):
     cfg.add_mtp_loss = True
     cfg.mtp_loss_scaling_factor = 1.0
     cfg.experimental_dataflow = False
-    cfg.cp_balance_mode = "zigzag"
+    cfg.cp_balance_mode = "dualchunk_allgather"
     cfg.recompute_modules = None
     loss.config = cfg
     loss.ignored_index = -100
@@ -175,7 +175,7 @@ def _fake_cp(cp_size=2):
 
     - module-level ``get_context_parallel_world_size`` -> cp_size;
     - source-module ``get_context_parallel_rank`` (local import) -> 0;
-    - ``extract_local_zigzag_chunks`` (local import) -> identity;
+    - ``extract_local_cp_chunks`` (local import) -> identity;
     - CP scatter/gather PyLayers -> identity;
     - ``dist.all_reduce`` -> no-op and ``fleet`` -> MagicMock (the
       distillation branch all-reduces the per-depth loss).
@@ -194,7 +194,7 @@ def _fake_cp(cp_size=2):
             mock.patch.object(ps, "get_context_parallel_rank", lambda: 0)
         )
         stack.enter_context(
-            mock.patch.object(mtp, "extract_local_zigzag_chunks", identity)
+            mock.patch.object(mtp, "extract_local_cp_chunks", identity)
         )
         stack.enter_context(
             mock.patch.object(ll.ContextParallelScatterOp, "apply", identity)
@@ -212,7 +212,7 @@ def _fake_cp(cp_size=2):
 class TestLanguageLossMegatronCP(unittest.TestCase):
     """Covers the CP>1 sublines (515,518,522,530,603,771) via monkeypatch.
 
-    ``extract_local_zigzag_chunks`` is mocked to identity, so all tensors
+    ``extract_local_cp_chunks`` is mocked to identity, so all tensors
     keep their full length and shapes stay self-consistent.
     """
 

--- a/tests/single_card_tests/transformer/test_language_loss_megatron_labels.py
+++ b/tests/single_card_tests/transformer/test_language_loss_megatron_labels.py
@@ -52,7 +52,9 @@ def _make_cu(seq_lens):
     return paddle.to_tensor(cu, dtype="int32")
 
 
-def _make_loss(K, *, distill, use_erndata=True):
+def _make_loss(
+    K, *, distill, use_erndata=True, cp_balance_mode="dualchunk_allgather"
+):
     loss = LanguageLoss.__new__(LanguageLoss)
     cfg = MagicMock()
     cfg.num_nextn_predict_layers = K
@@ -66,7 +68,7 @@ def _make_loss(K, *, distill, use_erndata=True):
     cfg.add_mtp_loss = True
     cfg.mtp_loss_scaling_factor = 1.0
     cfg.experimental_dataflow = False
-    cfg.cp_balance_mode = "dualchunk_allgather"
+    cfg.cp_balance_mode = cp_balance_mode
     cfg.recompute_modules = None
     loss.config = cfg
     loss.ignored_index = -100
@@ -175,13 +177,22 @@ def _fake_cp(cp_size=2):
 
     - module-level ``get_context_parallel_world_size`` -> cp_size;
     - source-module ``get_context_parallel_rank`` (local import) -> 0;
-    - ``extract_local_cp_chunks`` (local import) -> identity;
+    - ``extract_local_cp_chunks`` (local import) -> identity, recording the
+      kwargs it was called with;
     - CP scatter/gather PyLayers -> identity;
     - ``dist.all_reduce`` -> no-op and ``fleet`` -> MagicMock (the
       distillation branch all-reduces the per-depth loss).
+
+    Yields the recorded ``extract_local_cp_chunks`` calls.
     """
 
+    calls = []
+
     def identity(t, *a, **k):
+        return t
+
+    def recording_identity(t, *a, **k):
+        calls.append((a, k))
         return t
 
     with contextlib.ExitStack() as stack:
@@ -194,7 +205,9 @@ def _fake_cp(cp_size=2):
             mock.patch.object(ps, "get_context_parallel_rank", lambda: 0)
         )
         stack.enter_context(
-            mock.patch.object(mtp, "extract_local_cp_chunks", identity)
+            mock.patch.object(
+                mtp, "extract_local_cp_chunks", recording_identity
+            )
         )
         stack.enter_context(
             mock.patch.object(ll.ContextParallelScatterOp, "apply", identity)
@@ -202,11 +215,30 @@ def _fake_cp(cp_size=2):
         stack.enter_context(
             mock.patch.object(ll.ContextParallelGatherOp, "apply", identity)
         )
+
+        # The distillation branch swaps the gather for MTPDistillationLossShift
+        # under contiguous_allgather (language_loss.py:789-795). That PyLayer
+        # needs a real hybrid communicate group, so stand in for it with a
+        # shape-faithful stub: it consumes [B, S, H] and returns
+        # [B, S + K - 1, H] (the local slice plus the boundary window its P2P
+        # exchange fetches), which is what the per-depth
+        # ``target_p_self_op_dist[:, depth : depth + out_logp.shape[1]]`` slice
+        # downstream assumes.
+        def shift_stub(tensor, num_nextn_predict_layers, *a, **k):
+            b, _s, h = tensor.shape
+            tail = paddle.zeros(
+                [b, num_nextn_predict_layers, h], dtype=tensor.dtype
+            )
+            return paddle.concat([tensor[:, 1:], tail], axis=1)
+
+        stack.enter_context(
+            mock.patch.object(ll.MTPDistillationLossShift, "apply", shift_stub)
+        )
         stack.enter_context(
             mock.patch.object(ll.dist, "all_reduce", lambda *a, **k: None)
         )
         stack.enter_context(mock.patch.object(ll, "fleet", MagicMock()))
-        yield
+        yield calls
 
 
 class TestLanguageLossMegatronCP(unittest.TestCase):
@@ -247,6 +279,47 @@ class TestLanguageLossMegatronCP(unittest.TestCase):
         with _fake_cp(cp_size=2):
             out = loss.forward(logits, labels)
         self.assertEqual(out.dtype, paddle.float32)
+
+
+class TestLanguageLossCpBalanceMode(unittest.TestCase):
+    """Every CP slice here must use ``config.cp_balance_mode``.
+
+    The identity mock above keeps shapes self-consistent whatever layout is
+    requested, so the two tests before this one pass even if the mode is
+    hard-coded -- which is exactly the defect this change fixes. Assert on the
+    recorded kwarg instead, for both layouts and both loss branches.
+    """
+
+    def setUp(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def _modes_used(self, *, distill, cp_balance_mode):
+        K, B, L, V = 2, 1, 8, 5
+        loss = _make_loss(K, distill=distill, cp_balance_mode=cp_balance_mode)
+        LanguageLoss._cu_seqlens_q_stash = _make_cu([3, 5])
+        logits = [
+            paddle.randn([B, L, V], dtype="float32") for _ in range(K + 1)
+        ]
+        labels = paddle.arange(B * L, dtype="int64").reshape([B, L])
+        with _fake_cp(cp_size=2) as calls:
+            loss.forward(logits, labels)
+        self.assertTrue(calls, "no CP slice happened, so nothing was checked")
+        return [kwargs.get("mode") for _args, kwargs in calls]
+
+    def test_non_distill_forwards_configured_mode(self) -> None:
+        for mode in ("dualchunk_allgather", "contiguous_allgather"):
+            with self.subTest(mode=mode):
+                used = self._modes_used(distill=False, cp_balance_mode=mode)
+                self.assertEqual(set(used), {mode})
+
+    def test_distill_forwards_configured_mode(self) -> None:
+        for mode in ("dualchunk_allgather", "contiguous_allgather"):
+            with self.subTest(mode=mode):
+                used = self._modes_used(distill=True, cp_balance_mode=mode)
+                self.assertEqual(set(used), {mode})
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/transformer/test_language_loss_megatron_labels.py
+++ b/tests/single_card_tests/transformer/test_language_loss_megatron_labels.py
@@ -28,6 +28,11 @@ The CP>1 sublines (515/518/522/530/603/771) are covered single-card by
 monkeypatching ``get_context_parallel_world_size`` -> 2, faking the CP rank,
 and replacing ``extract_local_cp_chunks`` / the CP comm ops with
 identities (see TestLanguageLossMegatronCP).
+
+``_megatron_label_for_depth`` -- the separate Main/MTP head-loss entry point,
+which reaches its own CP slice without going through ``forward`` -- is covered
+by TestMegatronLabelForDepthCP, which runs the REAL extract helper so the
+slice is checked by value rather than by recorded kwarg.
 """
 
 from __future__ import annotations
@@ -37,6 +42,7 @@ import unittest
 from unittest import mock
 from unittest.mock import MagicMock
 
+import numpy as np
 import paddle
 
 import paddlefleet.models.common.language_loss.language_loss as ll
@@ -320,6 +326,141 @@ class TestLanguageLossCpBalanceMode(unittest.TestCase):
             with self.subTest(mode=mode):
                 used = self._modes_used(distill=True, cp_balance_mode=mode)
                 self.assertEqual(set(used), {mode})
+
+
+@contextlib.contextmanager
+def _cp_ranks(cp_size, cp_rank):
+    """Fake a CP group without touching ``extract_local_cp_chunks``.
+
+    Unlike ``_fake_cp`` this leaves the real extract helper installed, so the
+    slice actually happens and can be asserted on by value. Only the two
+    lookups ``_megatron_label_for_depth`` performs are patched: the module-level
+    ``get_context_parallel_world_size`` and the locally imported
+    ``get_context_parallel_rank``.
+    """
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            mock.patch.object(
+                ll, "get_context_parallel_world_size", lambda: cp_size
+            )
+        )
+        stack.enter_context(
+            mock.patch.object(ps, "get_context_parallel_rank", lambda: cp_rank)
+        )
+        yield
+
+
+def _local_slice_ref(full_np, cp_rank, cp_size, mode):
+    """NumPy reference for the two supported CP layouts on the seq axis.
+
+    ``dualchunk_allgather`` mirrors ``scatter_balance``: rank r owns
+    ``[interval*r, interval*(r+1))`` plus the mirrored tail chunk.
+    ``contiguous_allgather`` mirrors ``scatter_contiguous``: one chunk per rank.
+    """
+    seq_len = full_np.shape[1]
+    if mode == "dualchunk_allgather":
+        interval = seq_len // cp_size // 2
+        head = full_np[:, interval * cp_rank : interval * (cp_rank + 1)]
+        tail = full_np[
+            :, seq_len - interval * (cp_rank + 1) : seq_len - interval * cp_rank
+        ]
+        return np.concatenate([head, tail], axis=1)
+    chunk = seq_len // cp_size
+    return full_np[:, chunk * cp_rank : chunk * (cp_rank + 1)]
+
+
+class TestMegatronLabelForDepthCP(unittest.TestCase):
+    """``_megatron_label_for_depth`` slices with the REAL extract helper.
+
+    The separate Main/MTP head-loss path (``GPTMainLMHead`` / ``GPTMTPLMHead``,
+    language_loss.py:1026 and 1128) reaches the CP slice through this method
+    rather than through ``forward``, so the identity mock used above never
+    exercises it. Here the real ``extract_local_cp_chunks`` runs and the
+    assertion is on values: the CP>1 label must equal the numpy slice of the
+    CP=1 label for the configured ``cp_balance_mode``, on every rank and at
+    every depth. A hard-coded layout would fail one of the two modes, and the
+    union over ranks would not reconstruct the full sequence.
+    """
+
+    L = 16
+    CU = (4, 6, 6)
+
+    def setUp(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def tearDown(self) -> None:
+        LanguageLoss._cu_seqlens_q_stash = None
+
+    def _labels(self):
+        labels_np = np.arange(self.L, dtype="int64").reshape([1, self.L])
+        return labels_np, paddle.to_tensor(labels_np)
+
+    def test_slice_matches_cp1_label_for_both_modes(self) -> None:
+        cp_size = 2
+        for mode in ("dualchunk_allgather", "contiguous_allgather"):
+            for depth in (-1, 0, 1):
+                loss = _make_loss(2, distill=False, cp_balance_mode=mode)
+                LanguageLoss._cu_seqlens_q_stash = _make_cu(list(self.CU))
+                _labels_np, labels = self._labels()
+                # CP=1 gives the full-length label this depth should shard.
+                full = loss._megatron_label_for_depth(labels, depth).numpy()
+                for cp_rank in range(cp_size):
+                    with self.subTest(mode=mode, depth=depth, rank=cp_rank):
+                        with _cp_ranks(cp_size, cp_rank):
+                            got = loss._megatron_label_for_depth(
+                                labels, depth
+                            ).numpy()
+                        self.assertEqual(
+                            list(got.shape), [1, self.L // cp_size]
+                        )
+                        np.testing.assert_array_equal(
+                            got,
+                            _local_slice_ref(full, cp_rank, cp_size, mode),
+                        )
+
+    def test_ranks_together_cover_the_full_label(self) -> None:
+        # Whatever the layout, the ranks partition the sequence: no token is
+        # dropped or counted twice, so every label value appears exactly once.
+        cp_size = 2
+        for mode in ("dualchunk_allgather", "contiguous_allgather"):
+            with self.subTest(mode=mode):
+                loss = _make_loss(2, distill=False, cp_balance_mode=mode)
+                LanguageLoss._cu_seqlens_q_stash = _make_cu(list(self.CU))
+                _labels_np, labels = self._labels()
+                seen = []
+                for cp_rank in range(cp_size):
+                    with _cp_ranks(cp_size, cp_rank):
+                        seen.append(
+                            loss._megatron_label_for_depth(labels, -1).numpy()
+                        )
+                union = np.sort(np.concatenate(seen, axis=1), axis=1)
+                np.testing.assert_array_equal(
+                    union, np.arange(self.L, dtype="int64").reshape([1, self.L])
+                )
+
+    def test_unsupported_mode_is_rejected(self) -> None:
+        # contiguous_a2a shards contiguously but has a different mask contract
+        # and has never run on this path, so the helper refuses rather than
+        # silently returning a slice that would train against wrong labels.
+        loss = _make_loss(2, distill=False, cp_balance_mode="contiguous_a2a")
+        LanguageLoss._cu_seqlens_q_stash = _make_cu(list(self.CU))
+        _labels_np, labels = self._labels()
+        with (
+            _cp_ranks(2, 0),
+            self.assertRaisesRegex(ValueError, r"cp_balance_mode"),
+        ):
+            loss._megatron_label_for_depth(labels, 0)
+
+    def test_cp1_returns_full_length_unchanged(self) -> None:
+        # The CP block is skipped entirely at cp_size == 1, so depth -1 hands
+        # back the caller's own tensor untouched.
+        loss = _make_loss(2, distill=False)
+        LanguageLoss._cu_seqlens_q_stash = _make_cu(list(self.CU))
+        labels_np, labels = self._labels()
+        with _cp_ranks(1, 0):
+            out = loss._megatron_label_for_depth(labels, -1)
+        self.assertEqual(list(out.shape), [1, self.L])
+        np.testing.assert_array_equal(out.numpy(), labels_np)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/transformer/test_language_loss_megatron_labels.py
+++ b/tests/single_card_tests/transformer/test_language_loss_megatron_labels.py
@@ -216,8 +216,8 @@ def _fake_cp(cp_size=2):
             mock.patch.object(ll.ContextParallelGatherOp, "apply", identity)
         )
 
-        # The distillation branch swaps the gather for MTPDistillationLossShift
-        # under contiguous_allgather (language_loss.py:789-795). That PyLayer
+        # The distillation branch of LanguageLoss.forward swaps the gather for
+        # MTPDistillationLossShift under contiguous_allgather. That PyLayer
         # needs a real hybrid communicate group, so stand in for it with a
         # shape-faithful stub: it consumes [B, S, H] and returns
         # [B, S + K - 1, H] (the local slice plus the boundary window its P2P

--- a/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
+++ b/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
@@ -59,15 +59,15 @@ def _make_spec(num_transformer_layers=2, num_mtp=1):
 
 
 def _make_config(**overrides):
-    cfg = dict(
-        model_type="gpt",
-        enable_mtp_magic_send=False,
-        mtp_shared_last_layer=False,
-        gpt_model_use_experimental_version=False,
-        num_nextn_predict_layers=1,
-        multimax_modules=None,
-        separate_mtp_headloss=False,
-    )
+    cfg = {
+        "model_type": "gpt",
+        "enable_mtp_magic_send": False,
+        "mtp_shared_last_layer": False,
+        "gpt_model_use_experimental_version": False,
+        "num_nextn_predict_layers": 1,
+        "multimax_modules": None,
+        "separate_mtp_headloss": False,
+    }
     cfg.update(overrides)
     return SimpleNamespace(**cfg)
 

--- a/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
+++ b/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""``mtp_shared_last_layer`` must survive ``enable_mtp_magic_send``.
+
+``GPTModel.get_layer_desc_list`` emits two descs for the last-layer tie:
+
+  * the *pivot* -- the last backbone TransformerLayer, keyed
+    ``mtp_reuse_transformer``;
+  * the *MTP layer* -- keyed the same way, with
+    ``shared_submodule_weight_only=True`` so paddle's ``_alias_shared_layer``
+    aliases only the parameters under ``transformer_layer``.
+
+Both are required: paddle only aliases when a shared key has more than one
+member. The MTP-side branch used to test ``enable_mtp_magic_send`` first and
+short-circuit to a plain ``LayerDesc``, so with both flags on the tie silently
+did nothing -- the model trained an extra full MTP attention block while the
+config claimed it was shared. That is a wrong-parameter-count bug that no assert
+caught, which is why it is pinned here.
+
+The two mechanisms are orthogonal: magic send owns ``mtp_embed`` (a separate
+``SharedLayerDesc`` keyed ``mtp_embed``, synced through gpt_model's dedicated
+``_mtp_embed_global_group``), and the tie touches only ``transformer_layer``
+params. Their parameter sets do not overlap.
+"""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from paddle import nn
+from paddle.distributed.fleet.meta_parallel import LayerDesc, SharedLayerDesc
+
+from paddlefleet.models.gpt.gpt_model import GPTModel
+
+
+class _Stub(nn.Layer):
+    """Placeholder layer class; only its identity matters to LayerDesc."""
+
+
+def _make_spec(num_transformer_layers=2, num_mtp=1):
+    return SimpleNamespace(
+        embedding=_Stub,
+        head_empty_layers=[],
+        tail_empty_layers=[],
+        mhc_expand=None,
+        mhc_contract=None,
+        transformer_layers=[_Stub] * num_transformer_layers,
+        output_block_attn_res=None,
+        layer_norm=_Stub,
+        mtp=[_Stub] * num_mtp,
+        mtp_lm_head=None,
+        mtp_loss=None,
+        lm_head=_Stub,
+    )
+
+
+def _make_config(**overrides):
+    cfg = dict(
+        model_type="gpt",
+        enable_mtp_magic_send=False,
+        mtp_shared_last_layer=False,
+        gpt_model_use_experimental_version=False,
+        num_nextn_predict_layers=1,
+        multimax_modules=None,
+        separate_mtp_headloss=False,
+    )
+    cfg.update(overrides)
+    return SimpleNamespace(**cfg)
+
+
+def _layer_descs(**config_overrides):
+    """Call get_layer_desc_list without building a real GPTModel.
+
+    The method only touches ``self.config`` and ``self.add_sequential_layer``,
+    so a stub carrying those two is enough and keeps this a single-card test.
+    """
+    fake_self = SimpleNamespace(
+        config=_make_config(**config_overrides),
+        add_sequential_layer=lambda layers, desc, name_prefix="": layers.append(
+            {"layer": desc, "name_prefix": name_prefix}
+        ),
+    )
+    return GPTModel.get_layer_desc_list(
+        fake_self, _make_spec(), tie_word_embeddings=False
+    )
+
+
+def _shared_descs(layers, key):
+    return [
+        entry["layer"]
+        for entry in layers
+        if isinstance(entry["layer"], SharedLayerDesc)
+        and entry["layer"].layer_name == key
+    ]
+
+
+class TestMagicSendSharedLastLayerDesc(unittest.TestCase):
+    def test_tie_emits_two_members_under_magic_send(self) -> None:
+        layers = _layer_descs(
+            enable_mtp_magic_send=True, mtp_shared_last_layer=True
+        )
+        tied = _shared_descs(layers, "mtp_reuse_transformer")
+        self.assertEqual(
+            len(tied),
+            2,
+            "the tie needs both the pivot and the MTP desc; with one member "
+            "paddle's _alias_shared_layer never runs and the tie is a no-op",
+        )
+        # Exactly one of them aliases a submodule only: the MTP side. The pivot
+        # is a whole TransformerLayer and shares itself.
+        submodule_only = [
+            d for d in tied if getattr(d, "shared_submodule_weight_only", False)
+        ]
+        self.assertEqual(len(submodule_only), 1)
+
+    def test_magic_send_still_emits_its_own_mtp_embed(self) -> None:
+        # The tie must not displace magic send's embedding desc -- that table is
+        # the only reason magic send works at all on the last PP stage.
+        layers = _layer_descs(
+            enable_mtp_magic_send=True, mtp_shared_last_layer=True
+        )
+        self.assertEqual(len(_shared_descs(layers, "mtp_embed")), 1)
+
+    def test_no_tie_keeps_plain_layer_desc(self) -> None:
+        layers = _layer_descs(
+            enable_mtp_magic_send=True, mtp_shared_last_layer=False
+        )
+        self.assertEqual(_shared_descs(layers, "mtp_reuse_transformer"), [])
+        # ... and the MTP layer is a plain desc, not shared with anything.
+        self.assertTrue(
+            any(
+                isinstance(entry["layer"], LayerDesc)
+                and not isinstance(entry["layer"], SharedLayerDesc)
+                for entry in layers
+            )
+        )
+
+    def test_tie_without_magic_send_is_unchanged(self) -> None:
+        # Regression guard for the branch reorder: the non-magic-send behaviour
+        # must be byte-for-byte the same shape it always was.
+        layers = _layer_descs(
+            enable_mtp_magic_send=False, mtp_shared_last_layer=True
+        )
+        self.assertEqual(len(_shared_descs(layers, "mtp_reuse_transformer")), 2)
+        self.assertEqual(_shared_descs(layers, "mtp_embed"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
+++ b/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
@@ -5,34 +5,24 @@
 
 """``mtp_shared_last_layer`` must survive ``enable_mtp_magic_send``.
 
-``GPTModel.get_layer_desc_list`` emits two descs for the last-layer tie:
+``GPTModel.get_layer_desc_list`` emits two descs keyed ``mtp_reuse_transformer``
+for the last-layer tie: the *pivot* (the last backbone TransformerLayer) and the
+*MTP layer* (with ``shared_submodule_weight_only=True``, so paddle's
+``_alias_shared_layer`` aliases only the parameters under
+``transformer_layer``). Both are required -- paddle only aliases when a shared
+key has more than one member.
 
-  * the *pivot* -- the last backbone TransformerLayer, keyed
-    ``mtp_reuse_transformer``;
-  * the *MTP layer* -- keyed the same way, with
-    ``shared_submodule_weight_only=True`` so paddle's ``_alias_shared_layer``
-    aliases only the parameters under ``transformer_layer``.
-
-Both are required: paddle only aliases when a shared key has more than one
-member. The MTP-side branch used to test ``enable_mtp_magic_send`` first and
+The MTP-side branch used to test ``enable_mtp_magic_send`` first and
 short-circuit to a plain ``LayerDesc``, so with both flags on the tie silently
-did nothing -- the model trained an extra full MTP attention block while the
-config claimed it was shared. That was only reachable under ``python -O``,
-because ``TransformerConfig`` assert-rejected the combination and ``-O`` strips
-asserts; the rejection is gone now, so the branch order matters unconditionally
-and is pinned here.
+did nothing and the model trained a full extra MTP attention block while the
+config claimed it was shared. The two are in fact orthogonal: magic send owns
+``mtp_embed`` (its own ``SharedLayerDesc``, synced through gpt_model's
+``_mtp_embed_global_group``), and the tie touches only ``transformer_layer``.
 
-The two mechanisms are orthogonal: magic send owns ``mtp_embed`` (a separate
-``SharedLayerDesc`` keyed ``mtp_embed``, synced through gpt_model's dedicated
-``_mtp_embed_global_group``), and the tie touches only ``transformer_layer``
-params. Their parameter sets do not overlap.
-
-Scope note: these are desc-shape assertions. Whether paddle then *aliases* or
-falls back to a cross-stage broadcast+allreduce depends on the pivot and the MTP
-desc landing on the same rank (``PipelineLayer._build_layer_impl`` only fills
-``shared_layers`` from this rank's range) -- see the co-location note in
-``transformer_config.py``. That is not covered here and has not been checked
-end-to-end.
+Scope: desc-shape assertions only. Whether paddle then *aliases* or falls back
+to a cross-stage broadcast+allreduce depends on the pivot and the MTP desc
+landing on the same rank (see the co-location note in
+``transformer_config.py``), which is not covered here.
 """
 
 from __future__ import annotations
@@ -137,9 +127,8 @@ class TestMagicSendSharedLastLayerDesc(unittest.TestCase):
     def test_tie_with_k_gt_1_ties_every_mtp_layer_to_one_pivot(self) -> None:
         # K > 1 emits K MTP descs under the same key, so the shared group is
         # K + 1 members: one pivot plus K submodule-only aliases. All K MTP
-        # blocks therefore share the *same* backbone attention parameters --
-        # worth pinning, because a reader could reasonably expect one pivot per
-        # depth instead. Untested end-to-end; this is a desc-shape assertion.
+        # blocks therefore share the *same* backbone attention parameters, which
+        # a reader could reasonably expect to be one pivot per depth.
         layers = _layer_descs(
             num_mtp=3,
             enable_mtp_magic_send=True,

--- a/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
+++ b/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
@@ -17,13 +17,22 @@ Both are required: paddle only aliases when a shared key has more than one
 member. The MTP-side branch used to test ``enable_mtp_magic_send`` first and
 short-circuit to a plain ``LayerDesc``, so with both flags on the tie silently
 did nothing -- the model trained an extra full MTP attention block while the
-config claimed it was shared. That is a wrong-parameter-count bug that no assert
-caught, which is why it is pinned here.
+config claimed it was shared. That was only reachable under ``python -O``,
+because ``TransformerConfig`` assert-rejected the combination and ``-O`` strips
+asserts; the rejection is gone now, so the branch order matters unconditionally
+and is pinned here.
 
 The two mechanisms are orthogonal: magic send owns ``mtp_embed`` (a separate
 ``SharedLayerDesc`` keyed ``mtp_embed``, synced through gpt_model's dedicated
 ``_mtp_embed_global_group``), and the tie touches only ``transformer_layer``
 params. Their parameter sets do not overlap.
+
+Scope note: these are desc-shape assertions. Whether paddle then *aliases* or
+falls back to a cross-stage broadcast+allreduce depends on the pivot and the MTP
+desc landing on the same rank (``PipelineLayer._build_layer_impl`` only fills
+``shared_layers`` from this rank's range) -- see the co-location note in
+``transformer_config.py``. That is not covered here and has not been checked
+end-to-end.
 """
 
 from __future__ import annotations
@@ -72,7 +81,7 @@ def _make_config(**overrides):
     return SimpleNamespace(**cfg)
 
 
-def _layer_descs(**config_overrides):
+def _layer_descs(num_mtp=1, **config_overrides):
     """Call get_layer_desc_list without building a real GPTModel.
 
     The method only touches ``self.config`` and ``self.add_sequential_layer``,
@@ -85,7 +94,7 @@ def _layer_descs(**config_overrides):
         ),
     )
     return GPTModel.get_layer_desc_list(
-        fake_self, _make_spec(), tie_word_embeddings=False
+        fake_self, _make_spec(num_mtp=num_mtp), tie_word_embeddings=False
     )
 
 
@@ -124,6 +133,25 @@ class TestMagicSendSharedLastLayerDesc(unittest.TestCase):
             enable_mtp_magic_send=True, mtp_shared_last_layer=True
         )
         self.assertEqual(len(_shared_descs(layers, "mtp_embed")), 1)
+
+    def test_tie_with_k_gt_1_ties_every_mtp_layer_to_one_pivot(self) -> None:
+        # K > 1 emits K MTP descs under the same key, so the shared group is
+        # K + 1 members: one pivot plus K submodule-only aliases. All K MTP
+        # blocks therefore share the *same* backbone attention parameters --
+        # worth pinning, because a reader could reasonably expect one pivot per
+        # depth instead. Untested end-to-end; this is a desc-shape assertion.
+        layers = _layer_descs(
+            num_mtp=3,
+            enable_mtp_magic_send=True,
+            mtp_shared_last_layer=True,
+            num_nextn_predict_layers=3,
+        )
+        tied = _shared_descs(layers, "mtp_reuse_transformer")
+        self.assertEqual(len(tied), 4)
+        submodule_only = [
+            d for d in tied if getattr(d, "shared_submodule_weight_only", False)
+        ]
+        self.assertEqual(len(submodule_only), 3)
 
     def test_no_tie_keeps_plain_layer_desc(self) -> None:
         layers = _layer_descs(

--- a/tests/single_card_tests/transformer/test_moe_router_megatron_cp.py
+++ b/tests/single_card_tests/transformer/test_moe_router_megatron_cp.py
@@ -26,7 +26,7 @@ it single-card by:
   and ``get_context_parallel_rank`` -> 0;
 - feeding a 3-D ``input`` and an ``input_ids`` whose seq length differs from
   ``input``'s, so the ``elif`` condition is True;
-- replacing the (locally-imported) ``extract_local_zigzag_chunks`` with a
+- replacing the (locally-imported) ``extract_local_cp_chunks`` with a
   sentinel-raiser so execution stops right after line 1520 (before the full
   MoE routing, which needs real gate weights). The raised sentinel proves
   the slice line was reached.
@@ -65,7 +65,7 @@ def _fake_cp_and_extract(cp_size=2):
             mock.patch.object(mr, "get_context_parallel_rank", lambda: 0)
         )
         stack.enter_context(
-            mock.patch.object(mtp, "extract_local_zigzag_chunks", _raise)
+            mock.patch.object(mtp, "extract_local_cp_chunks", _raise)
         )
         yield
 
@@ -76,7 +76,7 @@ class TestTopKRouterMegatronCPSlice(unittest.TestCase):
         cfg = MagicMock()
         cfg.experimental_dataflow = False  # skip the preceding `if`
         cfg.use_erndata = True
-        cfg.cp_balance_mode = "zigzag"
+        cfg.cp_balance_mode = "dualchunk_allgather"
         router.config = cfg
         router.sequence_parallel = False
 

--- a/tests/single_card_tests/transformer/test_moe_router_megatron_cp.py
+++ b/tests/single_card_tests/transformer/test_moe_router_megatron_cp.py
@@ -16,8 +16,8 @@
 
 The router's ``forward`` has an ``elif`` that, under CP>1 +
 use_erndata=True, slices ``input_ids`` down to this rank's chunk to match the
-embedding (moe_router.py:1500, 1514, 1518-1520) — in whatever layout
-``config.cp_balance_mode`` names. We reach it single-card by:
+embedding — in whatever layout ``config.cp_balance_mode`` names. We reach it
+single-card by:
 
 - ``TopKRouter.__new__`` + MagicMock config (experimental_dataflow=False so
   the preceding ``if`` is skipped and the ``elif`` is evaluated;
@@ -28,7 +28,7 @@ embedding (moe_router.py:1500, 1514, 1518-1520) — in whatever layout
   ``input``'s, so the ``elif`` condition is True;
 - replacing the (locally-imported) ``extract_local_cp_chunks`` with a recorder
   that captures its kwargs and then raises a sentinel, so execution stops right
-  after line 1520 (before the full MoE routing, which needs real gate weights).
+  after the slice (before the full MoE routing, which needs real gate weights).
   The sentinel proves the slice line was reached; the captured ``mode`` proves
   the router read ``config.cp_balance_mode`` instead of assuming a layout.
 """

--- a/tests/single_card_tests/transformer/test_moe_router_megatron_cp.py
+++ b/tests/single_card_tests/transformer/test_moe_router_megatron_cp.py
@@ -15,9 +15,9 @@
 """Single-card coverage for TopKRouter.forward's megatron-MTP CP branch.
 
 The router's ``forward`` has an ``elif`` that, under CP>1 +
-use_erndata=True, zigzag-slices ``input_ids`` to match the
-embedding's per-rank chunk (moe_router.py:1500, 1514, 1518-1520). We reach
-it single-card by:
+use_erndata=True, slices ``input_ids`` down to this rank's chunk to match the
+embedding (moe_router.py:1500, 1514, 1518-1520) — in whatever layout
+``config.cp_balance_mode`` names. We reach it single-card by:
 
 - ``TopKRouter.__new__`` + MagicMock config (experimental_dataflow=False so
   the preceding ``if`` is skipped and the ``elif`` is evaluated;
@@ -26,10 +26,11 @@ it single-card by:
   and ``get_context_parallel_rank`` -> 0;
 - feeding a 3-D ``input`` and an ``input_ids`` whose seq length differs from
   ``input``'s, so the ``elif`` condition is True;
-- replacing the (locally-imported) ``extract_local_cp_chunks`` with a
-  sentinel-raiser so execution stops right after line 1520 (before the full
-  MoE routing, which needs real gate weights). The raised sentinel proves
-  the slice line was reached.
+- replacing the (locally-imported) ``extract_local_cp_chunks`` with a recorder
+  that captures its kwargs and then raises a sentinel, so execution stops right
+  after line 1520 (before the full MoE routing, which needs real gate weights).
+  The sentinel proves the slice line was reached; the captured ``mode`` proves
+  the router read ``config.cp_balance_mode`` instead of assuming a layout.
 """
 
 from __future__ import annotations
@@ -52,7 +53,17 @@ class _Sentinel(Exception):
 
 @contextlib.contextmanager
 def _fake_cp_and_extract(cp_size=2):
-    def _raise(*a, **k):
+    """Fake a CP group and swap ``extract_local_cp_chunks`` for a recorder.
+
+    Yields the ``calls`` list so a test can assert on the kwargs the router
+    passed -- ``mode`` in particular. Recording and *then* raising keeps the
+    original behaviour: execution stops right after the slice line, before the
+    real MoE routing that would need gate weights.
+    """
+    calls = []
+
+    def _record_and_raise(*a, **k):
+        calls.append((a, k))
         raise _Sentinel
 
     with contextlib.ExitStack() as stack:
@@ -65,18 +76,18 @@ def _fake_cp_and_extract(cp_size=2):
             mock.patch.object(mr, "get_context_parallel_rank", lambda: 0)
         )
         stack.enter_context(
-            mock.patch.object(mtp, "extract_local_cp_chunks", _raise)
+            mock.patch.object(mtp, "extract_local_cp_chunks", _record_and_raise)
         )
-        yield
+        yield calls
 
 
 class TestTopKRouterMegatronCPSlice(unittest.TestCase):
-    def test_elif_slices_input_ids(self) -> None:
+    def _run_forward(self, cp_balance_mode):
         router = TopKRouter.__new__(TopKRouter)
         cfg = MagicMock()
         cfg.experimental_dataflow = False  # skip the preceding `if`
         cfg.use_erndata = True
-        cfg.cp_balance_mode = "dualchunk_allgather"
+        cfg.cp_balance_mode = cp_balance_mode
         router.config = cfg
         router.sequence_parallel = False
 
@@ -85,8 +96,26 @@ class TestTopKRouterMegatronCPSlice(unittest.TestCase):
         # input_ids seq length (6) != input seq_len (4) -> elif condition True.
         input_ids = paddle.zeros([B, 6], dtype="int64")
 
-        with _fake_cp_and_extract(cp_size=2), self.assertRaises(_Sentinel):
+        with (
+            _fake_cp_and_extract(cp_size=2) as calls,
+            self.assertRaises(_Sentinel),
+        ):
             router.forward(inp, input_ids=input_ids)
+        return calls
+
+    def test_elif_slices_input_ids(self) -> None:
+        self.assertEqual(len(self._run_forward("dualchunk_allgather")), 1)
+
+    def test_slice_uses_configured_cp_balance_mode(self) -> None:
+        # The router must forward config.cp_balance_mode rather than assume a
+        # layout: picking the wrong one hands this rank input_ids belonging to
+        # other ranks' tokens, which shifts the MoE mask silently. Asserting on
+        # the recorded kwarg is what makes a hard-coded mode fail here -- the
+        # reachability check above passes either way.
+        for mode in ("dualchunk_allgather", "contiguous_allgather"):
+            with self.subTest(mode=mode):
+                ((_args, kwargs),) = self._run_forward(mode)
+                self.assertEqual(kwargs.get("mode"), mode)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/transformer/test_mtp_magic_send.py
+++ b/tests/single_card_tests/transformer/test_mtp_magic_send.py
@@ -320,14 +320,27 @@ class TestTransformerConfig(unittest.TestCase):
                 variable_seq_lengths=False,
             )
 
-    def test_magic_send_rejects_shared_last_layer(self):
-        with self.assertRaises(AssertionError):
-            TransformerConfig(
-                enable_mtp_magic_send=True,
-                num_nextn_predict_layers=1,
-                pipeline_model_parallel_size=2,
-                mtp_shared_last_layer=True,
-            )
+    def test_magic_send_accepts_shared_last_layer(self):
+        """The two used to be rejected here; the rejection was wrong.
+
+        SharedLayerDesc(shared_submodule_weight_only=True) aliases only the
+        parameters under ``transformer_layer``, while magic send owns
+        ``mtp_embed`` (its own SharedLayerDesc key, synced through gpt_model's
+        dedicated sub-group). The parameter sets do not overlap. Worse, the
+        rejection hid a real bug: ``get_layer_desc_list`` tested
+        ``enable_mtp_magic_send`` before ``mtp_shared_last_layer`` and
+        short-circuited to a plain LayerDesc, so anyone who bypassed the assert
+        got a silently untied MTP block. See
+        test_magic_send_shared_last_layer_desc.py.
+        """
+        cfg = TransformerConfig(
+            enable_mtp_magic_send=True,
+            num_nextn_predict_layers=1,
+            pipeline_model_parallel_size=2,
+            mtp_shared_last_layer=True,
+        )
+        self.assertTrue(cfg.enable_mtp_magic_send)
+        self.assertTrue(cfg.mtp_shared_last_layer)
 
     def test_magic_send_rejects_multimodal_embedding(self):
         """Magic send does not produce mtp_emb_res, which the multimodal

--- a/tests/single_card_tests/transformer/test_mtp_magic_send.py
+++ b/tests/single_card_tests/transformer/test_mtp_magic_send.py
@@ -326,12 +326,17 @@ class TestTransformerConfig(unittest.TestCase):
         SharedLayerDesc(shared_submodule_weight_only=True) aliases only the
         parameters under ``transformer_layer``, while magic send owns
         ``mtp_embed`` (its own SharedLayerDesc key, synced through gpt_model's
-        dedicated sub-group). The parameter sets do not overlap. Worse, the
-        rejection hid a real bug: ``get_layer_desc_list`` tested
+        dedicated sub-group). The parameter sets do not overlap. The rejection
+        also hid a latent bug: ``get_layer_desc_list`` tested
         ``enable_mtp_magic_send`` before ``mtp_shared_last_layer`` and
-        short-circuited to a plain LayerDesc, so anyone who bypassed the assert
-        got a silently untied MTP block. See
-        test_magic_send_shared_last_layer_desc.py.
+        short-circuited to a plain LayerDesc, so anyone running under
+        ``python -O`` -- where this very assert was stripped -- got a silently
+        untied MTP block. See test_magic_send_shared_last_layer_desc.py.
+
+        Caveat recorded in the co-location note in transformer_config.py: the
+        tie only *aliases* when the pivot and the MTP desc land on the same
+        rank. Across a PP boundary it degrades to broadcast + gradient
+        allreduce -- same numerics, none of the memory saving.
         """
         cfg = TransformerConfig(
             enable_mtp_magic_send=True,

--- a/tests/single_card_tests/transformer/test_mtp_magic_send.py
+++ b/tests/single_card_tests/transformer/test_mtp_magic_send.py
@@ -20,6 +20,7 @@ import sys
 import unittest
 from contextlib import ExitStack, nullcontext
 from dataclasses import dataclass
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import paddle
@@ -346,6 +347,38 @@ class TestTransformerConfig(unittest.TestCase):
         )
         self.assertTrue(cfg.enable_mtp_magic_send)
         self.assertTrue(cfg.mtp_shared_last_layer)
+
+    def test_magic_send_rejects_tie_word_embeddings(self):
+        """``tie_word_embeddings`` wins the desc branch and drops mtp_embed.
+
+        get_layer_desc_list tests the tie before enable_mtp_magic_send, so with
+        both on no ``mtp_embed`` desc is emitted, _mtp_embed_global_group
+        collapses to None and _synchronize_mtp_embed_weight broadcasts a zero
+        buffer into the MTP stage's real (perform_initialization=False) table:
+        training proceeds on an all-zero, never-synced vocab table. A ValueError
+        rather than an assert, for the reason spelled out in
+        test_multimodal_rejection_survives_optimized_mode.
+
+        Reached through ``from_config`` because ``tie_word_embeddings`` is not a
+        TransformerConfig field -- it arrives via register_attributes' setattr
+        fallback, which is exactly how a model_config.json delivers it.
+        """
+        cfg_in = SimpleNamespace(
+            num_hidden_layers=2,
+            hidden_size=64,
+            num_attention_heads=4,
+            enable_mtp_magic_send=True,
+            num_nextn_predict_layers=1,
+            pipeline_model_parallel_size=2,
+            tie_word_embeddings=True,
+        )
+        with self.assertRaisesRegex(ValueError, r"tie_word_embeddings"):
+            TransformerConfig.from_config(cfg_in)
+
+        # tie_word_embeddings=False must leave magic send alone.
+        cfg_in.tie_word_embeddings = False
+        cfg = TransformerConfig.from_config(cfg_in)
+        self.assertTrue(cfg.enable_mtp_magic_send)
 
     def test_magic_send_rejects_multimodal_embedding(self):
         """Magic send does not produce mtp_emb_res, which the multimodal

--- a/tests/single_card_tests/transformer/test_use_erndata_config.py
+++ b/tests/single_card_tests/transformer/test_use_erndata_config.py
@@ -17,6 +17,9 @@ historical ernie5 L+K layout. Guards checked here:
      forward is only reachable through the MTP layer.
   6. use_erndata=False never trips any of the guards regardless of other MTP
      flags.
+  7. use_erndata + MTP + CP>1 accepts both sequence-scatter layouts
+     (``dualchunk_allgather`` / ``contiguous_allgather``) and rejects
+     ``contiguous_a2a``.
 """
 
 from __future__ import annotations
@@ -129,6 +132,26 @@ class TestUseErndataValidation(unittest.TestCase):
                 )
             )
 
+    def test_erndata_magic_send_error_explains_why(self) -> None:
+        # The rejection is a design decision, not a missing feature: magic send
+        # would only add a replicated vocab table on the MTP stage, because
+        # erndata already delivers input_ids through the pipeline dict. Keep the
+        # reasoning in the message so it does not decay into a bare "not
+        # supported" and get re-implemented by someone reading only the guard.
+        with self.assertRaises(ValueError) as ctx:
+            TransformerConfig(
+                **self._base_kwargs(
+                    use_erndata=True,
+                    num_nextn_predict_layers=1,
+                    enable_mtp_magic_send=True,
+                    pipeline_model_parallel_size=2,
+                )
+            )
+        msg = str(ctx.exception)
+        self.assertIn("does not need", msg)
+        self.assertIn("input_ids", msg)
+        self.assertIn("cu_seqlens_q", msg)
+
     def test_erndata_incompat_with_experimental_dataflow(self) -> None:
         with self.assertRaisesRegex(ValueError, r"experimental_dataflow"):
             TransformerConfig(
@@ -151,17 +174,33 @@ class TestUseErndataValidation(unittest.TestCase):
                 )
             )
 
-    def test_erndata_cp_requires_dualchunk_allgather(self) -> None:
-        # `contiguous_allgather` is not equivalent to MCore's zigzag layout.
-        with self.assertRaisesRegex(
-            ValueError, r"cp_balance_mode='dualchunk_allgather'"
-        ):
+    def test_erndata_cp_accepts_contiguous_allgather(self) -> None:
+        # `contiguous_allgather` is a supported layout since the erndata MTP
+        # path slices through extract_local_cp_chunks (mode-aware) rather than
+        # hard-coding zigzag. It is also *mandatory* for the DSv4 hybrid stack,
+        # whose attention layers assert on it under CP.
+        cfg = TransformerConfig(
+            **self._base_kwargs(
+                use_erndata=True,
+                num_nextn_predict_layers=1,
+                context_parallel_size=2,
+                cp_balance_mode="contiguous_allgather",
+            )
+        )
+        self.assertEqual(cfg.cp_balance_mode, "contiguous_allgather")
+        self.assertEqual(cfg.context_parallel_size, 2)
+
+    def test_erndata_cp_rejects_contiguous_a2a(self) -> None:
+        # Ulysses splits heads inside the attention instead of round-tripping
+        # the sequence through scatter_contiguous, so the local-sequence layout
+        # the MTP path would have to slice with is not established.
+        with self.assertRaisesRegex(ValueError, r"cp_balance_mode"):
             TransformerConfig(
                 **self._base_kwargs(
                     use_erndata=True,
                     num_nextn_predict_layers=1,
                     context_parallel_size=2,
-                    cp_balance_mode="contiguous_allgather",
+                    cp_balance_mode="contiguous_a2a",
                 )
             )
 

--- a/tests/single_card_tests/transformer/test_use_erndata_config.py
+++ b/tests/single_card_tests/transformer/test_use_erndata_config.py
@@ -26,6 +26,10 @@ historical ernie5 L+K layout. Guards checked here:
   9. use_erndata + MTP + CP>1 rejects a model that builds an Indexer, whose
      loss-mask path assumes a CP-local ``input_ids``; configs that build no
      Indexer, and CP==1, stay legal.
+ 10. use_erndata + MTP + CP>1 rejects ``mtp_distillation_loss`` (that branch
+     double-scatters its loss mask).
+ 11. use_erndata + CP>1 requires a real MTP layer at all: nothing else shards
+     the full-length tensors the loader broadcasts.
 """
 
 from __future__ import annotations
@@ -305,6 +309,89 @@ class TestUseErndataValidation(unittest.TestCase):
         )
         self.assertEqual(cfg.pipeline_model_parallel_size, 2)
         self.assertTrue(cfg.use_erndata)
+
+    def test_erndata_cp_rejects_mtp_distillation_loss(self) -> None:
+        # LanguageLoss's distillation branch derives lossmask from the
+        # already-CP-sliced labels_cur_depth and then scatters it a second time,
+        # unlike its non-distillation sibling. Nothing else in __post_init__
+        # looked at mtp_distillation_loss, so the combination used to reach a
+        # broadcast error at `lossmask * plogp`.
+        with self.assertRaisesRegex(ValueError, r"mtp_distillation_loss"):
+            TransformerConfig(
+                **self._base_kwargs(
+                    use_erndata=True,
+                    num_nextn_predict_layers=1,
+                    context_parallel_size=2,
+                    cp_balance_mode="contiguous_allgather",
+                    mtp_distillation_loss=True,
+                )
+            )
+
+    def test_erndata_distillation_ok_without_cp(self) -> None:
+        # The double scatter only exists on the CP branch.
+        cfg = TransformerConfig(
+            **self._base_kwargs(
+                use_erndata=True,
+                num_nextn_predict_layers=1,
+                mtp_distillation_loss=True,
+            )
+        )
+        self.assertTrue(cfg.mtp_distillation_loss)
+
+    def test_erndata_cp_requires_mtp(self) -> None:
+        # GPTEmbedding only slices the erndata tensors inside its MTP branch, and
+        # the generic ContextParallelScatterOp fallback beside it needs
+        # experimental_dataflow, which erndata forbids. With MTP off nothing
+        # shards at all and attention dies on a shape mismatch naming neither
+        # flag. Reachable without any MTP-specific setting, since erniebot sets
+        # use_erndata implicitly from the YAML's `erndata:` section.
+        with self.assertRaisesRegex(ValueError, r"num_nextn_predict_layers"):
+            TransformerConfig(
+                **self._base_kwargs(
+                    use_erndata=True,
+                    num_nextn_predict_layers=0,
+                    context_parallel_size=2,
+                )
+            )
+
+    def test_erndata_cp_rejects_weight_only_mtp(self) -> None:
+        # WeightOnlyMTPLayer.forward returns its inputs unchanged, so the
+        # embedding's slicing branch is gated off and this collapses to the
+        # no-MTP case above.
+        with self.assertRaisesRegex(ValueError, r"mtp_load_weight_only"):
+            TransformerConfig(
+                **self._base_kwargs(
+                    use_erndata=True,
+                    num_nextn_predict_layers=1,
+                    context_parallel_size=2,
+                    cp_balance_mode="contiguous_allgather",
+                    mtp_load_weight_only=True,
+                )
+            )
+
+    def test_erndata_without_mtp_still_ok_at_cp1(self) -> None:
+        # Regression guard for the check above: CP==1 needs no sharding, so the
+        # K==0 erndata config must stay legal.
+        cfg = TransformerConfig(
+            **self._base_kwargs(
+                use_erndata=True,
+                num_nextn_predict_layers=0,
+                context_parallel_size=1,
+            )
+        )
+        self.assertTrue(cfg.use_erndata)
+
+    def test_non_erndata_cp_without_mtp_is_untouched(self) -> None:
+        # The new check must not leak into the default dataflow, where
+        # ContextParallelScatterOp does the sharding.
+        cfg = TransformerConfig(
+            **self._base_kwargs(
+                num_nextn_predict_layers=0,
+                context_parallel_size=2,
+            )
+        )
+        self.assertFalse(cfg.use_erndata)
+        self.assertEqual(cfg.context_parallel_size, 2)
 
     def test_non_erndata_compatible_with_all_flags(self) -> None:
         # Default path must never trip a new guard, even when other MTP flags

--- a/tests/single_card_tests/transformer/test_use_erndata_config.py
+++ b/tests/single_card_tests/transformer/test_use_erndata_config.py
@@ -122,6 +122,13 @@ class TestUseErndataValidation(unittest.TestCase):
     def test_erndata_incompat_with_magic_send(self) -> None:
         # enable_mtp_magic_send also requires PP>1 (checked earlier in
         # __post_init__), so we build a config that would pass that check.
+        #
+        # The rejection is a design decision, not a missing feature: erndata
+        # already delivers input_ids and cu_seqlens_q to the MTP stage through
+        # the pipeline dict, so magic send would only add a replicated vocab
+        # table there. That reasoning lives in the comment above the guard, and
+        # this test deliberately asserts on the flag name alone -- pinning the
+        # prose would make every rewording a CI failure.
         with self.assertRaisesRegex(ValueError, r"enable_mtp_magic_send"):
             TransformerConfig(
                 **self._base_kwargs(
@@ -131,26 +138,6 @@ class TestUseErndataValidation(unittest.TestCase):
                     pipeline_model_parallel_size=2,
                 )
             )
-
-    def test_erndata_magic_send_error_explains_why(self) -> None:
-        # The rejection is a design decision, not a missing feature: magic send
-        # would only add a replicated vocab table on the MTP stage, because
-        # erndata already delivers input_ids through the pipeline dict. Keep the
-        # reasoning in the message so it does not decay into a bare "not
-        # supported" and get re-implemented by someone reading only the guard.
-        with self.assertRaises(ValueError) as ctx:
-            TransformerConfig(
-                **self._base_kwargs(
-                    use_erndata=True,
-                    num_nextn_predict_layers=1,
-                    enable_mtp_magic_send=True,
-                    pipeline_model_parallel_size=2,
-                )
-            )
-        msg = str(ctx.exception)
-        self.assertIn("does not need", msg)
-        self.assertIn("input_ids", msg)
-        self.assertIn("cu_seqlens_q", msg)
 
     def test_erndata_incompat_with_experimental_dataflow(self) -> None:
         with self.assertRaisesRegex(ValueError, r"experimental_dataflow"):
@@ -194,7 +181,14 @@ class TestUseErndataValidation(unittest.TestCase):
         # Ulysses splits heads inside the attention instead of round-tripping
         # the sequence through scatter_contiguous, so the local-sequence layout
         # the MTP path would have to slice with is not established.
-        with self.assertRaisesRegex(ValueError, r"cp_balance_mode"):
+        #
+        # Match the erndata-specific wording, not the bare flag name: a plain
+        # `cp_balance_mode` regex would also be satisfied by the generic
+        # cp_balance_mode validation later in __post_init__, so this test would
+        # keep passing even if the erndata guard were deleted.
+        with self.assertRaisesRegex(
+            ValueError, r"use_erndata=True with MTP \+ context_parallel_size>1"
+        ):
             TransformerConfig(
                 **self._base_kwargs(
                     use_erndata=True,

--- a/tests/single_card_tests/transformer/test_use_erndata_config.py
+++ b/tests/single_card_tests/transformer/test_use_erndata_config.py
@@ -129,12 +129,9 @@ class TestUseErndataValidation(unittest.TestCase):
         # enable_mtp_magic_send also requires PP>1 (checked earlier in
         # __post_init__), so we build a config that would pass that check.
         #
-        # The rejection is a design decision, not a missing feature: erndata
-        # already delivers input_ids and cu_seqlens_q to the MTP stage through
-        # the pipeline dict, so magic send would only add a replicated vocab
-        # table there. That reasoning lives in the comment above the guard, and
-        # this test deliberately asserts on the flag name alone -- pinning the
-        # prose would make every rewording a CI failure.
+        # Assert on the flag name alone, not the prose: the reasoning for the
+        # rejection lives in the comment above the guard, and pinning it here
+        # would make every rewording a CI failure.
         with self.assertRaisesRegex(ValueError, r"enable_mtp_magic_send"):
             TransformerConfig(
                 **self._base_kwargs(
@@ -184,14 +181,13 @@ class TestUseErndataValidation(unittest.TestCase):
         self.assertEqual(cfg.context_parallel_size, 2)
 
     def test_erndata_cp_rejects_contiguous_a2a(self) -> None:
-        # Ulysses splits heads inside the attention instead of round-tripping
-        # the sequence through scatter_contiguous, so the local-sequence layout
-        # the MTP path would have to slice with is not established.
+        # Ulysses splits heads inside the attention, so the local-sequence mask
+        # contract the MTP path would slice against is not established.
         #
         # Match the erndata-specific wording, not the bare flag name: a plain
         # `cp_balance_mode` regex would also be satisfied by the generic
-        # cp_balance_mode validation later in __post_init__, so this test would
-        # keep passing even if the erndata guard were deleted.
+        # cp_balance_mode validation later in __post_init__, so the test would
+        # keep passing even if this guard were deleted.
         with self.assertRaisesRegex(
             ValueError, r"use_erndata=True with MTP \+ context_parallel_size>1"
         ):
@@ -269,16 +265,12 @@ class TestUseErndataValidation(unittest.TestCase):
         return kwargs
 
     def test_erndata_cp_rejects_indexer_model(self) -> None:
-        # Widening the cp_balance_mode check to accept contiguous_allgather made
-        # erndata + MTP + CP + DSv4 config-legal for the first time, and that
-        # combination is broken downstream: the Indexer loss-mask path
-        # (CompressedSparseAttention.forward,
-        # MQALatentAttention._indexer_loss_mask)
-        # all-gathers input_ids whenever CP>1 and experimental_dataflow is off,
-        # then reshapes to [b, cp_size * s_local] -- but erndata hands the model
-        # a full-length global input_ids that nothing trims, so the gather
-        # over-counts by cp_size. Keep the rejection at config time instead of
-        # letting it resurface as a shape error inside attention.
+        # Accepting contiguous_allgather made erndata + MTP + CP + DSv4
+        # config-legal for the first time, and that combination is broken
+        # downstream: the Indexer loss-mask path all-gathers input_ids and
+        # reshapes to [b, cp_size * s_local], but erndata delivers input_ids
+        # full-length and global, so the gather over-counts by cp_size. Reject at
+        # config time instead of as a shape error inside attention.
         with self.assertRaisesRegex(ValueError, r"Indexer"):
             TransformerConfig(**self._dsv4_kwargs(context_parallel_size=2))
 

--- a/tests/single_card_tests/transformer/test_use_erndata_config.py
+++ b/tests/single_card_tests/transformer/test_use_erndata_config.py
@@ -20,6 +20,12 @@ historical ernie5 L+K layout. Guards checked here:
   7. use_erndata + MTP + CP>1 accepts both sequence-scatter layouts
      (``dualchunk_allgather`` / ``contiguous_allgather``) and rejects
      ``contiguous_a2a``.
+  8. use_erndata + MTP + CP>1 rejects ``gpt_model_use_experimental_version``
+     (2-column mask the CP expansion refuses without experimental_dataflow),
+     while CP==1 keeps accepting it.
+  9. use_erndata + MTP + CP>1 rejects a model that builds an Indexer, whose
+     loss-mask path assumes a CP-local ``input_ids``; configs that build no
+     Indexer, and CP==1, stay legal.
 """
 
 from __future__ import annotations
@@ -209,6 +215,89 @@ class TestUseErndataValidation(unittest.TestCase):
         )
         self.assertEqual(cfg.cp_balance_mode, "dualchunk_allgather")
         self.assertEqual(cfg.context_parallel_size, 2)
+
+    def test_erndata_cp_rejects_experimental_version(self) -> None:
+        # gpt_model_use_experimental_version makes GPTEmbedding build a 2-column
+        # attn_mask_startend_row_indices, which the CP mask expansion accepts
+        # only under experimental_dataflow -- forbidden with erndata. Without
+        # this guard the combination dies as "Invalid attention mask shape"
+        # inside DotProductAttention, naming neither flag.
+        with self.assertRaisesRegex(
+            ValueError, r"gpt_model_use_experimental_version"
+        ):
+            TransformerConfig(
+                **self._base_kwargs(
+                    use_erndata=True,
+                    num_nextn_predict_layers=1,
+                    context_parallel_size=2,
+                    cp_balance_mode="contiguous_allgather",
+                    gpt_model_use_experimental_version=True,
+                )
+            )
+
+    def test_erndata_experimental_version_ok_without_cp(self) -> None:
+        # The 2-column mask is only a problem for the CP expansion path, so
+        # CP == 1 must stay legal.
+        cfg = TransformerConfig(
+            **self._base_kwargs(
+                use_erndata=True,
+                num_nextn_predict_layers=1,
+                gpt_model_use_experimental_version=True,
+            )
+        )
+        self.assertTrue(cfg.gpt_model_use_experimental_version)
+
+    def _dsv4_kwargs(self, **overrides):
+        """Smallest config that reaches the dsv4_hybrid validation block.
+
+        ``csa_compress_ratios`` must be num_hidden_layers +
+        num_nextn_predict_layers long, and a ratio in [2, 127] with
+        ``csa_dense_mode=False`` is what makes gpt_layer_specs build a
+        CSAIndexer.
+        """
+        kwargs = {
+            "num_hidden_layers": 2,
+            "hidden_size": 64,
+            "num_attention_heads": 4,
+            "use_erndata": True,
+            "num_nextn_predict_layers": 1,
+            "cp_balance_mode": "contiguous_allgather",
+            "experimental_attention_variant": "dsv4_hybrid",
+            "csa_compress_ratios": [4, 4, 4],
+        }
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_erndata_cp_rejects_indexer_model(self) -> None:
+        # Widening the cp_balance_mode check to accept contiguous_allgather made
+        # erndata + MTP + CP + DSv4 config-legal for the first time, and that
+        # combination is broken downstream: the Indexer loss-mask path
+        # (csa_attention.py:2884-2911, mqa_latent_attention.py:2494-2502)
+        # all-gathers input_ids whenever CP>1 and experimental_dataflow is off,
+        # then reshapes to [b, cp_size * s_local] -- but erndata hands the model
+        # a full-length global input_ids that nothing trims, so the gather
+        # over-counts by cp_size. Keep the rejection at config time instead of
+        # letting it resurface as a shape error inside attention.
+        with self.assertRaisesRegex(ValueError, r"Indexer"):
+            TransformerConfig(**self._dsv4_kwargs(context_parallel_size=2))
+
+    def test_erndata_indexer_ok_without_cp(self) -> None:
+        # CP == 1 never enters the gather branch.
+        cfg = TransformerConfig(**self._dsv4_kwargs(context_parallel_size=1))
+        self.assertEqual(cfg.context_parallel_size, 1)
+
+    def test_erndata_cp_ok_when_no_indexer_is_built(self) -> None:
+        # csa_dense_mode drops the CSAIndexer, and ratio 128 (HCA) never builds
+        # one, so neither config reaches the input_ids gather.
+        for label, overrides in (
+            ("csa_dense_mode", {"csa_dense_mode": True}),
+            ("hca_only", {"csa_compress_ratios": [128, 128, 128]}),
+        ):
+            with self.subTest(label):
+                cfg = TransformerConfig(
+                    **self._dsv4_kwargs(context_parallel_size=2, **overrides)
+                )
+                self.assertEqual(cfg.context_parallel_size, 2)
 
     def test_erndata_accepts_pp_gt_1(self) -> None:
         # PP>1 is supported: cu_seqlens_q is threaded through

--- a/tests/single_card_tests/transformer/test_use_erndata_config.py
+++ b/tests/single_card_tests/transformer/test_use_erndata_config.py
@@ -28,8 +28,10 @@ historical ernie5 L+K layout. Guards checked here:
      Indexer, and CP==1, stay legal.
  10. use_erndata + MTP + CP>1 rejects ``mtp_distillation_loss`` (that branch
      double-scatters its loss mask).
- 11. use_erndata + CP>1 requires a real MTP layer at all: nothing else shards
-     the full-length tensors the loader broadcasts.
+ 11. use_erndata + CP>1 requires one of the two paths that slice the
+     full-length tensors the loader broadcasts: a real MTP layer, or
+     ``experimental_dataflow`` (whose ContextParallelScatterOp covers the
+     no-MTP case).
 """
 
 from __future__ import annotations
@@ -338,10 +340,10 @@ class TestUseErndataValidation(unittest.TestCase):
         )
         self.assertTrue(cfg.mtp_distillation_loss)
 
-    def test_erndata_cp_requires_mtp(self) -> None:
+    def test_erndata_cp_requires_a_slicing_path(self) -> None:
         # GPTEmbedding only slices the erndata tensors inside its MTP branch, and
-        # the generic ContextParallelScatterOp fallback beside it needs
-        # experimental_dataflow, which erndata forbids. With MTP off nothing
+        # the plain-path ContextParallelScatterOp beside it needs
+        # experimental_dataflow. With MTP off and the default dataflow nothing
         # shards at all and attention dies on a shape mismatch naming neither
         # flag. Reachable without any MTP-specific setting, since erniebot sets
         # use_erndata implicitly from the YAML's `erndata:` section.
@@ -353,6 +355,51 @@ class TestUseErndataValidation(unittest.TestCase):
                     context_parallel_size=2,
                 )
             )
+
+    def test_erndata_cp_without_mtp_ok_under_experimental_dataflow(
+        self,
+    ) -> None:
+        # The other slicing path: with no MTP layer, GPTEmbedding.forward takes
+        # its plain branch, which calls ContextParallelScatterOp on
+        # decoder_input (and on the RoPE tables further down) whenever
+        # experimental_dataflow is set; LanguageLoss._forward scatters labels
+        # under the same flag. The MTP block only forbids experimental_dataflow
+        # when num_nextn_predict_layers > 0, so this must stay legal.
+        cfg = TransformerConfig(
+            **self._base_kwargs(
+                use_erndata=True,
+                num_nextn_predict_layers=0,
+                experimental_dataflow=True,
+                context_parallel_size=2,
+            )
+        )
+        self.assertTrue(cfg.use_erndata)
+        self.assertTrue(cfg.experimental_dataflow)
+        self.assertEqual(cfg.context_parallel_size, 2)
+
+    def test_erndata_cp_without_mtp_ok_under_experimental_dataflow_contiguous(
+        self,
+    ) -> None:
+        # cp_balance_mode is not constrained on that path: it is passed straight
+        # through to ContextParallelScatterOp, which implements all three
+        # layouts. Only the local-slice MTP path has to agree with the rest of
+        # the model, and it is off here.
+        for mode in (
+            "dualchunk_allgather",
+            "contiguous_allgather",
+            "contiguous_a2a",
+        ):
+            with self.subTest(cp_balance_mode=mode):
+                cfg = TransformerConfig(
+                    **self._base_kwargs(
+                        use_erndata=True,
+                        num_nextn_predict_layers=0,
+                        experimental_dataflow=True,
+                        context_parallel_size=2,
+                        cp_balance_mode=mode,
+                    )
+                )
+                self.assertEqual(cfg.cp_balance_mode, mode)
 
     def test_erndata_cp_rejects_weight_only_mtp(self) -> None:
         # WeightOnlyMTPLayer.forward returns its inputs unchanged, so the
@@ -366,6 +413,24 @@ class TestUseErndataValidation(unittest.TestCase):
                     context_parallel_size=2,
                     cp_balance_mode="contiguous_allgather",
                     mtp_load_weight_only=True,
+                )
+            )
+
+    def test_erndata_cp_weight_only_mtp_has_no_dataflow_escape(self) -> None:
+        # The experimental_dataflow escape does not reach weight-only MTP:
+        # num_nextn_predict_layers > 0 puts the config in the MTP block, which
+        # rejects experimental_dataflow before the slicing guard is reached. So
+        # erndata + CP > 1 + mtp_load_weight_only has no legal spelling, and the
+        # rejection has to name experimental_dataflow rather than pass silently.
+        with self.assertRaisesRegex(ValueError, r"experimental_dataflow"):
+            TransformerConfig(
+                **self._base_kwargs(
+                    use_erndata=True,
+                    num_nextn_predict_layers=1,
+                    context_parallel_size=2,
+                    cp_balance_mode="contiguous_allgather",
+                    mtp_load_weight_only=True,
+                    experimental_dataflow=True,
                 )
             )
 

--- a/tests/single_card_tests/transformer/test_use_erndata_config.py
+++ b/tests/single_card_tests/transformer/test_use_erndata_config.py
@@ -272,7 +272,8 @@ class TestUseErndataValidation(unittest.TestCase):
         # Widening the cp_balance_mode check to accept contiguous_allgather made
         # erndata + MTP + CP + DSv4 config-legal for the first time, and that
         # combination is broken downstream: the Indexer loss-mask path
-        # (csa_attention.py:2884-2911, mqa_latent_attention.py:2494-2502)
+        # (CompressedSparseAttention.forward,
+        # MQALatentAttention._indexer_loss_mask)
         # all-gathers input_ids whenever CP>1 and experimental_dataflow is off,
         # then reshapes to [b, cp_size * s_local] -- but erndata hands the model
         # a full-length global input_ids that nothing trims, so the gather

--- a/tests/test_configs.yaml
+++ b/tests/test_configs.yaml
@@ -224,8 +224,9 @@ tests:
   - test_case: [tests/multi_card_tests/test_separate_mtp_input_cp.py]
     products:
       - num_gpus: 2
-  # use_erndata=True + CP=2: the RoPE tables must follow the same
-  # zigzag layout the megatron MTP branch slices the embeddings with.
+  # use_erndata=True + CP=2: the RoPE tables must follow the same layout
+  # (config.cp_balance_mode) the megatron MTP branch slices the embeddings
+  # with -- checked for dualchunk_allgather and contiguous_allgather.
   - test_case: [tests/multi_card_tests/test_gpt_mtp_megatron_cp.py]
     products:
       - num_gpus: 2


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Bug fixes

### Description
The `use_erndata` MTP path keeps its tensors full-length on every CP rank and slices them locally instead of calling `ContextParallelScatterOp` (which would redo the embedding lookup `cp_size` times). That slice was hard-coded to the zigzag layout, while the rest of the model scatters according to `config.cp_balance_mode`. When the two disagree the model trains on mismatched sequence slices and produces a silently wrong loss rather than an error.

This matters in practice because `contiguous_allgather` is not optional for every model: the DSv4 hybrid stack builds its sparse-attention index tables over the global sequence and then row-slices this rank's queries, and asserts on `cp_balance_mode == 'contiguous_allgather'` under CP.

- `multi_token_prediction`: add `extract_local_contiguous_chunk` (mirrors `scatter_contiguous`) and `extract_local_cp_chunks`, a layout-aware dispatcher. `contiguous_a2a` (Ulysses) raises instead of guessing.
- `gpt_embedding`: route the main embedding, the K rolled MTP embeddings and the RoPE tables through the dispatcher.
- `language_loss`: same for `labels` and `labels_cur_depth`.
- `moe_router`: same for the seq-aux-loss `input_ids` slice.
- `transformer_config`: accept `cp_balance_mode` in {`dualchunk_allgather`, `contiguous_allgather`} for `use_erndata` + MTP + CP > 1.
- `transformer_config`: also require, for `use_erndata` + CP > 1, that *some* path slices the loader's full-length sequence — either a real MTP layer (which slices in `GPTEmbedding`) or `experimental_dataflow=True` (whose plain-path `ContextParallelScatterOp` does it, together with the RoPE tables and `LanguageLoss`'s labels). With neither, no CP sharding happens at all and attention dies on a shape mismatch naming neither flag.

Also fixes a silent no-op in `gpt_model.get_layer_desc_list`: the `enable_mtp_magic_send` branch was tested first and short-circuited to a plain `LayerDesc`, so `mtp_shared_last_layer` did nothing whenever both flags were set. The two mechanisms are orthogonal — `SharedLayerDesc` with `shared_submodule_weight_only=True` aliases only the parameters under `transformer_layer`, while magic send owns `mtp_embed` — so the assert forbidding the combination is dropped and replaced by a note recording the precondition `_alias_shared_layer` actually depends on.

Finally, the `use_erndata` + `enable_mtp_magic_send` rejection now explains itself: erndata already delivers full-length `input_ids` and `cu_seqlens_q` to the MTP stage through the pipeline dict, so magic send would only add a second trainable vocab table there in order to shrink a hidden-state P2P payload that `overlap_p2p_comm` already hides.


### 是否引起精度变化
是

Scope of the change:
- `dualchunk_allgather` (the layout the old hard-coded slice implemented) is bit-identical to before.
- `contiguous_allgather` under `use_erndata` + MTP + CP > 1 previously produced a silently wrong loss from mismatched sequence slices; it now trains correctly, so its loss values change.
- `enable_mtp_magic_send` together with `mtp_shared_last_layer` previously ignored the weight sharing; the sharing now takes effect, which changes numerics for that combination.

