### PR TITLE
[Deps] Bump Paddle to 3.4.0.post20260905+33af96148b6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ description = "Fleet Core - Core Functional Library for Large Scale Distributed 
 requires-python = ">=3.10"
 dependencies = [
     "colorlog>=6.10.1",
-    "paddlepaddle-gpu==3.4.0.post20260903+e4e12582077",
+    "paddlepaddle-gpu==3.4.0.post20260905+33af96148b6",
     "ruamel.yaml>=0.17",
     "tilelang-paddle==0.1.12",
 ]


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Improvements

### Description
Update the Paddle GPU dependency to the official CUDA 12.9 CPython 3.12 Linux x86_64 nightly wheel built from Paddle release/3.4 at commit `33af96148b6b62dbf1f6e3c8333d8cac4070a71a`.

- Dependency: `paddlepaddle-gpu==3.4.0.post20260905+33af96148b6`
- Wheel: `paddlepaddle_gpu-3.4.0.post20260905+33af96148b6-cp312-cp312-linux_x86_64.whl`
- Merged in dev: #1975 (https://github.com/PaddlePaddle/PaddleFleet/pull/1975)
- This PR changes only the dependency pin.

### 是否引起精度变化
否