### PR TITLE
[Tests] Fix FA4 flag pin and indexer loss coeff in MQA CP tests

### DIFF
--- a/tests/multi_card_tests/transformer/test_mla_cp_contiguous_allgather.py
+++ b/tests/multi_card_tests/transformer/test_mla_cp_contiguous_allgather.py
@@ -207,6 +207,17 @@ def build_cfg(cp_size, sink=False, attn_mode="mha"):
     c.dsa_index_topk = 128
     c.dsa_indexer_rotary_interleaved = False
     c.dsa_indexer_use_sparse_loss = True
+    # The indexer's ranking reaches attention only through ``topk`` indices,
+    # which carry no gradient, so its parameters join the backward graph *only*
+    # via the KL loss -- and ``_needs_indexer_loss``
+    # (mqa_latent_attention.py:990) gates that on a positive coefficient. At the
+    # default 0.0 no ``indexer.*`` parameter can ever get a gradient, which is
+    # what ``test_6b`` asserts about. Same knob and magnitude as
+    # ``test_mqa_dsa_cp.py::test_7_indexer_loss_normalisation``, whose subject
+    # is the loss *denominator*; here the loss is the means by which the
+    # indexer's own CP path is compared against CP=1 through the whole MLA
+    # layer.
+    c.dsa_indexer_loss_coeff = 0.1
     c.csa_window_size = 128
     c.add_full_attention_sink_bias = sink
     c.rope_type = "rope"

--- a/tests/multi_card_tests/transformer/test_mla_cp_contiguous_allgather.py
+++ b/tests/multi_card_tests/transformer/test_mla_cp_contiguous_allgather.py
@@ -471,11 +471,14 @@ class TestMLAContiguousAllgatherCP(unittest.TestCase):
     def _check_mqa(self, attn_mode):
         # ``mqa_full_causal`` (and the phase-2 warmup) accept dense FA4 only --
         # ``MQALatentAttention._assert_dense_fa4`` raises otherwise -- and a bare
-        # launcher process leaves the flag at the image default 2. Pin it to the
-        # value ``TrainingArguments.__post_init__`` derives on these SM100 boxes.
+        # launcher process leaves the flag at the image default 2. ``_fa4_pin``
+        # reproduces both flags ``TrainingArguments.__post_init__`` /production
+        # imply on these SM100 boxes: version 4 *and* determinism off, since
+        # ``ci/multi-card_test.sh`` exports ``FLAGS_cudnn_deterministic=1`` and
+        # that alone degrades the (576, 512) pair back to FA2.
         # Call-site scoped, not module scoped: ``test_4`` asserts on the refusal
         # the *default* flag produces.
-        with U._flash_attn_version(4):
+        with U._fa4_pin():
             r = run_mla_cp(_row_end([200, 150, 162], 512), attn_mode=attn_mode)
         self.assertLess(r["fwd"], FWD_RTOL, f"{attn_mode}: forward")
         self.assertLess(r["dH"], GRAD_RTOL, f"{attn_mode}: dH")

--- a/tests/single_card_tests/transformer/hybrid_mla_utils.py
+++ b/tests/single_card_tests/transformer/hybrid_mla_utils.py
@@ -818,7 +818,7 @@ def cpp_flashmask_backend():
 
 @contextlib.contextmanager
 def _fa4_pin():
-    """``_flash_attn_version(4)`` where FA4 can serve, a no-op where it cannot.
+    """FA4's *whole* flag pair where FA4 can serve, a no-op where it cannot.
 
     The full-causal phases have exactly one backend, and
     ``MQALatentAttention._assert_dense_fa4`` raises when the process flags do not
@@ -827,11 +827,22 @@ def _fa4_pin():
     where ``_fa4_can_serve()`` is True -- and the same modules also hold ``mha``
     cases that do run without FA4, which is why the pin has to stand down rather
     than force a value the box cannot honour.
+
+    ``FLAGS_cudnn_deterministic`` is part of the pin, not a separate concern:
+    ``_dispatch_fa_version`` (``flash_mask_facade.py``) whitelists the
+    ``(576, 512)`` head-dim pair for FA4 only ``and not deterministic``, because
+    FA4's big-head-dim backward has no ordered-accumulation variant. Both CI
+    entrypoints export ``FLAGS_cudnn_deterministic=1``
+    (``ci/multi-card_test.sh``, ``ci/single_card_test.sh``), so pinning the
+    version alone still degrades to FA2 and trips ``_assert_dense_fa4``. The
+    non-deterministic FA4 backward is what production runs, and the gradient
+    comparisons here use bf16-scale relative tolerances that have room for the
+    atomics accumulation order.
     """
     if not _fa4_can_serve():
         yield
         return
-    with _flash_attn_version(4):
+    with _flash_attn_version(4), _cudnn_deterministic(0):
         yield
 
 


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
Devs

### Description
修复 latent-MQA CP 测试夹具里两个使这些用例在 SM100 CI 上根本跑不起来的问题。仅改动 tests/ 下的两个文件，未触碰任何生产代码。

#### 1. `FLAGS_cudnn_deterministic` 没有纳入 FA4 pin

MQA full-causal 阶段在 SM100 CI 机器上直接中止：

```
RuntimeError: latent MQA full-causal attention requires FA4 dense flashmask,
but head dims (576, 512) resolve to FA2. FLAGS_flash_attn_version=4,
FLAGS_cudnn_deterministic=True. ... keep FLAGS_cudnn_deterministic off -- FA4
has no deterministic backward for this head-dim pair.
```

`_dispatch_fa_version`（`packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py:189-194`）对 `(576, 512)` 这一 head-dim 对的 FA4 白名单条件是 `and not deterministic`，因为 FA4 的 big-head-dim 反向没有有序累加实现。两个 CI 入口都 `export FLAGS_cudnn_deterministic=1`（`ci/multi-card_test.sh:74`、`ci/single_card_test.sh:39`），因此 `_fa4_pin` 只设置 `FLAGS_flash_attn_version=4` 时仍会被降级回 FA2，`MQALatentAttention._assert_dense_fa4` 拒绝启动。

修复方式是把 determinism 纳入 pin 本身，让 pin 复现生产隐含的**整对** flag 而不是其中一半：

- `tests/single_card_tests/transformer/hybrid_mla_utils.py` — `_fa4_pin` 改为 `with _flash_attn_version(4), _cudnn_deterministic(0):`，原因写进 docstring。
- `tests/multi_card_tests/transformer/test_mla_cp_contiguous_allgather.py` — `_check_mqa` 从只 pin 版本的 `U._flash_attn_version(4)` 换成 `U._fa4_pin()`，保留调用点作用域，使 `test_4_sink_cp_default_fa_flag` 仍能观察到未 pin 时的拒绝行为。

放在 `_fa4_pin` 里一处解决，即可覆盖三个 multi-card 使用方（`test_mla_cp_recompute.py:73`、`test_mqa_dsa_cp.py:102`、`test_mqa_indexer_dualchunk_cp.py:60`）以及所有基于 `_fa4_module_hooks` 的 single-card 模块。`_fa4_can_serve()` 为 False 时 `_fa4_pin` 仍整体让位，因此 cc 9.0 镜像和未做 gate 的 `mha` 用例不受影响。非确定性 FA4 反向正是生产环境跑的配置，这些套件的梯度比较使用 bf16 量级的相对容差，对 atomics 累加顺序带来的漂移有余量。

#### 2. `build_cfg` 把 indexer loss 系数留在了 0.0

indexer 的排序只通过 `topk` 索引到达 attention，而索引不携带梯度，所以它的参数只能经由 KL loss 进入反向图 —— 而 `MQALatentAttention._needs_indexer_loss`（`mqa_latent_attention.py:990`）以 `indexer_loss_coeff > 0` 为门槛。`build_cfg` 从未设置 `dsa_indexer_loss_coeff`，它停留在默认值 0.0（`transformer_config.py:1542`），于是任何 `indexer.*` 参数都拿不到梯度，`test_6b_mqa_dsa_cp_equivalence` 的断言无从观察。

设为 0.1，与 `test_mqa_dsa_cp.py::test_7_indexer_loss_normalisation` 同一个旋钮、同一量级（那个用例的主题是 loss 的**分母**；这里 loss 是把 indexer 自身的 CP 路径贯穿整个 MLA 层与 CP=1 作对比的手段）。该系数是模型级的，但只有 `mqa_dsa` 会构建 indexer，因此 `mha` / `mqa` 夹具不受影响；唯一会在意"有正系数但没有 indexer"的校验挂在 `train_indexer_only=True` 下（`transformer_config.py:2946`），此处未开启。

#### 验证

两个文件本地验证通过

### 是否引起精度变化
否