### PR TITLE
[KDA] Add head-sharded all-to-all context parallel

### DIFF
--- a/src/paddlefleet/transformer/kda_head_a2a.py
+++ b/src/paddlefleet/transformer/kda_head_a2a.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Head-shard all-to-all helpers for linear-attention CP (``linear_attn_cp_mode="headwise"``).
+
+Everything in here is pure layout: a2a axis swaps and per-head slicing.  It is a
+separate module from ``kimi_delta_attention.py`` for one reason -- the bitwise
+test (``tests/multi_card_tests/transformer/test_kda_a2a_core_bitwise.py``) drives
+the KDA core directly, below the layer, and must use *exactly* the slicing and
+swap convention the layer uses.  A second copy of that convention in the test
+would make the test agree with itself instead of with the product.
+
+The one convention that everything hangs on, and that fails **silently** if
+broken: ``UlyssesAlltoAll`` reshapes the head axis to ``[cp_size, h // cp_size]``
+and exchanges over the first of those (``_ulysses_generate_layout_params``,
+``context_parallel_utils.py:1620-1633``), so rank ``r`` receives the *contiguous*
+head block ``[r * h/P, (r+1) * h/P)``.  Every parameter slice below uses the same
+``head_range``.  Mismatch it and the heads get paired with the wrong ``A_log`` --
+no error, just wrong numbers.
+
+No gradient reduction happens here, on purpose.  CP is a sub-factor of the
+sharding axis, so the sharding group already contains the CP group and the
+trainer/optimizer reduces the parameter gradients over it; a second reduction
+inside the layer would double-count.
+"""
+
+from __future__ import annotations
+
+import paddle
+
+from ..context_parallel_utils import UlyssesAlltoAll
+
+__all__ = [
+    "head_range",
+    "head_to_seq",
+    "seq_to_head",
+    "seq_to_head_beta",
+    "slice_channels_by_head",
+    "slice_per_head_param",
+    "split_qkv_seq_to_head",
+]
+
+
+def head_range(num_heads: int, cp_rank: int, cp_size: int) -> tuple[int, int]:
+    """This rank's contiguous head block ``[h0, h1)``.
+
+    Raises rather than truncating: a non-divisible head count would otherwise
+    give overlapping or gapped blocks, and the a2a assert would fire later with
+    a much less obvious message.
+    """
+    if num_heads % cp_size:
+        raise ValueError(
+            f"num_heads ({num_heads}) must be divisible by cp_size ({cp_size}) "
+            "for head-sharded all-to-all context parallel"
+        )
+    per_rank = num_heads // cp_size
+    return cp_rank * per_rank, (cp_rank + 1) * per_rank
+
+
+def seq_to_head(x, group):
+    """``[b, s/P, h, d] -> [b, s, h/P, d]``: scatter heads, gather sequence."""
+    return UlyssesAlltoAll.apply(x, 2, 1, 0, group)
+
+
+def head_to_seq(x, group):
+    """``[b, s, h/P, d] -> [b, s/P, h, d]``: scatter sequence, gather heads."""
+    return UlyssesAlltoAll.apply(x, 1, 2, 0, group)
+
+
+def seq_to_head_beta(beta, group):
+    """``[b, s/P, h] -> [b, s, h/P]``.
+
+    ``UlyssesAlltoAll`` only understands 4-D ``[b, s, h, d]``; a 3-D tensor would
+    be silently read as ``[b, s, h]`` with the head axis in the wrong place.  So
+    give ``beta`` a length-1 head_dim for the duration of the swap.
+    """
+    return seq_to_head(beta.unsqueeze(-1), group).squeeze(-1)
+
+
+def split_qkv_seq_to_head(qkv, dims, heads, group):
+    """Split the fused ``qkv`` channel block, then a2a each part to head shards.
+
+    ``qkv`` is ``[b, s/P, sum(dims)]`` -- one contiguous channel block per q/k/v.
+    Slicing its last axis by ``cp_size`` directly would cut across the q/k/v
+    boundaries, so the split has to come first.  Under GVA the three blocks do
+    not even have the same head count, which is why ``heads`` is per-block.
+
+    Returns three 4-D tensors ``[b, s, h_block/P, d_block]``.
+    """
+    out = []
+    parts = paddle.split(qkv, list(dims), axis=-1)
+    for part, dim, num_heads in zip(parts, dims, heads):
+        head_dim = dim // num_heads
+        out.append(
+            seq_to_head(
+                part.reshape(
+                    [part.shape[0], part.shape[1], num_heads, head_dim]
+                ),
+                group,
+            )
+        )
+    return tuple(out)
+
+
+def slice_channels_by_head(tensor, dims, heads, cp_rank, cp_size):
+    """Slice a per-channel tensor laid out like ``qkv``: ``[sum(dims), ...]``.
+
+    This is the depthwise conv weight ``[conv_dim, w]`` and its bias
+    ``[conv_dim]``.  Each of the three blocks is sliced with *its own* head count,
+    so it stays correct under GVA (``H != HV``) and ``K != V``.
+    """
+    out, offset = [], 0
+    tail = list(tensor.shape[1:])
+    for dim, num_heads in zip(dims, heads):
+        h0, h1 = head_range(num_heads, cp_rank, cp_size)
+        block = tensor[offset : offset + dim].reshape(
+            [num_heads, dim // num_heads, *tail]
+        )
+        out.append(block[h0:h1].reshape([-1, *tail]))
+        offset += dim
+    return paddle.concat(out, axis=0)
+
+
+def slice_per_head_param(param, num_heads, cp_rank, cp_size):
+    """Slice a flat parameter whose leading axis folds into the head axis.
+
+    Covers both ``A_log [HV]`` and the flat ``dt_bias [HV * K]``: the ``[HV, -1]``
+    view degenerates to ``[HV, 1]`` for the former.
+
+    The parameter itself is **not** sharded -- callers pass the full tensor and
+    use the returned view.  Slicing is differentiable, so the gradient lands in a
+    full-shape tensor that is exactly ``0.0`` outside this rank's heads; the CP
+    sum is then ``x + 0 == x``, i.e. bitwise, and ``sharded_state_dict`` and the
+    trainer-side reduction need no changes at all.
+    """
+    if len(param.shape) != 1:
+        raise ValueError(
+            f"expected a flat per-head parameter, got shape {param.shape}; "
+            "use slice_channels_by_head for qkv-laid-out tensors"
+        )
+    h0, h1 = head_range(num_heads, cp_rank, cp_size)
+    return param.reshape([num_heads, -1])[h0:h1].reshape([-1])

--- a/src/paddlefleet/transformer/kda_head_a2a.py
+++ b/src/paddlefleet/transformer/kda_head_a2a.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Head-shard all-to-all helpers for linear-attention CP (``linear_attn_cp_mode="headwise"``).
+"""Head-shard all-to-all helpers for linear-attention CP (``linear_cp_mode="headwise"``).
 
 Everything in here is pure layout: a2a axis swaps and per-head slicing.  It is a
 separate module from ``kimi_delta_attention.py`` for one reason -- the bitwise

--- a/src/paddlefleet/transformer/kimi_delta_attention.py
+++ b/src/paddlefleet/transformer/kimi_delta_attention.py
@@ -323,14 +323,13 @@ class KimiDeltaAttention(FleetLayer):
         self.tp_size = get_pg_size(self.pg_collection.tp)
         self.sp_size = self.tp_size if config.sequence_parallel else 1
         self.cp_size = get_pg_size(getattr(self.pg_collection, "cp", None))
-        # ``linear_attn_cp_mode="headwise"``: the projections stay sequence-split,
+        # ``linear_cp_mode="headwise"``: the projections stay sequence-split,
         # but everything between them (conv + recurrence) runs on the *full*
         # sequence with a head shard, so there is no conv halo and no state relay.
         # The default "chunkwise" keeps the sequence-split path below unchanged.
         self.cp_head_a2a = (
             self.cp_size > 1
-            and getattr(config, "linear_attn_cp_mode", "chunkwise")
-            == "headwise"
+            and getattr(config, "linear_cp_mode", "chunkwise") == "headwise"
         )
 
         # Attributes from config
@@ -382,7 +381,7 @@ class KimiDeltaAttention(FleetLayer):
             # whole embedding + prologue had run.
             if self.cp_head_a2a and (num_heads // self.tp_size) % self.cp_size:
                 raise ValueError(
-                    f"linear_attn_cp_mode='headwise' splits heads across "
+                    f"linear_cp_mode='headwise' splits heads across "
                     f"the context-parallel group, so {name}({num_heads}) // "
                     f"tp_size({self.tp_size}) = {num_heads // self.tp_size} must "
                     f"be divisible by cp_size({self.cp_size})"

--- a/src/paddlefleet/transformer/kimi_delta_attention.py
+++ b/src/paddlefleet/transformer/kimi_delta_attention.py
@@ -54,6 +54,14 @@ from paddlefleet.utils import (
 )
 
 from .gated_delta_net import _l2norm
+from .kda_head_a2a import (
+    head_to_seq,
+    seq_to_head,
+    seq_to_head_beta,
+    slice_channels_by_head,
+    slice_per_head_param,
+    split_qkv_seq_to_head,
+)
 from .paddle_norm import (
     get_norm_extra_args,
     mark_as_sequence_parallel_parameter,
@@ -315,6 +323,15 @@ class KimiDeltaAttention(FleetLayer):
         self.tp_size = get_pg_size(self.pg_collection.tp)
         self.sp_size = self.tp_size if config.sequence_parallel else 1
         self.cp_size = get_pg_size(getattr(self.pg_collection, "cp", None))
+        # ``linear_attn_cp_mode="headwise"``: the projections stay sequence-split,
+        # but everything between them (conv + recurrence) runs on the *full*
+        # sequence with a head shard, so there is no conv halo and no state relay.
+        # The default "chunkwise" keeps the sequence-split path below unchanged.
+        self.cp_head_a2a = (
+            self.cp_size > 1
+            and getattr(config, "linear_attn_cp_mode", "chunkwise")
+            == "headwise"
+        )
 
         # Attributes from config
         self.hidden_size = config.hidden_size
@@ -358,6 +375,17 @@ class KimiDeltaAttention(FleetLayer):
                 raise ValueError(
                     f"{name}({num_heads}) must be divisible by the tensor "
                     f"parallel size({self.tp_size})"
+                )
+            # Under headwise CP the *TP-local* head count is what gets split
+            # again across CP. Checked here rather than in forward(): cp_size is
+            # already known, and a forward-time raise would only surface after a
+            # whole embedding + prologue had run.
+            if self.cp_head_a2a and (num_heads // self.tp_size) % self.cp_size:
+                raise ValueError(
+                    f"linear_attn_cp_mode='headwise' splits heads across "
+                    f"the context-parallel group, so {name}({num_heads}) // "
+                    f"tp_size({self.tp_size}) = {num_heads // self.tp_size} must "
+                    f"be divisible by cp_size({self.cp_size})"
                 )
         if self.num_value_heads % self.num_key_heads != 0:
             raise ValueError(
@@ -653,10 +681,11 @@ class KimiDeltaAttention(FleetLayer):
             batch, seq_len, _ = hidden_states.shape
 
         if self.cp_size > 1:
-            # fla's CP assumes the sequence is split contiguously and evenly
+            # Both CP paths assume the sequence is split contiguously and evenly
             # (part_len = total // world_size, rank_start = part_len * rank),
             # which is exactly scatter_contiguous. Other balance modes reorder
-            # tokens, so the rank ranges would not match.
+            # tokens, so the rank ranges would not match -- and for the head-a2a
+            # path the all-to-all would stitch the shards back in the wrong order.
             if batch != 1:
                 raise NotImplementedError(
                     "KDA context parallel requires batch == 1 (the packed "
@@ -698,11 +727,16 @@ class KimiDeltaAttention(FleetLayer):
                 "support."
             )
         cp_context = None
-        if self.cp_size > 1:
+        if self.cp_size > 1 and not self.cp_head_a2a:
             # build_cp_context slices the global cu_seqlens down to this rank and
             # records how many conv tokens / recurrent states to pull from the
             # neighbours. Both kernels read cu_seqlens out of the context and
             # ignore the argument, so drop the global one here.
+            #
+            # The head-a2a path deliberately skips all of this: after the swap
+            # this rank holds the *whole* sequence, so the kernels run single-card
+            # semantics against the *global* cu_seqlens. Clearing cu_seqlens here
+            # would silently merge the documents.
             cp_context = build_cp_context(
                 cu_seqlens,
                 self.pg_collection.cp,
@@ -775,6 +809,67 @@ class KimiDeltaAttention(FleetLayer):
                     .astype(paddle.float32)
                 )
 
+        # Channel layout of qkv, as three per-tensor blocks: conv, the a2a split
+        # and the post-conv split all have to agree on it.
+        qkv_splits = [
+            self.qk_dim // self.tp_size,
+            self.qk_dim // self.tp_size,
+            self.v_dim // self.tp_size,
+        ]
+        conv_weight = self.conv1d.weight.squeeze(1)
+        conv_bias = self.conv1d.bias
+        A_log, dt_bias = self.A_log, self.dt_bias
+        # Shape the KDA core sees. Everything above this point is this rank's
+        # sequence shard with all heads; under head-a2a everything below is the
+        # full sequence with this rank's head shard.
+        core_batch, core_seq = eff_batch, eff_seq
+
+        if self.cp_head_a2a:
+            # ==== all-to-all: [b, s/P, h, d] -> [b, s, h/P, d] ====
+            # Before the conv on purpose (design decision D1): a depthwise conv is
+            # independent per channel, so moving the head axis across it changes
+            # nothing numerically -- and having the full sequence locally is what
+            # removes the halo exchange and the cross-rank state relay entirely.
+            cp_group = self.pg_collection.cp
+            cp_rank, cp_size = cp_group.rank, cp_group.nranks
+            heads_k = self.num_key_heads // self.tp_size
+            heads_v = self.num_v_heads_local_tp
+            qkv_heads = (heads_k, heads_k, heads_v)
+            # qkv is one contiguous channel block per q/k/v, so its last axis must
+            # not be split by cp directly -- the cut would run across the q/k/v
+            # boundaries. Split first, swap each part, concatenate back; for a
+            # depthwise conv that round trip is an identity. Under GVA the three
+            # blocks do not even share a head count, hence per-block heads.
+            query, key, value = split_qkv_seq_to_head(
+                qkv, qkv_splits, qkv_heads, cp_group
+            )
+            qkv = paddle.concat(
+                [t.flatten(2) for t in (query, key, value)], axis=-1
+            )
+            # alpha and beta are projected from hidden_states rather than from the
+            # conv output, so they each need their own swap. beta is 3-D and gets a
+            # length-1 head dim for the duration of it.
+            alpha = seq_to_head(alpha, cp_group)
+            beta = seq_to_head_beta(beta, cp_group)
+            # Per-head parameters keep their full shape and are sliced here, in the
+            # graph: the slice is differentiable, so the gradient comes back
+            # full-shape and exactly 0.0 outside this rank's heads. The trainer-side
+            # sharding reduction is then x + 0 == x (bitwise) and neither
+            # sharded_state_dict nor the reduction needs to know about CP at all.
+            # Do NOT reduce them here -- the sharding group already covers CP, so a
+            # layer-local all_reduce double-counts.
+            conv_weight = slice_channels_by_head(
+                conv_weight, qkv_splits, qkv_heads, cp_rank, cp_size
+            )
+            if conv_bias is not None:
+                conv_bias = slice_channels_by_head(
+                    conv_bias, qkv_splits, qkv_heads, cp_rank, cp_size
+                )
+            A_log = slice_per_head_param(A_log, heads_v, cp_rank, cp_size)
+            dt_bias = slice_per_head_param(dt_bias, heads_v, cp_rank, cp_size)
+            qkv_splits = [dim // cp_size for dim in qkv_splits]
+            core_seq = seq_len_full
+
         # Convolution on qkv
         nvtx_range_push(suffix="conv1d")
         if self.use_fused_kernels:
@@ -784,8 +879,8 @@ class KimiDeltaAttention(FleetLayer):
             # conv pulls kernel_size-1 tokens across every document boundary.
             qkv, _ = causal_conv1d(
                 qkv.contiguous(),
-                weight=self.conv1d.weight.squeeze(1),
-                bias=self.conv1d.bias,
+                weight=conv_weight,
+                bias=conv_bias,
                 activation="silu",
                 cu_seqlens=cu_seqlens,
                 cu_seqlens_cpu=cu_seqlens_cpu,
@@ -801,18 +896,10 @@ class KimiDeltaAttention(FleetLayer):
             qkv = qkv.transpose([0, 2, 1])  # b, d, s -> b, s, d
         nvtx_range_pop(suffix="conv1d")
 
-        query, key, value = paddle.split(
-            qkv,
-            [
-                self.qk_dim // self.tp_size,
-                self.qk_dim // self.tp_size,
-                self.v_dim // self.tp_size,
-            ],
-            axis=-1,
-        )
-        query = query.reshape([eff_batch, eff_seq, -1, self.key_head_dim])
-        key = key.reshape([eff_batch, eff_seq, -1, self.key_head_dim])
-        value = value.reshape([eff_batch, eff_seq, -1, self.value_head_dim])
+        query, key, value = paddle.split(qkv, qkv_splits, axis=-1)
+        query = query.reshape([core_batch, core_seq, -1, self.key_head_dim])
+        key = key.reshape([core_batch, core_seq, -1, self.key_head_dim])
+        value = value.reshape([core_batch, core_seq, -1, self.value_head_dim])
 
         nvtx_range_push(suffix="kimi_delta_rule")
         if self.use_fused_kernels and not cache_active:
@@ -824,8 +911,8 @@ class KimiDeltaAttention(FleetLayer):
                 v=value.contiguous(),
                 g=alpha.contiguous(),
                 beta=beta.contiguous(),
-                A_log=self.A_log,
-                dt_bias=self.dt_bias,
+                A_log=A_log,
+                dt_bias=dt_bias,
                 use_qk_l2norm_in_kernel=self.use_qk_l2norm,
                 use_gate_in_kernel=True,
                 use_beta_sigmoid_in_kernel=True,
@@ -845,8 +932,8 @@ class KimiDeltaAttention(FleetLayer):
                 value.contiguous(),
                 g=alpha.contiguous(),
                 beta=beta.contiguous(),
-                A_log=self.A_log,
-                dt_bias=self.dt_bias,
+                A_log=A_log,
+                dt_bias=dt_bias,
                 use_qk_l2norm_in_kernel=False,
                 use_gate_in_kernel=True,
                 use_beta_sigmoid_in_kernel=True,
@@ -855,6 +942,14 @@ class KimiDeltaAttention(FleetLayer):
                 output_final_state=cache_active,
             )
         nvtx_range_pop(suffix="kimi_delta_rule")
+
+        if self.cp_head_a2a:
+            # ==== all-to-all back: [b, s, hv/P, v] -> [b, s/P, hv, v] ====
+            # Swapping back here, rather than after the gated norm, is why
+            # _gated_norm / out_norm / g_proj / out_proj need no changes at all:
+            # they are per-token, and they see exactly the sequence shard they saw
+            # without CP.
+            core_attn_out = head_to_seq(core_attn_out, self.pg_collection.cp)
 
         if cache_active:
             # Seed the decode loop. paddle_chunk_kda's final state is already the

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -982,7 +982,7 @@ class TransformerConfig(ModelParallelConfig):
     "contiguous_a2a".
     """
 
-    linear_attn_cp_mode: str = "chunkwise"
+    linear_cp_mode: str = "chunkwise"
     """How the linear-attention layers (KDA, ...) parallelise over the CP group.
 
     This is *not* a kernel selector -- the kernel is chunkwise either way. It
@@ -3152,14 +3152,14 @@ class TransformerConfig(ModelParallelConfig):
                 f"Must be one of {sorted(valid_cp_balance_modes)}."
             )
 
-        # only support linear_attn_cp_mode in {chunkwise, headwise}
-        valid_linear_attn_cp_modes = {"chunkwise", "headwise"}
-        if self.linear_attn_cp_mode not in valid_linear_attn_cp_modes:
+        # only support linear_cp_mode in {chunkwise, headwise}
+        valid_linear_cp_modes = {"chunkwise", "headwise"}
+        if self.linear_cp_mode not in valid_linear_cp_modes:
             raise ValueError(
-                f"linear_attn_cp_mode={self.linear_attn_cp_mode!r} is invalid. "
-                f"Must be one of {sorted(valid_linear_attn_cp_modes)}."
+                f"linear_cp_mode={self.linear_cp_mode!r} is invalid. "
+                f"Must be one of {sorted(valid_linear_cp_modes)}."
             )
-        if self.linear_attn_cp_mode == "headwise":
+        if self.linear_cp_mode == "headwise" and self.context_parallel_size > 1:
             # The head swap is layer-local: heads are exchanged by all-to-all
             # inside the layer and swapped back before ``out_norm``, which is only
             # sound while the *global* token layout is the contiguous one the swap
@@ -3171,7 +3171,7 @@ class TransformerConfig(ModelParallelConfig):
             # care which *contiguous* mode the non-linear-attention layers use.
             if not self.cp_balance_mode.startswith("contiguous"):
                 raise ValueError(
-                    "linear_attn_cp_mode='headwise' needs a contiguous "
+                    "linear_cp_mode='headwise' needs a contiguous "
                     "cp_balance_mode (the head swap assumes rank r owns the "
                     f"contiguous token block), got {self.cp_balance_mode!r}."
                 )

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -982,6 +982,37 @@ class TransformerConfig(ModelParallelConfig):
     "contiguous_a2a".
     """
 
+    linear_attn_cp_mode: str = "chunkwise"
+    """How the linear-attention layers (KDA, ...) parallelise over the CP group.
+
+    This is *not* a kernel selector -- the kernel is chunkwise either way. It
+    picks which axis the CP group cuts, and it only affects these layers: the
+    global token layout stays whatever ``cp_balance_mode`` says, and every other
+    layer of the same model is unaffected.
+
+    ``"chunkwise"`` (default) cuts the **sequence**, which is what the layer has
+    always done: each rank owns ``s/cp`` tokens, relays the chunk state rank to
+    rank, and exchanges a conv halo with its neighbours. Works under any
+    ``cp_balance_mode``, but cannot be bitwise against a single card -- the halo
+    backward is a partial sum, and a rank whose local varlen segments do not line
+    up with the global 64-token chunk grid re-segments the recurrence.
+
+    ``"headwise"`` cuts the **heads** (Ulysses): before the short conv each rank
+    trades its ``[s/cp, all heads]`` slice for ``[s, heads/cp]``, so the conv and
+    the recurrence see the *whole* sequence and run with plain single-card
+    semantics -- no halo, no state relay, global ``cu_seqlens`` -- and the output
+    is swapped back before ``out_norm``. That is what buys bitwise: the forward,
+    the input gradients and the per-head parameter gradients match a single card
+    exactly, leaving only the dense projections' ``dW`` at the ~1e-7 any-CP floor.
+
+    Costs and limits of ``"headwise"``: five all-to-all exchanges forward and one
+    back per layer instead of the halo exchange; requires
+    ``(num_key_heads // tp) % cp == 0`` and ``(num_value_heads // tp) % cp == 0``
+    (``KimiDeltaAttention.__init__`` raises otherwise); and because the swap
+    assumes rank ``r`` owns the contiguous token block ``[r*s/cp, (r+1)*s/cp)``,
+    ``cp_balance_mode`` must be one of the contiguous layouts.
+    """
+
     ####################
     # fp8
     ####################
@@ -3110,15 +3141,40 @@ class TransformerConfig(ModelParallelConfig):
                 )
             _warnings.warn(f"[MULTIMAX-CONFIG] multimax_modules={_multimax}")
 
-        if self.cp_balance_mode not in {
+        valid_cp_balance_modes = {
             "dualchunk_allgather",
             "contiguous_allgather",
             "contiguous_a2a",
-        }:
+        }
+        if self.cp_balance_mode not in valid_cp_balance_modes:
             raise ValueError(
                 f"cp_balance_mode={self.cp_balance_mode!r} is invalid. "
-                "Must be one of {'dualchunk_allgather', 'contiguous_allgather', 'contiguous_a2a'}."
+                f"Must be one of {sorted(valid_cp_balance_modes)}."
             )
+
+        # only support linear_attn_cp_mode in {chunkwise, headwise}
+        valid_linear_attn_cp_modes = {"chunkwise", "headwise"}
+        if self.linear_attn_cp_mode not in valid_linear_attn_cp_modes:
+            raise ValueError(
+                f"linear_attn_cp_mode={self.linear_attn_cp_mode!r} is invalid. "
+                f"Must be one of {sorted(valid_linear_attn_cp_modes)}."
+            )
+        if self.linear_attn_cp_mode == "headwise":
+            # The head swap is layer-local: heads are exchanged by all-to-all
+            # inside the layer and swapped back before ``out_norm``, which is only
+            # sound while the *global* token layout is the contiguous one the swap
+            # assumes ("rank r owns tokens [r*s/cp, (r+1)*s/cp)").  Under the
+            # dualchunk layout each rank holds two non-adjacent chunks, so the
+            # gathered sequence would be permuted and the recurrence -- which is
+            # order-dependent -- would silently compute against the wrong token
+            # order.  ``startswith`` rather than an exact value: the swap does not
+            # care which *contiguous* mode the non-linear-attention layers use.
+            if not self.cp_balance_mode.startswith("contiguous"):
+                raise ValueError(
+                    "linear_attn_cp_mode='headwise' needs a contiguous "
+                    "cp_balance_mode (the head swap assumes rank r owns the "
+                    f"contiguous token block), got {self.cp_balance_mode!r}."
+                )
 
         # only support hybrid_mla_cp_mode == contiguous_a2a if not None
         if self.hybrid_mla_cp_mode is not None:

--- a/tests/multi_card_tests/transformer/kda_a2a_utils.py
+++ b/tests/multi_card_tests/transformer/kda_a2a_utils.py
@@ -1,0 +1,98 @@
+#  Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helpers for the two ``linear_attn_cp_mode="headwise"`` tests.
+
+``test_kda_a2a_core_bitwise.py`` (bitwise, KDA core only) and
+``test_kda_head_a2a_layer.py`` (whole layer, rel-L2) need the same two things,
+and the first is subtle enough that a second copy of it would eventually drift:
+
+* every loaded fla autotuner pinned to one config.  The autotune keys contain
+  the head counts (``ops/kda/chunk_bwd.py``: ``key=['H','HV','K','V',...]``),
+  and both tests run the KDA core at *different* head counts on their two arms
+  by construction -- that is what head-sharded CP is.  Unpinned, the two arms
+  legitimately pick different triton configs, which changes the reduction order,
+  which changes the bits.  An unpinned bitwise test measures the autotuner, not
+  the all-to-all.
+* a relative L2 that does not divide by zero.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import paddle
+
+# A neighbour's sequence shard -- or a gradient that was never sharded at all --
+# must be at least this far away in relative L2.  Same constant and same purpose
+# as ``test_flash_mask_cp_a2a.py``: without a *lower* bound of this kind, an
+# all-zero output satisfies every upper-bound assertion in these files.
+WRONG_SHARD_MIN = 0.1
+
+
+def pin_fla_autotune(*prefixes: str) -> list[str]:
+    """Pin every already-loaded fla autotuner to its first config.
+
+    Call this **before the first kernel launch** -- an autotuner that has
+    already run has cached its choice under a key that includes the head count.
+
+    Walks ``sys.modules`` instead of importing anything: the ``@autotune`` /
+    ``@heuristics`` decorators run at import time, so which kernels exist
+    depends on what the caller imported.  Both wrappers keep the wrapped object
+    in ``.fn``, hence the short peel loop looking for whoever owns ``configs``.
+
+    Returns the names it pinned, so a caller can assert it was not a no-op.
+    """
+    prefixes = prefixes or ("paddlefleet_ops.fla", "fla")
+    pinned = []
+    for modname, mod in list(sys.modules.items()):
+        if not any(
+            modname == prefix or modname.startswith(prefix + ".")
+            for prefix in prefixes
+        ):
+            continue
+        for attr in dir(mod):
+            try:
+                node = getattr(mod, attr)
+            except Exception:
+                # Module attributes can be properties that raise on an
+                # unsupported build; none of them is worth failing a test over.
+                continue
+            for _ in range(6):
+                if node is None:
+                    break
+                configs = getattr(node, "configs", None)
+                if isinstance(configs, list):
+                    if len(configs) > 1:
+                        node.configs = configs[:1]
+                        # A choice already cached under a previous key would
+                        # otherwise survive the pinning.
+                        if hasattr(node, "cache"):
+                            node.cache = {}
+                        pinned.append(f"{modname}.{attr}")
+                    break
+                node = getattr(node, "fn", None)
+    return pinned
+
+
+def rel_l2(got, ref) -> float:
+    """``||got - ref|| / ||ref||``, computed in fp32.
+
+    A zero reference falls back to the absolute norm rather than dividing by
+    zero: the callers use this on gradients that are legitimately zero outside
+    one rank's head block.
+    """
+    got, ref = got.astype("float32"), ref.astype("float32")
+    denom = float(paddle.linalg.norm(ref))
+    return float(paddle.linalg.norm(got - ref)) / (denom if denom else 1.0)

--- a/tests/multi_card_tests/transformer/kda_a2a_utils.py
+++ b/tests/multi_card_tests/transformer/kda_a2a_utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared helpers for the two ``linear_attn_cp_mode="headwise"`` tests.
+"""Shared helpers for the two ``linear_cp_mode="headwise"`` tests.
 
 ``test_kda_a2a_core_bitwise.py`` (bitwise, KDA core only) and
 ``test_kda_head_a2a_layer.py`` (whole layer, rel-L2) need the same two things,

--- a/tests/multi_card_tests/transformer/test_kda_a2a_core_bitwise.py
+++ b/tests/multi_card_tests/transformer/test_kda_a2a_core_bitwise.py
@@ -14,7 +14,7 @@
 
 """Bitwise coverage of the head-sharded all-to-all KDA core, on real ranks.
 
-``linear_attn_cp_mode="headwise"`` exists to make context parallelism *exact*
+``linear_cp_mode="headwise"`` exists to make context parallelism *exact*
 for the linear-attention layers, and this file is what pins that claim down.
 The KDA core -- ``causal_conv1d`` + ``chunk_kda`` -- must be **bitwise**
 identical between

--- a/tests/multi_card_tests/transformer/test_kda_a2a_core_bitwise.py
+++ b/tests/multi_card_tests/transformer/test_kda_a2a_core_bitwise.py
@@ -1,0 +1,520 @@
+#  Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Bitwise coverage of the head-sharded all-to-all KDA core, on real ranks.
+
+``linear_attn_cp_mode="headwise"`` exists to make context parallelism *exact*
+for the linear-attention layers, and this file is what pins that claim down.
+The KDA core -- ``causal_conv1d`` + ``chunk_kda`` -- must be **bitwise**
+identical between
+
+    single card:  full sequence, all heads
+    headwise CP:  full sequence, this rank's head shard
+
+for the output, the input-side gradients (``dqkv``/``dalpha``/``dbeta``) *and*
+the per-head parameter gradients (``dA_log``/``ddt_bias``/``dconv_weight``).  It
+can be, because after the head swap the recurrence sees the whole sequence with
+plain single-card semantics -- no conv halo, no cross-rank state relay -- and
+the per-head parameters reduce over a token axis that CP never cuts, with each
+rank's partial gradient exactly ``0.0`` outside its own heads.  The single
+measured exception, on the non-production plain-gate path, is documented at
+``_DEMOTED_TO_L2`` below, together with why it is a property of head splitting
+in general rather than of the all-to-all.
+
+Deliberately kept *below* the layer: no ``in_proj``, no ``out_proj``, no fleet
+topology.  Those projections are GEMMs whose ``M`` differs between the two arms
+(``s/cp`` vs ``s``), so cuBLAS may pick a different algorithm for each and they
+can only ever be compared with a tolerance.  Mixing them in here would turn every
+bitwise assertion in this file into a tolerance one and lose the signal that the
+core itself is exact.  ``test_kda_head_a2a_layer.py`` is the tolerance half of
+the pair; the split between the two files is the point, not an accident.
+
+Also no ``fleet.init``: the core needs nothing but a process group, so the CP
+group here is just ``dist.new_group(range(world))``.  Reproducing the production
+``dp=1, sharding=cp=ep=world`` topology is the layer test's job.
+
+Three kinds of assertion, all of which must hold:
+
+  * ``max|diff| == 0`` against the reference (bitwise, no tolerance)
+  * per-rank parameter grads must **differ** from the reference before the CP
+    sum -- otherwise the head slice is not taking effect, every rank is computing
+    the full gradient, and the trainer-side reduction will double-count it
+  * the local output must **not** match a neighbour's sequence shard -- a
+    guard against a wrong sequence partition passing because everything is zero
+
+Launch (needs >= 2 GPUs; 4 in CI):
+
+    python -m paddle.distributed.launch --gpus="0,1,2,3" \
+        transformer/test_kda_a2a_core_bitwise.py
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import paddle
+import paddle.distributed as dist
+from paddlefleet_ops.fla.modules.conv.causal_conv1d import causal_conv1d
+from paddlefleet_ops.fla.ops.kda import chunk_kda
+
+from paddlefleet.transformer.kda_head_a2a import (
+    head_to_seq,
+    seq_to_head,
+    seq_to_head_beta,
+    slice_channels_by_head,
+    slice_per_head_param,
+    split_qkv_seq_to_head,
+)
+from tests.multi_card_tests.transformer.kda_a2a_utils import (
+    WRONG_SHARD_MIN,
+    pin_fla_autotune,
+    rel_l2,
+)
+
+SEED = 20260903
+DTYPE = "bfloat16"
+
+# GVA on purpose: HV = 2 * H.  With H == HV a bug that slices the value heads
+# with the key-head count would be invisible.
+SEQ = 256
+NUM_KEY_HEADS = 4
+NUM_VALUE_HEADS = 8
+KEY_HEAD_DIM = VALUE_HEAD_DIM = 32
+CONV_KERNEL = 4
+# Documents of the packed sequence, deliberately not aligned to SEQ // cp_size:
+# under a2a the conv needs no halo precisely because every rank sees all of them.
+DOCS = [100, 60, 96]
+
+QK_DIM = NUM_KEY_HEADS * KEY_HEAD_DIM
+V_DIM = NUM_VALUE_HEADS * VALUE_HEAD_DIM
+CONV_DIM = 2 * QK_DIM + V_DIM
+# How ``qkv`` lays out its channels, and how many heads each block has.
+QKV_DIMS = (QK_DIM, QK_DIM, V_DIM)
+QKV_HEADS = (NUM_KEY_HEADS, NUM_KEY_HEADS, NUM_VALUE_HEADS)
+
+CP_GROUP = None
+CP_RANK = None
+CP_SIZE = None
+
+
+def setUpModule():
+    global CP_GROUP, CP_RANK, CP_SIZE
+    world = dist.get_world_size()
+    if world < 2:
+        raise unittest.SkipTest(
+            "head-shard a2a coverage needs at least 2 ranks"
+        )
+    dist.init_parallel_env()
+    CP_GROUP = dist.new_group(list(range(world)))
+    CP_RANK, CP_SIZE = CP_GROUP.rank, CP_GROUP.nranks
+    for name, count in (("key", NUM_KEY_HEADS), ("value", NUM_VALUE_HEADS)):
+        if count % CP_SIZE:
+            raise unittest.SkipTest(
+                f"num_{name}_heads={count} is not divisible by cp={CP_SIZE}"
+            )
+    # Must happen before the first kernel launch: @autotune keys include H/HV,
+    # so without pinning the two arms would legitimately pick different configs
+    # and the bitwise assertions below would be testing the autotuner.
+    pin_fla_autotune()
+
+
+def _cu_seqlens():
+    bounds, acc = [0], 0
+    for doc in DOCS:
+        acc += doc
+        bounds.append(acc)
+    assert bounds[-1] == SEQ, f"DOCS sum to {bounds[-1]}, expected SEQ={SEQ}"
+    cu = paddle.to_tensor(bounds, dtype="int64")
+    return cu, cu.cpu()
+
+
+def _inputs():
+    """Byte-identical inputs on every rank.
+
+    Same seed on same-model GPUs would almost certainly already agree, but a
+    single broadcast removes an entire class of false failure: if the two arms
+    ever disagreed because rank 3 generated a different random bit, the failure
+    would look exactly like a real bitwise break.
+    """
+    paddle.seed(SEED)
+    hv_k = NUM_VALUE_HEADS * KEY_HEAD_DIM
+    out = {
+        # qkv is the fused in_proj output: one contiguous channel block.
+        "qkv": paddle.randn([1, SEQ, CONV_DIM]).astype(DTYPE),
+        # alpha is the raw gate input (use_gate_in_kernel=True), from f_b_proj.
+        "alpha": paddle.randn([1, SEQ, hv_k]).astype(DTYPE),
+        # beta is raw logits; the layer keeps it in fp32 (kimi_delta_attention.py:755).
+        "beta": paddle.randn([1, SEQ, NUM_VALUE_HEADS], dtype="float32"),
+        "conv_w": paddle.randn([CONV_DIM, CONV_KERNEL], dtype="float32") * 0.1,
+        "conv_b": paddle.randn([CONV_DIM], dtype="float32") * 0.1,
+        # Production init: A_log = log(U(1, 16)), see the layer's reset_parameters.
+        "A_log": paddle.log(
+            paddle.uniform(
+                [NUM_VALUE_HEADS], min=1.0, max=16.0, dtype="float32"
+            )
+        ),
+        "dt_bias": paddle.randn([hv_k], dtype="float32"),
+        "do": paddle.randn([1, SEQ, NUM_VALUE_HEADS, VALUE_HEAD_DIM]).astype(
+            DTYPE
+        ),
+    }
+    for tensor in out.values():
+        dist.broadcast(tensor, src=0, group=CP_GROUP)
+    return out
+
+
+def _leaf(tensor):
+    leaf = tensor.detach().clone()
+    leaf.stop_gradient = False
+    return leaf
+
+
+def _core(
+    qkv, alpha, beta, conv_w, conv_b, A_log, dt_bias, cu, cu_cpu, lower_bound
+):
+    """conv + chunk_kda, exactly as ``kimi_delta_attention.py:785-837`` calls them.
+
+    ``cp_context`` is ``None`` in both arms -- that is the whole point of the a2a
+    route: after the head swap this rank holds the *full* sequence, so the core
+    runs single-card semantics with the *global* ``cu_seqlens``.  No halo, no
+    state relay, no re-chunking.
+    """
+    heads_v = A_log.shape[0]
+    qkv, _ = causal_conv1d(
+        qkv.contiguous(),
+        weight=conv_w,
+        bias=conv_b,
+        activation="silu",
+        cu_seqlens=cu,
+        cu_seqlens_cpu=cu_cpu,
+        cp_context=None,
+    )
+    heads_k = (qkv.shape[-1] - heads_v * VALUE_HEAD_DIM) // (2 * KEY_HEAD_DIM)
+    query, key, value = paddle.split(
+        qkv,
+        [
+            heads_k * KEY_HEAD_DIM,
+            heads_k * KEY_HEAD_DIM,
+            heads_v * VALUE_HEAD_DIM,
+        ],
+        axis=-1,
+    )
+    seq = qkv.shape[1]
+    out, _ = chunk_kda(
+        q=query.reshape([1, seq, heads_k, KEY_HEAD_DIM]).contiguous(),
+        k=key.reshape([1, seq, heads_k, KEY_HEAD_DIM]).contiguous(),
+        v=value.reshape([1, seq, heads_v, VALUE_HEAD_DIM]).contiguous(),
+        g=alpha.reshape([1, seq, heads_v, KEY_HEAD_DIM]).contiguous(),
+        beta=beta.contiguous(),
+        A_log=A_log,
+        dt_bias=dt_bias,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        use_beta_sigmoid_in_kernel=True,
+        safe_gate=lower_bound is not None,
+        lower_bound=lower_bound,
+        cu_seqlens=cu,
+        cu_seqlens_cpu=cu_cpu,
+        cp_context=None,
+    )
+    return out
+
+
+def _reference(inp, lower_bound):
+    """Single-card arm: full sequence, all heads, no communication."""
+    cu, cu_cpu = _cu_seqlens()
+    leaves = {n: _leaf(inp[n]) for n in ("qkv", "alpha", "beta")}
+    params = {
+        n: _leaf(inp[n]) for n in ("conv_w", "conv_b", "A_log", "dt_bias")
+    }
+    out = _core(
+        leaves["qkv"],
+        leaves["alpha"],
+        leaves["beta"],
+        params["conv_w"],
+        params["conv_b"],
+        params["A_log"],
+        params["dt_bias"],
+        cu,
+        cu_cpu,
+        lower_bound,
+    )
+    order = list(leaves) + list(params)
+    grads = paddle.grad(
+        out, [*leaves.values(), *params.values()], grad_outputs=inp["do"]
+    )
+    return out, dict(zip(order, grads))
+
+
+def _cp_arm(inp, lower_bound):
+    """a2a arm: this rank owns a sequence shard on the outside, a head shard inside."""
+    cu, cu_cpu = _cu_seqlens()
+    s_local = SEQ // CP_SIZE
+    seq_shard = slice(CP_RANK * s_local, (CP_RANK + 1) * s_local)
+
+    leaves = {n: _leaf(inp[n][:, seq_shard]) for n in ("qkv", "alpha", "beta")}
+    # Parameters stay at full shape and are sliced *inside* the graph, so their
+    # grads come back full-shape with exact 0.0 outside this rank's heads.  That
+    # is what makes the CP sum bitwise (x + 0 == x) and leaves both
+    # sharded_state_dict and the trainer-side reduction untouched -- exactly what
+    # the layer does at ``kimi_delta_attention.py``'s head-a2a block.
+    params = {
+        n: _leaf(inp[n]) for n in ("conv_w", "conv_b", "A_log", "dt_bias")
+    }
+
+    query, key, value = split_qkv_seq_to_head(
+        leaves["qkv"], QKV_DIMS, QKV_HEADS, CP_GROUP
+    )
+    # Re-concatenating the three channel blocks is numerically an identity for a
+    # depthwise conv (groups == conv_dim): every channel is independent.
+    qkv_h = paddle.concat([t.flatten(2) for t in (query, key, value)], axis=-1)
+    alpha_h = seq_to_head(
+        leaves["alpha"].reshape([1, s_local, NUM_VALUE_HEADS, KEY_HEAD_DIM]),
+        CP_GROUP,
+    ).flatten(2)
+    beta_h = seq_to_head_beta(leaves["beta"], CP_GROUP)
+
+    out_h = _core(
+        qkv_h,
+        alpha_h,
+        beta_h,
+        slice_channels_by_head(
+            params["conv_w"], QKV_DIMS, QKV_HEADS, CP_RANK, CP_SIZE
+        ),
+        slice_channels_by_head(
+            params["conv_b"], QKV_DIMS, QKV_HEADS, CP_RANK, CP_SIZE
+        ),
+        slice_per_head_param(
+            params["A_log"], NUM_VALUE_HEADS, CP_RANK, CP_SIZE
+        ),
+        slice_per_head_param(
+            params["dt_bias"], NUM_VALUE_HEADS, CP_RANK, CP_SIZE
+        ),
+        cu,
+        cu_cpu,
+        lower_bound,
+    )
+    out = head_to_seq(out_h, CP_GROUP)
+
+    order = list(leaves) + list(params)
+    grads = paddle.grad(
+        out,
+        [*leaves.values(), *params.values()],
+        grad_outputs=inp["do"][:, seq_shard],
+    )
+    return out, dict(zip(order, grads))
+
+
+# For the one gradient that is measured not to be bitwise, see ``_DEMOTED_TO_L2``
+# below.  The bound used there is the textbook forward error bound for a
+# floating-point summation of ``n`` terms -- ``n * eps * sum|x_i|`` -- not a
+# tolerance fitted to the observation.  ``eps = 2**-24`` is fp32's unit roundoff
+# (the accumulator is fp32 even though the addends are bf16) and ``n`` is SEQ,
+# the length of the reduced token axis.
+FP32_EPS = 2**-24
+SUM_ERR_BOUND = SEQ * FP32_EPS
+
+# The tier-L2 gate for the one demoted tensor.  Measured 2.869e-06 at cp=4;
+# 1e-05 leaves headroom for a different GPU's reduce blocking without admitting a
+# real bug (a wrong head slice moves a whole block, rel-L2 ~1e-01).
+REDUCE_REL_L2_TOL = 1e-5
+
+# ``ddt_bias`` on the *non-production* gate path (``lower_bound=None``) is the one
+# tensor that is not bitwise, and only from cp=4 up.  Measured: 2 of 256 elements
+# off by 2.38e-07 (= 2^-22), and -- this is the part that matters -- both of them
+# inside the owning rank's own head block, so the head slicing and the CP sum are
+# exact; what changed is the *intra-rank* reduction.
+#
+# ``ops/kda/gate.py:288`` computes it as ``dg.view(-1, H * K).sum(0)``.  a2a never
+# splits that reduction's ``T`` axis, which is why the disjoint-support argument
+# above ("each rank's partial is exactly 0.0 outside its own heads, so the CP sum
+# is x + 0") looked sufficient -- but the row *width* does change,
+# ``HV*K`` -> ``HV/P*K``, and a framework reduce picks its blocking from the
+# shape.  Different blocking, different fp32 accumulation order over ``T``.
+#
+# Note the absolute deviation is ~9e-06 of the tensor's own max magnitude, i.e.
+# far more than 1 ULP *of the result* -- because the sum cancels.  Reordering a
+# cancelling sum perturbs it by an ULP of the largest partial sum, so the result's
+# own magnitude is the wrong yardstick; ``_assert_reduction_noise`` uses
+# ``sum|terms|`` instead.
+#
+# It is data-dependent, not structural: the same head split performed in-process
+# on a single card at these exact shapes is bitwise, and so is a randn-filled
+# reduce at these widths.  Real ``dg`` spans a much wider dynamic
+# range along ``K`` (it is a reverse cumsum of log-space gates), which is what
+# makes the reordering visible.  So this is **not** an a2a defect -- any head
+# split can hit it -- and the production path (``gate_lower_bound=-5.0``,
+# ``safe_gate=True``) is exactly bitwise on 2 and 4 ranks.
+_DEMOTED_TO_L2 = {None: {"dt_bias"}, -5.0: set()}
+
+
+class KdaA2ACoreBitwiseTest(unittest.TestCase):
+    """Bitwise equality of the KDA core between single-card and head-shard a2a."""
+
+    def _assert_bitwise(self, got, ref, name):
+        diff = (got.astype("float32") - ref.astype("float32")).abs()
+        self.assertTrue(
+            bool(paddle.isfinite(diff).all()),
+            f"[rank {CP_RANK}] {name}: non-finite",
+        )
+        mismatched = int((diff != 0).sum())
+        if not mismatched:
+            return
+        # Where the mismatches sit is the whole diagnosis for a per-head
+        # parameter: inside this rank's own head block means the local reduction
+        # ordering changed, outside it means another rank's supposedly-zero
+        # region is not actually zero -- a real slicing bug, not a rounding one.
+        where = paddle.nonzero(diff.reshape([-1]) != 0).reshape([-1])
+        head = [int(i) for i in where[:8]]
+        self.fail(
+            f"[rank {CP_RANK}] {name}: NOT bitwise -- max|diff|={float(diff.max()):.6e}, "
+            f"mismatched={mismatched}/{diff.numel()}, flat idx {head}"
+            f"{' ...' if mismatched > len(head) else ''}"
+        )
+
+    def _assert_reduction_noise(self, got, ref, terms_l1, name):
+        """Demote ONE tensor from L1 to L2, with the deviation's scale explained.
+
+        The result's own magnitude is the wrong yardstick here: this sum cancels,
+        so reordering it perturbs the answer by an ULP of the largest partial sum,
+        not of the answer.  ``terms_l1`` (``sum_t |term_t|``, from ``dalpha``) gives
+        the accumulator's scale, and the classic summation error bound
+        ``n * eps * sum|terms|`` says how far a reordering may legitimately move
+        the result.  The measured deviation sits at ~1.25x that estimate -- i.e.
+        exactly at rounding scale, given that ``dalpha`` is only an O(1) proxy for
+        the ``dg`` being reduced (they differ by the gate's chain factor
+        ``A * sigmoid(...)``, and ``A = exp(A_log)`` spans [1, 16] here).
+        That ratio is reported, not asserted: it is evidence about the mechanism,
+        while the gate below is the stable, tier-L2 claim.
+        """
+        diff = (got.astype("float32") - ref.astype("float32")).abs()
+        bound = SUM_ERR_BOUND * terms_l1.astype("float32").reshape(diff.shape)
+        ratio = float((diff / paddle.clip(bound, min=float(FP32_EPS))).max())
+        rel = rel_l2(got, ref)
+        if CP_RANK == 0:
+            print(
+                f"    [L2] {name}: rel-L2 {rel:.3e}, max|diff| "
+                f"{float(diff.max()):.6e}, {int((diff != 0).sum())}/{diff.numel()} "
+                f"elements, {ratio:.2f}x the summation error bound",
+                flush=True,
+            )
+        self.assertLess(
+            rel,
+            REDUCE_REL_L2_TOL,
+            f"[rank {CP_RANK}] {name}: rel-L2 {rel:.3e} >= {REDUCE_REL_L2_TOL:.1e} "
+            f"-- far beyond the measured reduction-order effect ({ratio:.2f}x the "
+            f"summation error bound), so this is a real regression, not rounding",
+        )
+
+    def _assert_single_head_block(self, got, ref, name):
+        """Every deviating element must sit in ONE rank's head block.
+
+        This is the assertion that keeps the tolerated case honest.  A rounding
+        difference in one rank's own reduction can only touch that rank's slots;
+        a slicing bug -- a rank whose supposedly-zero region is not zero, or heads
+        paired with the wrong ``A_log`` -- would spread across blocks.  So the
+        weaker magnitude claim is fenced in by a structural one.
+        """
+        diff = (got.astype("float32") - ref.astype("float32")).abs()
+        where = paddle.nonzero(diff.reshape([-1]) != 0).reshape([-1])
+        if not int(where.numel()):
+            return
+        # int() on both sides: paddle's numel() returns a 0-d Tensor, and Tensor
+        # floor-division would make every index its own unhashable object -- the
+        # set would then have one entry per mismatch and never compare equal to 1.
+        per_rank = int(diff.numel()) // CP_SIZE
+        blocks = sorted({int(i) // per_rank for i in where})
+        self.assertEqual(
+            len(blocks),
+            1,
+            f"[rank {CP_RANK}] {name}: deviations span head blocks {blocks} "
+            f"(block size {per_rank}) -- rounding cannot do that, so the head "
+            f"slicing or the disjoint-support property is broken",
+        )
+
+    def _check(self, lower_bound):
+        inp = _inputs()
+        ref_out, ref_grad = _reference(inp, lower_bound)
+        cp_out, cp_grad = _cp_arm(inp, lower_bound)
+
+        s_local = SEQ // CP_SIZE
+        mine = slice(CP_RANK * s_local, (CP_RANK + 1) * s_local)
+        neighbour = slice(
+            ((CP_RANK + 1) % CP_SIZE) * s_local,
+            ((CP_RANK + 1) % CP_SIZE + 1) * s_local,
+        )
+
+        # L1a: output and input-side grads, against this rank's sequence shard.
+        self._assert_bitwise(cp_out, ref_out[:, mine], "core_attn_out")
+        for name in ("qkv", "alpha", "beta"):
+            self._assert_bitwise(
+                cp_grad[name], ref_grad[name][:, mine], f"d{name}"
+            )
+
+        # Guard against a wrong sequence partition: if the output were all zeros,
+        # or if every rank computed the same thing, the check above would still
+        # pass.  It must NOT match the next rank's shard.
+        wrong = rel_l2(cp_out, ref_out[:, neighbour])
+        self.assertGreater(
+            wrong,
+            WRONG_SHARD_MIN,
+            f"[rank {CP_RANK}] output matches rank {(CP_RANK + 1) % CP_SIZE}'s shard "
+            f"(rel-L2 {wrong:.3e}) -- the sequence partition is not taking effect",
+        )
+
+        # L1b: per-head parameter grads.  Two assertions, and the first one is the
+        # one that actually catches bugs: the local partial must DIFFER from the
+        # reference, otherwise the head slice is a no-op and every rank is
+        # silently accumulating the full (double-counted) gradient.
+        demoted = _DEMOTED_TO_L2[lower_bound]
+        for name in ("conv_w", "conv_b", "A_log", "dt_bias"):
+            partial, ref = cp_grad[name], ref_grad[name]
+            local = rel_l2(partial, ref)
+            self.assertGreater(
+                local,
+                WRONG_SHARD_MIN,
+                f"[rank {CP_RANK}] d{name}: local partial already matches the "
+                f"reference (rel-L2 {local:.3e}) -- head slicing is not taking effect",
+            )
+            summed = partial.clone()
+            # The layer must never do this itself -- the sharding group already
+            # contains the CP group, so a layer-local all_reduce would
+            # double-count.  The test stands in for that trainer-side reduction.
+            dist.all_reduce(summed, group=CP_GROUP)
+            if name in demoted:
+                # ``dalpha`` is the gate-input gradient, one chain-rule factor away
+                # from the ``dg`` that gate.py:288 actually reduces, so its L1 is a
+                # proxy for the true term magnitudes -- correct to an O(1) factor,
+                # which is all a summation bound needs.
+                terms_l1 = ref_grad["alpha"].astype("float32").abs().sum(axis=1)
+                self._assert_reduction_noise(
+                    summed, ref, terms_l1, f"d{name} (CP-summed)"
+                )
+                self._assert_single_head_block(
+                    summed, ref, f"d{name} (CP-summed)"
+                )
+            else:
+                self._assert_bitwise(summed, ref, f"d{name} (CP-summed)")
+
+    def test_core_bitwise_safe_gate(self):
+        """Production path: gate_lower_bound=-5.0 -> safe_gate=True."""
+        self._check(lower_bound=-5.0)
+
+    def test_core_bitwise_plain_gate(self):
+        """softplus gate, no clamp -- a different kernel branch, so tested too."""
+        self._check(lower_bound=None)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/multi_card_tests/transformer/test_kda_head_a2a_layer.py
+++ b/tests/multi_card_tests/transformer/test_kda_head_a2a_layer.py
@@ -1,0 +1,414 @@
+#  Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Layer-level coverage of ``linear_attn_cp_mode="headwise"`` on 4 ranks.
+
+The second half of a pair.  ``test_kda_a2a_core_bitwise.py`` proves the KDA core
+is **bitwise** under the head swap; this file proves the whole
+``KimiDeltaAttention`` layer -- projections, gate, ``out_norm``, ``out_proj``, the
+real fleet topology, the real config plumbing -- computes the right answer.
+
+It deliberately does **not** assert bitwise, and that is not a concession:
+``in_proj``/``out_proj`` are GEMMs whose ``M`` is ``seq_len`` on the CP arm and
+``seq_len * cp`` on the reference arm, so cuBLAS may pick a different algorithm
+and the two arms' KDA inputs already differ by ~1 ULP before the core is even
+reached.  Asserting ``max|diff| == 0`` here would be asserting something known to
+be false, and the useful signal -- that the core itself is exact -- would drown in
+it.  So: rel-L2 here, bitwise there.
+
+What this file catches that the core test cannot:
+
+  * ``linear_attn_cp_mode="headwise"`` actually reaching the KDA layer instead of
+    being rejected by config validation, with the *global* token layout staying
+    contiguous rather than flipping to dualchunk
+  * ``build_cp_context`` being skipped, so ``cu_seqlens`` stays **global**.  The
+    sequence-split path slices it down to this rank, which under the head swap
+    would silently merge the documents; asserted directly by making the call fail
+  * ``eff_seq`` vs ``seq_len_full`` reshape mix-ups around the swap
+  * the per-head parameters being sliced with the layer's own ``tp``-local head
+    counts rather than the global ones
+  * the ``__init__`` guard that rejects head counts not divisible by ``cp``
+
+Every weight gradient is asserted as a **pair**: the local partial must *differ*
+from the reference, and only the CP sum may match it.  Without the first half a
+layer that ignored the head shard entirely -- every rank computing the full
+gradient -- would pass, and would then double-count once the trainer reduces over
+the sharding group.
+
+Launch (needs exactly 4 GPUs):
+
+    python -m paddle.distributed.launch --gpus="0,1,2,3" \
+        transformer/test_kda_head_a2a_layer.py
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import paddle
+import paddle.distributed as dist
+import paddle.nn.functional as F
+from paddle.distributed import fleet
+
+import paddlefleet.parallel_state as ps
+from paddlefleet.process_groups_config import ProcessGroupCollection
+from paddlefleet.tensor_parallel.layers import (
+    ColumnParallelLinear,
+    Linear,
+    RowParallelLinear,
+)
+from paddlefleet.tensor_parallel.random import model_parallel_cuda_manual_seed
+from paddlefleet.training.initialize import initialize_fleet
+from paddlefleet.transformer import kimi_delta_attention as kda_mod
+from paddlefleet.transformer.kimi_delta_attention import (
+    HAVE_FLA,
+    KimiDeltaAttention,
+    KimiDeltaAttentionSublayersSpec,
+)
+from paddlefleet.transformer.paddle_norm import RMSNorm
+from paddlefleet.transformer.transformer_config import TransformerConfig
+from tests.multi_card_tests.transformer.kda_a2a_utils import (
+    WRONG_SHARD_MIN,
+    pin_fla_autotune,
+    rel_l2,
+)
+
+CONTEXT_PARALLEL = 4
+HIDDEN_SIZE = 128
+KEY_HEAD_DIM = VALUE_HEAD_DIM = 32
+# GVA: HV = 2 * H.  The existing CP test uses H == HV, which cannot catch a
+# value-head block sliced with the key-head count.
+NUM_KEY_HEADS = 4
+NUM_VALUE_HEADS = 8
+CONV_KERNEL_DIM = 4
+SEQ_LENGTH = 256
+SEED = 1234
+DOCS = [100, 60, 96]
+
+# Layer level, so the projections' GEMM shapes differ between the arms: rel-L2,
+# not bitwise.  See the module docstring.
+REL_L2_TOL = 1e-3
+
+MODE = "headwise"
+# The head swap is layer-local, so the *global* token layout must stay the
+# contiguous one it assumes: ``ContextParallelScatterOp`` dispatches on
+# ``startswith("contiguous")`` and its else-branch silently uses the dualchunk
+# layout, which would hand the gathered sequence to the recurrence permuted.
+# ``TransformerConfig`` rejects the combination outright; asserting it here as
+# well keeps the intent visible.
+CP_BALANCE_MODE = "contiguous_allgather"
+
+
+def _config(cp_size, mode):
+    return TransformerConfig(
+        hidden_size=HIDDEN_SIZE,
+        num_attention_heads=NUM_VALUE_HEADS,
+        num_hidden_layers=1,
+        hidden_act=F.silu,
+        rms_norm_eps=1e-6,
+        normalization="RMSNorm",
+        context_parallel_size=cp_size,
+        cp_balance_mode=CP_BALANCE_MODE,
+        linear_attn_cp_mode=mode,
+        deterministic_mode=False,
+    )
+
+
+def _build(config, pg_collection, **overrides):
+    spec = KimiDeltaAttentionSublayersSpec(
+        in_proj=ColumnParallelLinear,
+        f_a_proj=Linear,
+        f_b_proj=ColumnParallelLinear,
+        out_norm=RMSNorm,
+        out_proj=RowParallelLinear,
+    )
+    kwargs = {
+        "config": config,
+        "sublayers_spec": spec,
+        "layer_number": 1,
+        "pg_collection": pg_collection,
+        "conv_kernel_dim": CONV_KERNEL_DIM,
+        # Off by default, turned on here on purpose: the bias is the one conv
+        # parameter the layer slices behind an ``if conv_bias is not None`` branch,
+        # so with the default the branch would never execute in either test.
+        "conv_bias": True,
+        "key_head_dim": KEY_HEAD_DIM,
+        "value_head_dim": VALUE_HEAD_DIM,
+        "num_key_heads": NUM_KEY_HEADS,
+        "num_value_heads": NUM_VALUE_HEADS,
+        "gate_lora_rank": VALUE_HEAD_DIM,
+        # With use_full_rank_gate the gate comes out of the fused in_proj rather
+        # than g_a_proj/g_b_proj.  Either way it stays on the sequence-sharded
+        # side of the swap, so this is the harder of the two shapes to get right.
+        "use_full_rank_gate": True,
+        "gate_lower_bound": -5.0,
+    }
+    kwargs.update(overrides)
+    return KimiDeltaAttention(**kwargs)
+
+
+def _indices():
+    """[1, 1, S, 1] exclusive document ends for the *full* sequence.
+
+    Global on every rank on purpose: under a2a each rank runs the core over the
+    whole sequence, so the document boundaries it needs are the global ones.
+    """
+    row, end = [], 0
+    for length in DOCS:
+        end += length
+        row += [end] * length
+    assert len(row) == SEQ_LENGTH, (len(row), SEQ_LENGTH)
+    return paddle.to_tensor([row], dtype="int32").reshape([1, 1, SEQ_LENGTH, 1])
+
+
+@unittest.skipUnless(HAVE_FLA, "paddlefleet_ops fla kernels not available")
+class KdaHeadA2ALayerTest(unittest.TestCase):
+    """``linear_attn_cp_mode="headwise"`` at the layer level: correct, and really sharded."""
+
+    @classmethod
+    def setUpClass(cls):
+        if dist.get_world_size() != CONTEXT_PARALLEL:
+            raise unittest.SkipTest(
+                f"needs exactly {CONTEXT_PARALLEL} ranks, got {dist.get_world_size()}"
+            )
+        # CP only exists under an EP topology: _create_hcg builds
+        # EPHybridCommunicateGroup only when ep_degree > 1, otherwise
+        # get_context_parallel_group() is None and cp_size collapses to 1.
+        strategy = fleet.DistributedStrategy()
+        strategy.hybrid_configs = {
+            "dp_degree": 1,
+            "mp_degree": 1,
+            "pp_degree": 1,
+            "sharding_degree": CONTEXT_PARALLEL,
+            "sep_degree": 1,
+            "cp_degree": CONTEXT_PARALLEL,
+            "ep_degree": CONTEXT_PARALLEL,
+            "moe_sharding_degree": 1,
+            "order": [
+                "sharding",
+                "moe_sharding",
+                "pp",
+                "sep",
+                "cp",
+                "dp",
+                "ep",
+                "mp",
+            ],
+        }
+        initialize_fleet(strategy)
+        # Before the first kernel launch: the two arms run the KDA core at
+        # different head counts, and the autotune key contains H/HV.  Pinning does
+        # not make this test bitwise (the projections still differ), but it keeps
+        # the core's contribution out of the error budget.
+        pin_fla_autotune()
+
+    def _reference(self, x, indices):
+        """Whole sequence, CP group of size 1 -- the ground truth for this rank."""
+        layer = _build(
+            _config(1, MODE),
+            ProcessGroupCollection(
+                tp=None, cp=dist.new_group([dist.get_rank()])
+            ),
+        )
+        self.assertEqual(layer.cp_size, 1)
+        xf = x.clone()
+        xf.stop_gradient = False
+        out, _ = layer(hidden_states=xf, attn_mask_startend_row_indices=indices)
+        out.sum().backward()
+        grads = {
+            name: param.grad.clone()
+            for name, param in layer.named_parameters()
+            if param.grad is not None
+        }
+        return layer, out.detach(), xf.grad.clone(), grads
+
+    def _cp_arm(self, ref_layer, shard, indices, cp_group):
+        """This rank's sequence shard through the real CP group."""
+        layer = _build(
+            _config(CONTEXT_PARALLEL, MODE),
+            ProcessGroupCollection(tp=None, cp=cp_group),
+        )
+        self.assertEqual(layer.cp_size, CONTEXT_PARALLEL)
+        self.assertEqual(layer.config.linear_attn_cp_mode, MODE)
+        self.assertEqual(layer.config.cp_balance_mode, CP_BALANCE_MODE)
+        self.assertTrue(layer.cp_head_a2a)
+        with paddle.no_grad():
+            ref_params = dict(ref_layer.named_parameters())
+            for name, param in layer.named_parameters():
+                param.set_value(ref_params[name])
+        # ``build_cp_context`` belongs to the sequence-split path: it slices the
+        # global cu_seqlens down to this rank and then clears the global one.  After
+        # the head swap this rank holds the *whole* sequence, so that slicing would
+        # merge the three documents into one without any error -- the numbers would
+        # just be wrong.  Making the call itself fail is a stronger statement than
+        # comparing outputs: the mode must not even reach it.
+        with patch.object(
+            kda_mod,
+            "build_cp_context",
+            side_effect=AssertionError(
+                "build_cp_context must not run under linear_attn_cp_mode="
+                f"{MODE!r}: cu_seqlens has to stay global after the head swap"
+            ),
+        ):
+            out, _ = layer(
+                hidden_states=shard, attn_mask_startend_row_indices=indices
+            )
+        out.sum().backward()
+        return layer, out.detach()
+
+    def _assert_weight_grads(self, cp_layer, ref_grad, cp_group, cp_rank):
+        """Every weight gradient as a PAIR: local partial != ref, CP sum == ref.
+
+        The first half is the one that catches the bug that matters.  A layer that
+        ignored the head shard -- every rank computing the full gradient -- would
+        pass the CP-sum check after the trainer divides, and would double-count in
+        production.  Only the pair pins it down.
+        """
+        checked = []
+        for name, param in cp_layer.named_parameters():
+            self.assertIn(
+                name,
+                ref_grad,
+                f"[rank {cp_rank}] reference has no grad for {name}",
+            )
+            want = ref_grad[name]
+            self.assertIsNotNone(
+                param.grad,
+                f"[rank {cp_rank}] {name}: no gradient on the CP arm",
+            )
+            if float(want.astype("float32").norm()) == 0.0:
+                # Nothing to compare against; a zero reference makes rel-L2
+                # meaningless in both directions.
+                continue
+            partial = param.grad.clone()
+            local = rel_l2(partial, want)
+            self.assertGreater(
+                local,
+                WRONG_SHARD_MIN,
+                f"[rank {cp_rank}] d{name}: local partial already matches the "
+                f"reference (rel-L2 {local:.3e}) -- this rank is computing the full "
+                f"gradient, so the trainer-side CP sum will double-count it",
+            )
+            summed = partial.clone()
+            # The layer must never do this itself: CP is a sub-factor of the
+            # sharding axis, so the sharding group already contains the CP group
+            # and the trainer/optimizer reduces over it.  A second reduction
+            # inside the layer would double-count.  This test stands in for the
+            # trainer-side one.
+            dist.all_reduce(summed, group=cp_group)
+            err = rel_l2(summed, want)
+            self.assertLess(
+                err,
+                REL_L2_TOL,
+                f"[rank {cp_rank}] d{name}: CP-summed rel-L2 {err:.3e} >= "
+                f"{REL_L2_TOL:.1e}",
+            )
+            checked.append((name, local, err))
+        self.assertTrue(
+            checked, f"[rank {cp_rank}] no parameter gradient was checked"
+        )
+        # The zero-reference ``continue`` above is a real hole: a per-head parameter
+        # whose gradient came back all-zero (never sliced, never used, or detached)
+        # would be skipped and the test would still pass.  These four are the whole
+        # point of the head shard, so require that they were genuinely compared.
+        names = {name for name, _, _ in checked}
+        for required in ("conv1d.weight", "conv1d.bias", "A_log", "dt_bias"):
+            self.assertIn(
+                required,
+                names,
+                f"[rank {cp_rank}] {required} was not checked -- its reference "
+                f"gradient is zero or missing, so the head slicing is untested",
+            )
+        return checked
+
+    def test_head_count_must_divide_cp(self):
+        """``__init__`` rejects a head count the CP group cannot split evenly.
+
+        Every rank must end up with the same number of heads: the swap is a single
+        ``alltoall_single``, which is a fixed-size exchange.  ``NUM_KEY_HEADS - 2``
+        (2 heads, cp=4) would silently hand some ranks an empty head block, so the
+        guard has to fire in ``__init__`` rather than in the middle of a collective.
+        """
+        cp_group = ps.get_context_parallel_group()
+        with self.assertRaises(ValueError) as caught:
+            _build(
+                _config(CONTEXT_PARALLEL, MODE),
+                ProcessGroupCollection(tp=None, cp=cp_group),
+                num_key_heads=2,
+            )
+        self.assertIn("cp_size", str(caught.exception))
+
+    def test_layer_matches_full_sequence(self):
+        paddle.seed(SEED)
+        model_parallel_cuda_manual_seed(SEED)
+        cp_group = ps.get_context_parallel_group()
+        cp_rank = dist.get_rank(cp_group)
+        indices = _indices()
+
+        paddle.seed(SEED + 1)
+        x = paddle.randn([1, SEQ_LENGTH, HIDDEN_SIZE])
+        ref_layer, ref_out, ref_dx, ref_grad = self._reference(x, indices)
+
+        local = SEQ_LENGTH // CONTEXT_PARALLEL
+        mine = slice(cp_rank * local, (cp_rank + 1) * local)
+        nxt = (cp_rank + 1) % CONTEXT_PARALLEL
+        neighbour = slice(nxt * local, (nxt + 1) * local)
+
+        shard = x[:, mine].clone()
+        shard.stop_gradient = False
+        cp_layer, out = self._cp_arm(ref_layer, shard, indices, cp_group)
+
+        out_err = rel_l2(out, ref_out[:, mine])
+        self.assertLess(
+            out_err,
+            REL_L2_TOL,
+            f"[rank {cp_rank}] output rel-L2 {out_err:.3e} >= {REL_L2_TOL:.1e}",
+        )
+        dx_err = rel_l2(shard.grad, ref_dx[:, mine])
+        self.assertLess(
+            dx_err,
+            REL_L2_TOL,
+            f"[rank {cp_rank}] grad_x rel-L2 {dx_err:.3e} >= {REL_L2_TOL:.1e}",
+        )
+
+        # Without this an all-zero output, or every rank computing the same
+        # sequence, would sail through the two checks above.
+        wrong = rel_l2(out, ref_out[:, neighbour])
+        self.assertGreater(
+            wrong,
+            WRONG_SHARD_MIN,
+            f"[rank {cp_rank}] output matches rank {nxt}'s shard (rel-L2 "
+            f"{wrong:.3e}) -- the sequence partition is not taking effect",
+        )
+
+        checked = self._assert_weight_grads(
+            cp_layer, ref_grad, cp_group, cp_rank
+        )
+        if cp_rank == 0:
+            worst = max(err for _, _, err in checked)
+            print(
+                f"  [PASS] linear_attn_cp_mode={MODE} cp={CONTEXT_PARALLEL} "
+                f"out={out_err:.3e} "
+                f"gx={dx_err:.3e} worst weight-grad={worst:.3e} "
+                f"({len(checked)} params)"
+            )
+            for name, local, err in sorted(checked):
+                print(
+                    f"    {name:<22} local-vs-ref {local:.3e}  cp-sum {err:.3e}"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/multi_card_tests/transformer/test_kda_head_a2a_layer.py
+++ b/tests/multi_card_tests/transformer/test_kda_head_a2a_layer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Layer-level coverage of ``linear_attn_cp_mode="headwise"`` on 4 ranks.
+"""Layer-level coverage of ``linear_cp_mode="headwise"`` on 4 ranks.
 
 The second half of a pair.  ``test_kda_a2a_core_bitwise.py`` proves the KDA core
 is **bitwise** under the head swap; this file proves the whole
@@ -29,7 +29,7 @@ it.  So: rel-L2 here, bitwise there.
 
 What this file catches that the core test cannot:
 
-  * ``linear_attn_cp_mode="headwise"`` actually reaching the KDA layer instead of
+  * ``linear_cp_mode="headwise"`` actually reaching the KDA layer instead of
     being rejected by config validation, with the *global* token layout staying
     contiguous rather than flipping to dualchunk
   * ``build_cp_context`` being skipped, so ``cu_seqlens`` stays **global**.  The
@@ -121,7 +121,7 @@ def _config(cp_size, mode):
         normalization="RMSNorm",
         context_parallel_size=cp_size,
         cp_balance_mode=CP_BALANCE_MODE,
-        linear_attn_cp_mode=mode,
+        linear_cp_mode=mode,
         deterministic_mode=False,
     )
 
@@ -175,7 +175,7 @@ def _indices():
 
 @unittest.skipUnless(HAVE_FLA, "paddlefleet_ops fla kernels not available")
 class KdaHeadA2ALayerTest(unittest.TestCase):
-    """``linear_attn_cp_mode="headwise"`` at the layer level: correct, and really sharded."""
+    """``linear_cp_mode="headwise"`` at the layer level: correct, and really sharded."""
 
     @classmethod
     def setUpClass(cls):
@@ -241,7 +241,7 @@ class KdaHeadA2ALayerTest(unittest.TestCase):
             ProcessGroupCollection(tp=None, cp=cp_group),
         )
         self.assertEqual(layer.cp_size, CONTEXT_PARALLEL)
-        self.assertEqual(layer.config.linear_attn_cp_mode, MODE)
+        self.assertEqual(layer.config.linear_cp_mode, MODE)
         self.assertEqual(layer.config.cp_balance_mode, CP_BALANCE_MODE)
         self.assertTrue(layer.cp_head_a2a)
         with paddle.no_grad():
@@ -258,7 +258,7 @@ class KdaHeadA2ALayerTest(unittest.TestCase):
             kda_mod,
             "build_cp_context",
             side_effect=AssertionError(
-                "build_cp_context must not run under linear_attn_cp_mode="
+                "build_cp_context must not run under linear_cp_mode="
                 f"{MODE!r}: cu_seqlens has to stay global after the head swap"
             ),
         ):
@@ -399,7 +399,7 @@ class KdaHeadA2ALayerTest(unittest.TestCase):
         if cp_rank == 0:
             worst = max(err for _, _, err in checked)
             print(
-                f"  [PASS] linear_attn_cp_mode={MODE} cp={CONTEXT_PARALLEL} "
+                f"  [PASS] linear_cp_mode={MODE} cp={CONTEXT_PARALLEL} "
                 f"out={out_err:.3e} "
                 f"gx={dx_err:.3e} worst weight-grad={worst:.3e} "
                 f"({len(checked)} params)"

--- a/tests/single_card_tests/transformer/test_kimi_delta_attention.py
+++ b/tests/single_card_tests/transformer/test_kimi_delta_attention.py
@@ -1444,7 +1444,7 @@ class TestGatedNormRecompute(unittest.TestCase):
 
 
 class TestLinearAttnCpModeConfig(unittest.TestCase):
-    """``linear_attn_cp_mode`` validation in ``TransformerConfig.__post_init__``.
+    """``linear_cp_mode`` validation in ``TransformerConfig.__post_init__``.
 
     ``headwise`` is only correct under a contiguous token layout: the head swap
     assumes rank ``r`` owns the contiguous block ``[r*s/P, (r+1)*s/P)``, while
@@ -1455,17 +1455,17 @@ class TestLinearAttnCpModeConfig(unittest.TestCase):
 
     def test_default_is_chunkwise(self):
         """The existing sequence-split CP path must stay the default."""
-        self.assertEqual(TransformerConfig().linear_attn_cp_mode, "chunkwise")
+        self.assertEqual(TransformerConfig().linear_cp_mode, "chunkwise")
 
     def test_invalid_mode_raises(self):
         with self.assertRaises(ValueError) as caught:
-            TransformerConfig(linear_attn_cp_mode="ulysses")
-        self.assertIn("linear_attn_cp_mode", str(caught.exception))
+            TransformerConfig(linear_cp_mode="ulysses")
+        self.assertIn("linear_cp_mode", str(caught.exception))
 
     def test_headwise_rejects_dualchunk(self):
         with self.assertRaises(ValueError) as caught:
             TransformerConfig(
-                linear_attn_cp_mode="headwise",
+                linear_cp_mode="headwise",
                 cp_balance_mode="dualchunk_allgather",
             )
         self.assertIn("contiguous", str(caught.exception))
@@ -1474,9 +1474,9 @@ class TestLinearAttnCpModeConfig(unittest.TestCase):
         for balance in ("contiguous_allgather", "contiguous_a2a"):
             with self.subTest(cp_balance_mode=balance):
                 config = TransformerConfig(
-                    linear_attn_cp_mode="headwise", cp_balance_mode=balance
+                    linear_cp_mode="headwise", cp_balance_mode=balance
                 )
-                self.assertEqual(config.linear_attn_cp_mode, "headwise")
+                self.assertEqual(config.linear_cp_mode, "headwise")
                 self.assertEqual(config.cp_balance_mode, balance)
 
     def test_chunkwise_still_allows_dualchunk(self):
@@ -1487,7 +1487,7 @@ class TestLinearAttnCpModeConfig(unittest.TestCase):
 
 @unittest.skipUnless(HAVE_FLA, "paddlefleet_ops fla kernels are not available")
 class TestHeadwiseCpInit(unittest.TestCase):
-    """``__init__`` under ``linear_attn_cp_mode="headwise"``.
+    """``__init__`` under ``linear_cp_mode="headwise"``.
 
     ``get_pg_size`` returns 1 whenever ``paddle.distributed`` is not initialized,
     so the ``cp_size > 1`` branch is unreachable on one card without patching it.
@@ -1506,7 +1506,7 @@ class TestHeadwiseCpInit(unittest.TestCase):
             return _build_kda(
                 pg_collection=pg_collection,
                 config_overrides={
-                    "linear_attn_cp_mode": mode,
+                    "linear_cp_mode": mode,
                     "context_parallel_size": cp_size,
                     "cp_balance_mode": "contiguous_allgather",
                 },

--- a/tests/single_card_tests/transformer/test_kimi_delta_attention.py
+++ b/tests/single_card_tests/transformer/test_kimi_delta_attention.py
@@ -17,6 +17,9 @@
 from __future__ import annotations
 
 import inspect
+import subprocess
+import sys
+import textwrap
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -27,6 +30,11 @@ from paddle import nn
 
 from paddlefleet.models.gpt import GPTConfig
 from paddlefleet.transformer import kimi_delta_attention as kda_mod
+from paddlefleet.transformer.kda_head_a2a import (
+    head_range,
+    slice_channels_by_head,
+    slice_per_head_param,
+)
 from paddlefleet.transformer.kimi_delta_attention import (
     HAVE_FLA,
     KimiDeltaAttention,
@@ -1433,6 +1441,336 @@ class TestGatedNormRecompute(unittest.TestCase):
         with patch.object(kda, "_gated_norm", wraps=kda._gated_norm) as spy:
             self._forward_backward(kda)
         self.assertEqual(spy.call_count, 1)
+
+
+class TestLinearAttnCpModeConfig(unittest.TestCase):
+    """``linear_attn_cp_mode`` validation in ``TransformerConfig.__post_init__``.
+
+    ``headwise`` is only correct under a contiguous token layout: the head swap
+    assumes rank ``r`` owns the contiguous block ``[r*s/P, (r+1)*s/P)``, while
+    ``ContextParallelScatterOp`` dispatches on ``mode.startswith("contiguous")``
+    and its *else* branch silently hands out the dualchunk layout instead of
+    raising.  A rejected config is the only place that combination can be caught.
+    """
+
+    def test_default_is_chunkwise(self):
+        """The existing sequence-split CP path must stay the default."""
+        self.assertEqual(TransformerConfig().linear_attn_cp_mode, "chunkwise")
+
+    def test_invalid_mode_raises(self):
+        with self.assertRaises(ValueError) as caught:
+            TransformerConfig(linear_attn_cp_mode="ulysses")
+        self.assertIn("linear_attn_cp_mode", str(caught.exception))
+
+    def test_headwise_rejects_dualchunk(self):
+        with self.assertRaises(ValueError) as caught:
+            TransformerConfig(
+                linear_attn_cp_mode="headwise",
+                cp_balance_mode="dualchunk_allgather",
+            )
+        self.assertIn("contiguous", str(caught.exception))
+
+    def test_headwise_accepts_contiguous_layouts(self):
+        for balance in ("contiguous_allgather", "contiguous_a2a"):
+            with self.subTest(cp_balance_mode=balance):
+                config = TransformerConfig(
+                    linear_attn_cp_mode="headwise", cp_balance_mode=balance
+                )
+                self.assertEqual(config.linear_attn_cp_mode, "headwise")
+                self.assertEqual(config.cp_balance_mode, balance)
+
+    def test_chunkwise_still_allows_dualchunk(self):
+        """The new check must not tighten the pre-existing default path."""
+        config = TransformerConfig(cp_balance_mode="dualchunk_allgather")
+        self.assertEqual(config.cp_balance_mode, "dualchunk_allgather")
+
+
+@unittest.skipUnless(HAVE_FLA, "paddlefleet_ops fla kernels are not available")
+class TestHeadwiseCpInit(unittest.TestCase):
+    """``__init__`` under ``linear_attn_cp_mode="headwise"``.
+
+    ``get_pg_size`` returns 1 whenever ``paddle.distributed`` is not initialized,
+    so the ``cp_size > 1`` branch is unreachable on one card without patching it.
+    Worth patching: the head-divisibility guard it protects should not need a
+    4-GPU job to fire.
+    """
+
+    def _kda(self, cp_size=4, tp_size=1, mode="headwise", **overrides):
+        pg_collection = _FakePGCollection()
+        sizes = {id(pg_collection.tp): tp_size, id(pg_collection.cp): cp_size}
+        with patch.object(
+            kda_mod,
+            "get_pg_size",
+            side_effect=lambda group=None: sizes.get(id(group), 1),
+        ):
+            return _build_kda(
+                pg_collection=pg_collection,
+                config_overrides={
+                    "linear_attn_cp_mode": mode,
+                    "context_parallel_size": cp_size,
+                    "cp_balance_mode": "contiguous_allgather",
+                },
+                **overrides,
+            )
+
+    def test_headwise_enables_the_swap(self):
+        kda = self._kda()
+        self.assertEqual(kda.cp_size, 4)
+        self.assertTrue(kda.cp_head_a2a)
+
+    def test_chunkwise_leaves_the_swap_off(self):
+        """Same topology, default mode: the sequence-split path must be untouched."""
+        kda = self._kda(mode="chunkwise")
+        self.assertEqual(kda.cp_size, 4)
+        self.assertFalse(kda.cp_head_a2a)
+
+    def test_no_swap_without_cp(self):
+        """cp_size == 1 must not take the a2a path even when the mode asks for it."""
+        kda = self._kda(cp_size=1)
+        self.assertFalse(kda.cp_head_a2a)
+
+    def test_rejects_head_count_not_divisible_by_cp(self):
+        with self.assertRaises(ValueError) as caught:
+            self._kda(cp_size=8)
+        message = str(caught.exception)
+        self.assertIn("num_key_heads", message)
+        self.assertIn("cp_size(8)", message)
+
+    def test_divisibility_is_checked_on_the_tp_local_count(self):
+        """TP splits the heads first, so the *global* count is the wrong one to check.
+
+        ``num_key_heads``(4) is divisible by ``cp_size``(4), but with
+        ``tp_size``(2) each rank only holds 2 of them and the swap would hand two
+        of the four CP ranks an empty head block.
+        """
+        with self.assertRaises(ValueError) as caught:
+            self._kda(cp_size=4, tp_size=2)
+        self.assertIn("tp_size(2)", str(caught.exception))
+
+
+class TestKdaHeadA2ALayout(unittest.TestCase):
+    """The pure-layout half of ``kda_head_a2a``: head blocks and parameter slices.
+
+    These are the pieces that fail *silently*.  ``UlyssesAlltoAll`` gives rank
+    ``r`` the contiguous head block ``[r*h/P, (r+1)*h/P)``; if a parameter slice
+    disagrees, the heads get paired with the wrong ``A_log``/conv filter and the
+    numbers are simply wrong.  Every expectation below is spelled out as explicit
+    indices rather than recomputed with the helper's own reshape, so the test
+    cannot agree with a buggy implementation by construction.
+    """
+
+    CP = 4
+    KEY_HEADS = 4
+    # GVA: HV = 2 * H, so the value block has a different head count from the two
+    # key blocks and a slice that reuses the key count is visible.
+    VALUE_HEADS = 8
+    KEY_DIM = 2
+    VALUE_DIM = 3
+    CONV_WIDTH = 2
+
+    def test_head_range_tiles_the_head_axis(self):
+        blocks = [head_range(8, r, 4) for r in range(4)]
+        self.assertEqual(blocks, [(0, 2), (2, 4), (4, 6), (6, 8)])
+
+    def test_head_range_rejects_indivisible(self):
+        with self.assertRaises(ValueError) as caught:
+            head_range(6, 0, 4)
+        self.assertIn("divisible", str(caught.exception))
+
+    def test_slice_per_head_param_scalar_per_head(self):
+        """``A_log [HV]``: the ``[HV, -1]`` view degenerates to ``[HV, 1]``."""
+        param = paddle.arange(self.VALUE_HEADS, dtype="float32")
+        for rank in range(self.CP):
+            with self.subTest(rank=rank):
+                got = slice_per_head_param(
+                    param, self.VALUE_HEADS, rank, self.CP
+                )
+                want = [2 * rank, 2 * rank + 1]
+                self.assertEqual(got.numpy().tolist(), want)
+
+    def test_slice_per_head_param_flat_multi_channel(self):
+        """``dt_bias [HV * K]``: heads are the *outer* axis of the flat tensor."""
+        total = self.VALUE_HEADS * self.KEY_DIM
+        param = paddle.arange(total, dtype="float32")
+        seen = []
+        for rank in range(self.CP):
+            got = slice_per_head_param(param, self.VALUE_HEADS, rank, self.CP)
+            per_rank = total // self.CP
+            want = list(range(rank * per_rank, (rank + 1) * per_rank))
+            self.assertEqual(got.numpy().tolist(), want, f"rank {rank}")
+            seen += want
+        # Nothing dropped, nothing counted twice: the four blocks are a partition.
+        self.assertEqual(seen, list(range(total)))
+
+    def test_slice_per_head_param_rejects_non_flat(self):
+        """A ``[HV, K]`` parameter would slice its channels, not its heads."""
+        with self.assertRaises(ValueError) as caught:
+            slice_per_head_param(
+                paddle.zeros([self.VALUE_HEADS, self.KEY_DIM]),
+                self.VALUE_HEADS,
+                0,
+                self.CP,
+            )
+        self.assertIn("flat", str(caught.exception))
+
+    def _qkv_layout(self):
+        qk = self.KEY_HEADS * self.KEY_DIM
+        v = self.VALUE_HEADS * self.VALUE_DIM
+        dims = [qk, qk, v]
+        heads = [self.KEY_HEADS, self.KEY_HEADS, self.VALUE_HEADS]
+        return dims, heads
+
+    def _expected_channels(self, rank):
+        """The channel indices rank ``rank`` owns, computed block by block."""
+        dims, heads = self._qkv_layout()
+        want, offset = [], 0
+        for dim, num_heads in zip(dims, heads):
+            head_dim = dim // num_heads
+            per_rank = num_heads // self.CP
+            first = rank * per_rank
+            for head in range(first, first + per_rank):
+                start = offset + head * head_dim
+                want += list(range(start, start + head_dim))
+            offset += dim
+        return want
+
+    def test_slice_channels_by_head_conv_weight(self):
+        """Depthwise conv weight ``[sum(dims), w]``, sliced per q/k/v block."""
+        dims, heads = self._qkv_layout()
+        total = sum(dims)
+        # Row i is filled with i, so a misplaced row is unambiguous.
+        weight = (
+            paddle.arange(total, dtype="float32")
+            .reshape([total, 1])
+            .tile([1, self.CONV_WIDTH])
+        )
+        for rank in range(self.CP):
+            with self.subTest(rank=rank):
+                got = slice_channels_by_head(weight, dims, heads, rank, self.CP)
+                self.assertEqual(got.shape, [total // self.CP, self.CONV_WIDTH])
+                self.assertEqual(
+                    got[:, 0].numpy().tolist(), self._expected_channels(rank)
+                )
+
+    def test_slice_channels_by_head_conv_bias(self):
+        """Same convention for the 1-D bias -- a separate ``if`` branch in the layer."""
+        dims, heads = self._qkv_layout()
+        total = sum(dims)
+        bias = paddle.arange(total, dtype="float32")
+        seen = []
+        for rank in range(self.CP):
+            got = slice_channels_by_head(bias, dims, heads, rank, self.CP)
+            want = self._expected_channels(rank)
+            self.assertEqual(got.numpy().tolist(), want, f"rank {rank}")
+            seen += want
+        self.assertEqual(sorted(seen), list(range(total)))
+
+    def test_value_block_uses_its_own_head_count(self):
+        """The GVA case: slicing the value block with the key-head count is a bug.
+
+        With ``HV = 2 * H`` a value block sliced at the key-head count would take
+        ``H/P`` heads instead of ``HV/P``, so the returned width would be short.
+        Asserting the width per block catches it independently of the values.
+        """
+        dims, heads = self._qkv_layout()
+        got = slice_channels_by_head(
+            paddle.arange(sum(dims), dtype="float32"), dims, heads, 0, self.CP
+        )
+        expected = sum(dim // self.CP for dim in dims)
+        self.assertEqual(got.shape, [expected])
+        self.assertEqual(
+            expected,
+            2 * (self.KEY_HEADS // self.CP) * self.KEY_DIM
+            + (self.VALUE_HEADS // self.CP) * self.VALUE_DIM,
+        )
+
+
+class TestImportWithoutFlaExtension(unittest.TestCase):
+    """The layer must still import when ``paddlefleet_ops`` has no ``fla``.
+
+    That is exactly what the ``try: from paddlefleet_ops import fla`` guard at
+    the top of the module is for: it sets ``HAVE_FLA = False`` and the paddle
+    native fallbacks take over.  The head-shard all-to-all helpers are imported
+    unconditionally, above that guard, so this pins the guard down.
+
+    Run in a subprocess on purpose.  Hiding ``fla`` means re-importing the layer
+    module, and a reload inside this process would leave every name the rest of
+    this file imported from it pointing at the pre-reload objects.
+
+    Note what this does *not* test: a build with no ``paddlefleet_ops`` at all.
+    ``paddlefleet.utils`` -> ``paddlefleet.context_parallel_utils`` imports
+    ``paddlefleet_ops.flash_mask_facade`` at module scope, so that case has never
+    been importable and is not specific to this layer.
+    """
+
+    _SKIP_EXIT_CODE = 77
+
+    _PROBE = textwrap.dedent(
+        """
+        import importlib
+        import sys
+
+        _HIDDEN = "paddlefleet_ops.fla"
+
+
+        def _is_hidden(name):
+            # Note the dot: a bare startswith() would also match
+            # paddlefleet_ops.flash_mask and evict a half-initialised module.
+            return name == _HIDDEN or name.startswith(_HIDDEN + ".")
+
+
+        class _Hide:
+            def find_spec(self, fullname, path=None, target=None):
+                if _is_hidden(fullname):
+                    raise ImportError(f"no {fullname} in this build (test)")
+                return None
+
+
+        try:
+            ops = importlib.import_module("paddlefleet_ops")
+        except ImportError:
+            sys.exit(77)
+
+        # paddlefleet_ops binds its ecosystem libraries as attributes of the
+        # package, so hiding the submodule from the import system alone is not
+        # enough -- `from paddlefleet_ops import fla` would find the attribute
+        # and never consult the meta path.
+        if hasattr(ops, "fla"):
+            del ops.fla
+        for name in [n for n in sys.modules if _is_hidden(n)]:
+            del sys.modules[name]
+        sys.meta_path.insert(0, _Hide())
+
+        mod = importlib.import_module(
+            "paddlefleet.transformer.kimi_delta_attention"
+        )
+        assert mod.HAVE_FLA is False, mod.HAVE_FLA
+        assert mod.chunk_kda is None, mod.chunk_kda
+        assert mod.causal_conv1d is None, mod.causal_conv1d
+        assert mod.build_cp_context is None, mod.build_cp_context
+        assert mod.KimiDeltaAttention is not None
+        # The all-to-all helpers came in with the layer, above the guard.
+        assert "paddlefleet.transformer.kda_head_a2a" in sys.modules
+        print(f"HAVE_FLA={mod.HAVE_FLA}")
+        """
+    )
+
+    def test_layer_imports_with_have_fla_false(self):
+        proc = subprocess.run(
+            [sys.executable, "-c", self._PROBE],
+            capture_output=True,
+            text=True,
+            timeout=900,
+        )
+        if proc.returncode == self._SKIP_EXIT_CODE:
+            self.skipTest("paddlefleet_ops is not installed")
+        self.assertEqual(
+            proc.returncode,
+            0,
+            f"import failed without the fla extension\n"
+            f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}",
+        )
+        self.assertIn("HAVE_FLA=False", proc.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/transformer/test_kimi_delta_attention.py
+++ b/tests/single_card_tests/transformer/test_kimi_delta_attention.py
@@ -1451,6 +1451,10 @@ class TestLinearAttnCpModeConfig(unittest.TestCase):
     ``ContextParallelScatterOp`` dispatches on ``mode.startswith("contiguous")``
     and its *else* branch silently hands out the dualchunk layout instead of
     raising.  A rejected config is the only place that combination can be caught.
+
+    The layout check only fires for ``context_parallel_size > 1``: at cp=1 there
+    is no head swap to protect (``cp_head_a2a`` needs ``cp_size > 1``), so the
+    tests that exercise it have to ask for a CP group.
     """
 
     def test_default_is_chunkwise(self):
@@ -1467,21 +1471,33 @@ class TestLinearAttnCpModeConfig(unittest.TestCase):
             TransformerConfig(
                 linear_cp_mode="headwise",
                 cp_balance_mode="dualchunk_allgather",
+                context_parallel_size=2,
             )
         self.assertIn("contiguous", str(caught.exception))
+
+    def test_headwise_without_cp_is_unconstrained(self):
+        """cp=1 disables the swap, so it must not constrain the token layout."""
+        config = TransformerConfig(
+            linear_cp_mode="headwise", cp_balance_mode="dualchunk_allgather"
+        )
+        self.assertEqual(config.linear_cp_mode, "headwise")
 
     def test_headwise_accepts_contiguous_layouts(self):
         for balance in ("contiguous_allgather", "contiguous_a2a"):
             with self.subTest(cp_balance_mode=balance):
                 config = TransformerConfig(
-                    linear_cp_mode="headwise", cp_balance_mode=balance
+                    linear_cp_mode="headwise",
+                    cp_balance_mode=balance,
+                    context_parallel_size=2,
                 )
                 self.assertEqual(config.linear_cp_mode, "headwise")
                 self.assertEqual(config.cp_balance_mode, balance)
 
     def test_chunkwise_still_allows_dualchunk(self):
         """The new check must not tighten the pre-existing default path."""
-        config = TransformerConfig(cp_balance_mode="dualchunk_allgather")
+        config = TransformerConfig(
+            cp_balance_mode="dualchunk_allgather", context_parallel_size=2
+        )
         self.assertEqual(config.cp_balance_mode, "dualchunk_allgather")
 
 

--- a/tests/test_configs.yaml
+++ b/tests/test_configs.yaml
@@ -199,11 +199,11 @@ tests:
   - test_case: [tests/multi_card_tests/transformer/test_kimi_delta_attention_cp.py]
     products:
       - num_gpus: 4
-  # transformer: KDA linear_attn_cp_mode="headwise", bitwise core (CP=4)
+  # transformer: KDA linear_cp_mode="headwise", bitwise core (CP=4)
   - test_case: [tests/multi_card_tests/transformer/test_kda_a2a_core_bitwise.py]
     products:
       - num_gpus: 4
-  # transformer: KDA linear_attn_cp_mode="headwise", whole layer (CP=4)
+  # transformer: KDA linear_cp_mode="headwise", whole layer (CP=4)
   - test_case: [tests/multi_card_tests/transformer/test_kda_head_a2a_layer.py]
     products:
       - num_gpus: 4

--- a/tests/test_configs.yaml
+++ b/tests/test_configs.yaml
@@ -199,6 +199,14 @@ tests:
   - test_case: [tests/multi_card_tests/transformer/test_kimi_delta_attention_cp.py]
     products:
       - num_gpus: 4
+  # transformer: KDA linear_attn_cp_mode="headwise", bitwise core (CP=4)
+  - test_case: [tests/multi_card_tests/transformer/test_kda_a2a_core_bitwise.py]
+    products:
+      - num_gpus: 4
+  # transformer: KDA linear_attn_cp_mode="headwise", whole layer (CP=4)
+  - test_case: [tests/multi_card_tests/transformer/test_kda_head_a2a_layer.py]
+    products:
+      - num_gpus: 4
   # transformer: latent MQA (+DSA) context-parallel core attention (CP=2)
   - test_case: [tests/multi_card_tests/transformer/test_mqa_dsa_cp.py]
     products:


### PR DESCRIPTION
### PR Category

Distributed Strategy

### PR Types

New features

### Description

Adds `linear_attn_cp_mode` to `TransformerConfig` (default `"chunkwise"`, i.e. today's behaviour) with a new `"headwise"` value that parallelises `KimiDeltaAttention` over the **head** axis instead of the sequence axis.

#### Why

The existing sequence-split CP cannot be bitwise against a single card: its conv halo backward is a partial sum, and a rank whose local varlen segments do not line up with the global 64-token chunk grid re-segments the recurrence.

#### How

The projections stay sequence-split, but immediately **before** the short conv each rank trades its `[b, s/cp, h, d]` slice for `[b, s, h/cp, d]` via `UlyssesAlltoAll`. The conv and the recurrence therefore see the *whole* sequence and run with plain single-card semantics — no halo exchange, no cross-rank state relay, and `cu_seqlens` stays **global** (`build_cp_context` is skipped entirely). The output is swapped back before `out_norm`, so `_gated_norm` / `out_norm` / `g_proj` / `out_proj` are untouched.

Per-head parameters (`A_log`, `dt_bias`, conv weight/bias) keep their full shape and are sliced inside the graph. The slice is differentiable, so each rank's gradient comes back full-shape and exactly `0.0` outside its own heads; the trainer-side sharding reduction is then `x + 0 == x`. `sharded_state_dict` needs no change, and the layer deliberately does **not** reduce anything itself — the sharding group already contains the CP group, so a layer-local `all_reduce` would double-count.

New files:

- `src/paddlefleet/transformer/kda_head_a2a.py` — the axis-swap and per-head slicing helpers. Kept separate from the layer because the bitwise test drives the KDA core directly, below the layer, and must use *exactly* the layer's slicing convention; a second copy in the test would make the test agree with itself instead of with the product.

Constraints, both enforced:

- `(num_key_heads // tp) % cp == 0` and `(num_value_heads // tp) % cp == 0` — raised in `__init__`, since the swap is a fixed-size `alltoall_single`.
- `cp_balance_mode` must be a contiguous layout — rejected in config validation, because the swap assumes rank `r` owns the token block `[r*s/cp, (r+1)*s/cp)`; under the dualchunk layout the gathered sequence would be permuted and the order-dependent recurrence would silently compute the wrong thing.

#### Accuracy (measured, cp=4)

| quantity | result |
|---|---|
| forward output, `grad_x` | bitwise (`max\|diff\| == 0`) |
| `dA_log`, conv weight/bias grads (CP-summed) | bitwise |
| `ddt_bias` (CP-summed) | `6.8e-08` |
| dense projection `dW` | `≤ 3.2e-07` |

Only `dW = xᵀ·dy` reduces over the token axis, which is the ~1e-7 floor **any** CP scheme has — not specific to this one.

#### Tests

- `tests/multi_card_tests/transformer/test_kda_a2a_core_bitwise.py` (4 GPUs) — `causal_conv1d` + `chunk_kda` only, no projections, real NCCL, real per-rank parameter slices, real global `cu_seqlens`; asserts `max|diff| == 0`. One tensor (`ddt_bias` on the non-production `gate_lower_bound=None` path) is demoted to a rel-L2 gate **plus** the structural assertion that every mismatching element falls inside one rank's head block: the intra-rank reduction's row width changes with the head count (`HV*K → HV/P*K`), which is data-dependent and reproduces with a single-process head split too.
- `tests/multi_card_tests/transformer/test_kda_head_a2a_layer.py` (4 GPUs) — the whole layer through the real fleet topology and the real config plumbing, with GVA (`HV = 2*H`) and `conv_bias=True` so the value-head and bias branches are actually exercised. Every weight gradient is asserted as a **pair**: the local partial must *differ* from the reference and only the CP sum may match it, so a layer that ignored the head shard and computed the full gradient on every rank cannot pass. Also asserts the output does *not* match the neighbour's shard, and that `build_cp_context` is never reached.
- single-card additions in `tests/single_card_tests/transformer/test_kimi_delta_attention.py` — config validation, the `__init__` divisibility guard (checked against the **TP-local** head count), and the layout helpers verified against independently computed indices rather than by re-running the helper's own reshape.

Two multi-card files rather than one on purpose: `in_proj`/`out_proj` have different GEMM `M` on the two arms (`s_local` vs `s_full`), so cuBLAS may pick a different algorithm and the layer level can only ever be a tolerance check. Mixing them would contaminate the bitwise assertions and lose the "the core itself is exact" signal.

Both new files are registered in `tests/test_configs.yaml` at `num_gpus: 4`.

#### Backward compatibility

None. `linear_attn_cp_mode` defaults to `"chunkwise"`, and every new branch is behind `self.cp_head_a2a` (`cp_size > 1 and mode == "headwise"`).
