### PR TITLE
[BlockAttnRes] Fix the fused attnres backward with frozen inputs

### DIFF
--- a/src/paddlefleet/transformer/block_attn_res.py
+++ b/src/paddlefleet/transformer/block_attn_res.py
@@ -404,13 +404,16 @@ class BlockAttnRes(FleetLayer):
 
         # Fused Triton kernel (FLA fused_attnres) has highest priority:
         # single kernel for RMSNorm + projection + softmax + weighted sum.
-        self._use_fused = (
-            HAVE_FUSED_ATTNRES
-            and self._use_pylayer
+        # Split out from _use_fused so the two cannot disagree: the warning
+        # below must fire only when the extension is the one missing piece, not
+        # when this instance was never eligible (LayerNorm, deterministic mode).
+        fused_eligible = (
+            self._use_pylayer
             and getattr(config, "attn_res_fusion", True)
             and not getattr(config, "deterministic_mode", False)
         )
-        if getattr(config, "attn_res_fusion", True) and not HAVE_FUSED_ATTNRES:
+        self._use_fused = HAVE_FUSED_ATTNRES and fused_eligible
+        if fused_eligible and not HAVE_FUSED_ATTNRES:
             _warn_fused_attnres_unavailable_once()
 
     def forward(self, partial_block: Tensor, blocks: list[Tensor]) -> Tensor:

--- a/src/paddlefleet/transformer/block_attn_res.py
+++ b/src/paddlefleet/transformer/block_attn_res.py
@@ -45,6 +45,8 @@ from paddlefleet.transformer.layer import FleetLayer
 
 from .paddle_norm import RMSNorm, get_norm_extra_args
 
+logger = logging.getLogger(__name__)
+
 try:
     from paddle.distributed.fleet.utils.sequence_parallel_utils import (
         mark_as_sequence_parallel_parameter,
@@ -64,9 +66,37 @@ try:
     )
 
     HAVE_FUSED_ATTNRES = True
-except (ImportError, AttributeError):
+    _FUSED_ATTNRES_IMPORT_ERROR = None
+except (ImportError, AttributeError) as exc:
     _build_ptr_table = fused_attnres_fwd = fused_attnres_bwd = None
     HAVE_FUSED_ATTNRES = False
+    _FUSED_ATTNRES_IMPORT_ERROR = f"{type(exc).__name__}: {exc}"
+
+_fused_attnres_fallback_warned = False
+
+
+def _warn_fused_attnres_unavailable_once():
+    """Warn once per process that the fused kernel was asked for but is missing.
+
+    The fallback to the PyLayer path is silent and is a large perf difference,
+    so a run configured for the fused kernel that never got it would otherwise
+    leave no trace at all. Rank 0 only, or the line shows up once per card.
+    """
+    global _fused_attnres_fallback_warned
+    if _fused_attnres_fallback_warned:
+        return
+    _fused_attnres_fallback_warned = True
+    try:
+        if paddle.distributed.get_rank() != 0:
+            return
+    except Exception:
+        pass
+    logger.warning(
+        "attn_res_fusion is enabled but the FLA fused attnres kernel could "
+        "not be imported (%s); BlockAttnRes falls back to the unfused path "
+        "and timings are not representative of the fused implementation.",
+        _FUSED_ATTNRES_IMPORT_ERROR,
+    )
 
 
 @contextlib.contextmanager
@@ -255,6 +285,14 @@ class FusedAttnResTritonFunc(paddle.autograd.PyLayer):
     @staticmethod
     def forward(ctx, proj_weight, norm_weight, norm_eps, *residuals):
         D = residuals[0].shape[-1]
+        # Paddle requires backward to return None at every forward *Tensor*
+        # position whose stop_gradient is True, or py_layer_node.cc:213 raises
+        # "backward function should return None at N position, because it's
+        # forward Tensor's stopgradient is true". norm_eps is a float and does
+        # not occupy a position. Mirrors BlockAttnResFunc.backward above.
+        ctx.needs_grad = [
+            not t.stop_gradient for t in (proj_weight, norm_weight, *residuals)
+        ]
         flat_residuals = tuple(
             r.reshape([-1, D]).contiguous() for r in residuals
         )
@@ -314,7 +352,10 @@ class FusedAttnResTritonFunc(paddle.autograd.PyLayer):
         # Return order: d_proj_weight, d_norm_weight, *d_residuals
         # (norm_eps is non-tensor, no gradient)
         d_residuals = [dv.reshape(ctx.output_shape) for dv in dvs]
-        return (dq, dw, *d_residuals)
+        raw_grads = (dq, dw, *d_residuals)
+        return tuple(
+            g if need else None for need, g in zip(ctx.needs_grad, raw_grads)
+        )
 
 
 class BlockAttnRes(FleetLayer):
@@ -369,6 +410,8 @@ class BlockAttnRes(FleetLayer):
             and getattr(config, "attn_res_fusion", True)
             and not getattr(config, "deterministic_mode", False)
         )
+        if getattr(config, "attn_res_fusion", True) and not HAVE_FUSED_ATTNRES:
+            _warn_fused_attnres_unavailable_once()
 
     def forward(self, partial_block: Tensor, blocks: list[Tensor]) -> Tensor:
         """Compute Block Attention Residual.

--- a/src/paddlefleet/transformer/block_attn_res.py
+++ b/src/paddlefleet/transformer/block_attn_res.py
@@ -87,10 +87,19 @@ def _warn_fused_attnres_unavailable_once():
         return
     _fused_attnres_fallback_warned = True
     try:
-        if paddle.distributed.get_rank() != 0:
-            return
-    except Exception:
-        pass
+        rank = paddle.distributed.get_rank()
+    except Exception as exc:
+        # Only reads the launcher env vars, so this is a broken env, not a
+        # collective fault. Report it: the line below now prints on every card.
+        logger.warning(
+            "could not read the distributed rank (%s: %s), so the fused "
+            "attnres warning below is not filtered down to rank 0.",
+            type(exc).__name__,
+            exc,
+        )
+        rank = 0
+    if rank != 0:
+        return
     logger.warning(
         "attn_res_fusion is enabled but the FLA fused attnres kernel could "
         "not be imported (%s); BlockAttnRes falls back to the unfused path "

--- a/tests/single_card_tests/model/test_fused_block_attn_res.py
+++ b/tests/single_card_tests/model/test_fused_block_attn_res.py
@@ -23,15 +23,21 @@ path covered in that case.
 """
 
 import unittest
+from unittest import mock
 
 import paddle
 
 from paddlefleet.transformer.block_attn_res import (
     HAVE_FUSED_ATTNRES,
+    BlockAttnRes,
     BlockAttnResFunc,
+    BlockAttnResSublayersSpec,
     FusedAttnResTritonFunc,
     _block_attn_res_rmsnorm,
 )
+from paddlefleet.transformer.identity_op import IdentityOp
+from paddlefleet.transformer.paddle_norm import RMSNorm
+from paddlefleet.transformer.transformer_config import TransformerConfig
 
 # The FLA extension is optional in production (block_attn_res.py guards its
 # import and falls back), so the tests must not fail at collection time when it
@@ -337,6 +343,93 @@ class TestFusedAttnResPrecision(unittest.TestCase):
             f"norm_weight grad mismatch: {grad_norm_diff:.2e}",
         )
 
+    def test_backward_with_frozen_inputs(self):
+        """Frozen forward inputs must come back as None, not as a gradient.
+
+        Paddle requires a PyLayer's backward to return None at every forward
+        Tensor position whose stop_gradient is True; returning a real gradient
+        raises "backward function should return None at N position, because
+        it's forward Tensor's stopgradient is true" from py_layer_node.cc. Every
+        other fused case here marks all inputs trainable, so dropping
+        FusedAttnResTritonFunc's stop_gradient filtering would leave them green
+        while any frozen parameter blew up at runtime.
+
+        Freezing is applied to proj_weight, norm_weight and one completed block
+        at once, which is also the layout a partially frozen expert produces.
+        The surviving inputs are checked against the unfused reference so a
+        filter that returned None too eagerly fails too.
+        """
+        batch_seq, hidden_size, num_blocks = 4, 256, 3
+        norm_eps = 1e-6
+        frozen_block = 1
+
+        def build():
+            paddle.seed(self.seed)
+            blocks = [
+                paddle.randn([batch_seq, hidden_size], dtype="bfloat16")
+                for _ in range(num_blocks)
+            ]
+            partial = paddle.randn([batch_seq, hidden_size], dtype="bfloat16")
+            proj = paddle.randn([1, hidden_size], dtype="bfloat16")
+            norm_w = (
+                paddle.ones([hidden_size], dtype="bfloat16")
+                + paddle.randn([hidden_size], dtype="bfloat16") * 0.1
+            )
+            return blocks, partial, proj, norm_w
+
+        # Reference: everything trainable, unfused eager math.
+        blocks_ref, partial_ref, proj_ref, norm_ref = build()
+        for t in [*blocks_ref, partial_ref, proj_ref, norm_ref]:
+            t.stop_gradient = False
+        _block_attn_res_rmsnorm(
+            partial_ref, blocks_ref, proj_ref, norm_ref, norm_eps
+        ).astype("float32").sum().backward()
+
+        # Fused: proj_weight, norm_weight and blocks[frozen_block] are frozen.
+        blocks, partial, proj, norm_w = build()
+        partial.stop_gradient = False
+        for i, block in enumerate(blocks):
+            block.stop_gradient = i == frozen_block
+        proj.stop_gradient = True
+        norm_w.stop_gradient = True
+
+        # Without the stop_gradient filtering this call is what raises.
+        FusedAttnResTritonFunc.apply(
+            proj, norm_w, norm_eps, *blocks, partial
+        ).astype("float32").sum().backward()
+
+        self.assertIsNone(proj.grad, "frozen proj_weight must not get a grad")
+        self.assertIsNone(norm_w.grad, "frozen norm_weight must not get a grad")
+        self.assertIsNone(
+            blocks[frozen_block].grad,
+            f"frozen residual[{frozen_block}] must not get a grad",
+        )
+
+        # The trainable inputs still have to carry the same gradients.
+        atol = rtol = 5e-2
+        survivors = [
+            (f"residual[{i}]", blocks[i], blocks_ref[i])
+            for i in range(num_blocks)
+            if i != frozen_block
+        ] + [("partial_block", partial, partial_ref)]
+        for name, got, expected in survivors:
+            self.assertIsNotNone(got.grad, f"{name} lost its gradient")
+            diff = (
+                (got.grad.astype("float32") - expected.grad.astype("float32"))
+                .abs()
+                .max()
+                .item()
+            )
+            self.assertTrue(
+                paddle.allclose(
+                    got.grad.astype("float32"),
+                    expected.grad.astype("float32"),
+                    atol=atol,
+                    rtol=rtol,
+                ).item(),
+                f"{name} grad mismatch with frozen peers: {diff:.2e}",
+            )
+
 
 class TestBlockAttnResFallback(unittest.TestCase):
     """Cover the extension-free fallback path.
@@ -473,6 +566,55 @@ class TestBlockAttnResFallback(unittest.TestCase):
             self.assertTrue(all(h is not None for h in handles))
         else:
             self.assertTrue(all(h is None for h in handles))
+
+    def test_fallback_warning_only_when_fused_was_eligible(self):
+        """The "falls back" warning must track real fused eligibility.
+
+        `_use_fused` needs four things: the extension, RMSNorm, the
+        `attn_res_fusion` flag, and `deterministic_mode` off. A warning keyed on
+        only the first two would fire for a LayerNorm or deterministic-mode
+        layer that was never going to use the fused kernel, which misreads as a
+        missing extension when diagnosing performance.
+        """
+        from paddlefleet.transformer import block_attn_res
+
+        if HAVE_FUSED_ATTNRES:
+            self.skipTest("the warning only exists when the extension is gone")
+
+        def build(norm, **config_kwargs):
+            # Warning is once-per-process; reset so each case is observable.
+            block_attn_res._fused_attnres_fallback_warned = False
+            config = TransformerConfig(
+                hidden_size=16,
+                num_hidden_layers=1,
+                num_attention_heads=2,
+                **config_kwargs,
+            )
+            with mock.patch.object(block_attn_res.logger, "warning") as warning:
+                layer = BlockAttnRes(
+                    config, BlockAttnResSublayersSpec(norm=norm)
+                )
+            return layer, warning.call_count
+
+        eligible, warned = build(RMSNorm)
+        self.assertFalse(eligible._use_fused)
+        self.assertEqual(
+            warned, 1, "an eligible layer must report the missing extension"
+        )
+
+        for label, norm, kwargs in (
+            ("non-RMSNorm", IdentityOp, {}),
+            ("deterministic_mode", RMSNorm, {"deterministic_mode": True}),
+            ("attn_res_fusion off", RMSNorm, {"attn_res_fusion": False}),
+        ):
+            with self.subTest(ineligible=label):
+                layer, warned = build(norm, **kwargs)
+                self.assertFalse(layer._use_fused)
+                self.assertEqual(
+                    warned,
+                    0,
+                    f"{label} was never fused-eligible, so it must stay quiet",
+                )
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/model/test_fused_block_attn_res.py
+++ b/tests/single_card_tests/model/test_fused_block_attn_res.py
@@ -22,6 +22,9 @@ either is missing; `TestBlockAttnResFallback` keeps the extension-free fallback
 path covered in that case.
 """
 
+import builtins
+import importlib.util
+import sys
 import unittest
 from unittest import mock
 
@@ -29,9 +32,7 @@ import paddle
 
 from paddlefleet.transformer.block_attn_res import (
     HAVE_FUSED_ATTNRES,
-    BlockAttnRes,
     BlockAttnResFunc,
-    BlockAttnResSublayersSpec,
     FusedAttnResTritonFunc,
     _block_attn_res_rmsnorm,
 )
@@ -567,8 +568,101 @@ class TestBlockAttnResFallback(unittest.TestCase):
         else:
             self.assertTrue(all(h is None for h in handles))
 
-    def test_fallback_warning_only_when_fused_was_eligible(self):
-        """The "falls back" warning must track real fused eligibility.
+
+def _import_block_attn_res_without_extension():
+    """Execute a private copy of block_attn_res with the FLA import blocked.
+
+    Exercises the `except (ImportError, AttributeError)` arm of the optional
+    import, which is dead code wherever the extension is installed. The copy
+    lives under a private module name that is dropped again afterwards, so the
+    real `paddlefleet.transformer.block_attn_res` object and every class
+    identity other tests compare against stay untouched -- a plain
+    `importlib.reload` would swap `BlockAttnRes` out from under them.
+    """
+    from paddlefleet.transformer import block_attn_res
+
+    blocked = "paddlefleet_ops.fla.ops.attnres.fused"
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == blocked:
+            raise ImportError(f"blocked by {__name__}: {name}")
+        return real_import(name, *args, **kwargs)
+
+    name = "paddlefleet.transformer._block_attn_res_no_fla"
+    spec = importlib.util.spec_from_file_location(name, block_attn_res.__file__)
+    module = importlib.util.module_from_spec(spec)
+    # `@dataclass` resolves string annotations through sys.modules, so the copy
+    # has to be registered while its body runs.  patch.dict unregisters it
+    # again, keeping the private name out of the rest of the process.
+    with (
+        mock.patch.dict(sys.modules, {name: module}),
+        mock.patch.object(builtins, "__import__", guarded_import),
+    ):
+        spec.loader.exec_module(module)
+    return module
+
+
+class TestFusedAttnResUnavailable(unittest.TestCase):
+    """The missing-extension gating and its once-per-process warning.
+
+    `HAVE_FUSED_ATTNRES` is patched instead of skipped: on a machine with the
+    extension these lines are otherwise unreachable, and on one without it the
+    fused tests are unreachable, so a skip in either direction means the branch
+    is never covered by the same job that covers the fused path.
+    """
+
+    def setUp(self):
+        from paddlefleet.transformer import block_attn_res
+
+        self.mod = block_attn_res
+        paddle.set_device("gpu:0" if _HAVE_GPU else "cpu")
+        # The warning is once-per-process state owned by the real module;
+        # restore it so test order cannot change what a later test observes.
+        self.addCleanup(
+            setattr,
+            block_attn_res,
+            "_fused_attnres_fallback_warned",
+            block_attn_res._fused_attnres_fallback_warned,
+        )
+
+    def _build(self, module=None, norm=RMSNorm, have_fused=False, **kwargs):
+        """Build a BlockAttnRes and return it with the captured warning mock."""
+        module = module or self.mod
+        module._fused_attnres_fallback_warned = False
+        config = TransformerConfig(
+            hidden_size=16,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            **kwargs,
+        )
+        with (
+            mock.patch.object(module, "HAVE_FUSED_ATTNRES", have_fused),
+            mock.patch.object(module.logger, "warning") as warning,
+        ):
+            layer = module.BlockAttnRes(
+                config, module.BlockAttnResSublayersSpec(norm=norm)
+            )
+        return layer, warning
+
+    def test_eligible_layer_reports_the_import_failure(self):
+        """An eligible layer must warn, and name why the import failed.
+
+        The recorded import error is the only clue the operator gets, so it has
+        to reach the log rather than a bare "not available".
+        """
+        reason = "ImportError: sentinel from test"
+        with mock.patch.object(self.mod, "_FUSED_ATTNRES_IMPORT_ERROR", reason):
+            layer, warning = self._build()
+
+        self.assertFalse(layer._use_fused)
+        self.assertEqual(
+            warning.call_count, 1, "the missing extension must be reported"
+        )
+        self.assertIn(reason, warning.call_args.args)
+
+    def test_ineligible_layers_stay_quiet(self):
+        """The warning tracks real eligibility, not just the missing extension.
 
         `_use_fused` needs four things: the extension, RMSNorm, the
         `attn_res_fusion` flag, and `deterministic_mode` off. A warning keyed on
@@ -576,45 +670,87 @@ class TestBlockAttnResFallback(unittest.TestCase):
         layer that was never going to use the fused kernel, which misreads as a
         missing extension when diagnosing performance.
         """
-        from paddlefleet.transformer import block_attn_res
-
-        if HAVE_FUSED_ATTNRES:
-            self.skipTest("the warning only exists when the extension is gone")
-
-        def build(norm, **config_kwargs):
-            # Warning is once-per-process; reset so each case is observable.
-            block_attn_res._fused_attnres_fallback_warned = False
-            config = TransformerConfig(
-                hidden_size=16,
-                num_hidden_layers=1,
-                num_attention_heads=2,
-                **config_kwargs,
-            )
-            with mock.patch.object(block_attn_res.logger, "warning") as warning:
-                layer = BlockAttnRes(
-                    config, BlockAttnResSublayersSpec(norm=norm)
-                )
-            return layer, warning.call_count
-
-        eligible, warned = build(RMSNorm)
-        self.assertFalse(eligible._use_fused)
-        self.assertEqual(
-            warned, 1, "an eligible layer must report the missing extension"
-        )
-
         for label, norm, kwargs in (
             ("non-RMSNorm", IdentityOp, {}),
             ("deterministic_mode", RMSNorm, {"deterministic_mode": True}),
             ("attn_res_fusion off", RMSNorm, {"attn_res_fusion": False}),
         ):
             with self.subTest(ineligible=label):
-                layer, warned = build(norm, **kwargs)
+                layer, warning = self._build(norm=norm, **kwargs)
                 self.assertFalse(layer._use_fused)
                 self.assertEqual(
-                    warned,
+                    warning.call_count,
                     0,
                     f"{label} was never fused-eligible, so it must stay quiet",
                 )
+
+    def test_eligible_layer_with_extension_uses_fused_and_stays_quiet(self):
+        """The other side of the gate: present extension, no warning."""
+        layer, warning = self._build(have_fused=True)
+
+        self.assertTrue(layer._use_fused)
+        self.assertEqual(warning.call_count, 0)
+
+    def test_warning_is_emitted_once_per_process(self):
+        """Every layer of a deep model hits this; only the first may log."""
+        self.mod._fused_attnres_fallback_warned = False
+        with mock.patch.object(self.mod.logger, "warning") as warning:
+            self.mod._warn_fused_attnres_unavailable_once()
+            self.mod._warn_fused_attnres_unavailable_once()
+
+        self.assertEqual(warning.call_count, 1)
+
+    def test_warning_is_rank_zero_only(self):
+        """Otherwise the line is repeated once per card on every job."""
+        self.mod._fused_attnres_fallback_warned = False
+        with (
+            mock.patch.object(paddle.distributed, "get_rank", return_value=1),
+            mock.patch.object(self.mod.logger, "warning") as warning,
+        ):
+            self.mod._warn_fused_attnres_unavailable_once()
+
+        self.assertEqual(warning.call_count, 0)
+
+    def test_warning_survives_an_unavailable_rank(self):
+        """`get_rank()` raises before `fleet.init`, and the warning still matters.
+
+        BlockAttnRes is built while the model is being constructed, which for
+        some entrypoints happens before the collective is up. Letting that
+        exception escape would turn a diagnostic into a crash.
+        """
+        self.mod._fused_attnres_fallback_warned = False
+        with (
+            mock.patch.object(
+                paddle.distributed,
+                "get_rank",
+                side_effect=RuntimeError("collective not initialized"),
+            ),
+            mock.patch.object(self.mod.logger, "warning") as warning,
+        ):
+            self.mod._warn_fused_attnres_unavailable_once()
+
+        self.assertEqual(warning.call_count, 1)
+
+    def test_module_imports_without_the_extension(self):
+        """Importing with no FLA extension must degrade, not raise."""
+        module = _import_block_attn_res_without_extension()
+
+        self.assertFalse(module.HAVE_FUSED_ATTNRES)
+        self.assertIsNone(module.fused_attnres_fwd)
+        self.assertIsNone(module.fused_attnres_bwd)
+        self.assertIsNone(module._build_ptr_table)
+        self.assertIn("ImportError", module._FUSED_ATTNRES_IMPORT_ERROR)
+
+        # And an eligible layer built against it reports that same reason,
+        # without any patching of the availability flag.
+        layer, warning = self._build(
+            module=module, have_fused=module.HAVE_FUSED_ATTNRES
+        )
+        self.assertFalse(layer._use_fused)
+        self.assertEqual(warning.call_count, 1)
+        self.assertIn(
+            module._FUSED_ATTNRES_IMPORT_ERROR, warning.call_args.args
+        )
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/model/test_fused_block_attn_res.py
+++ b/tests/single_card_tests/model/test_fused_block_attn_res.py
@@ -572,12 +572,9 @@ class TestBlockAttnResFallback(unittest.TestCase):
 def _import_block_attn_res_without_extension():
     """Execute a private copy of block_attn_res with the FLA import blocked.
 
-    Exercises the `except (ImportError, AttributeError)` arm of the optional
-    import, which is dead code wherever the extension is installed. The copy
-    lives under a private module name that is dropped again afterwards, so the
-    real `paddlefleet.transformer.block_attn_res` object and every class
-    identity other tests compare against stay untouched -- a plain
-    `importlib.reload` would swap `BlockAttnRes` out from under them.
+    Covers the `except (ImportError, AttributeError)` import arm, which is dead
+    code wherever the extension is installed. A private copy is used because
+    `importlib.reload` would swap `BlockAttnRes` out from under other tests.
     """
     from paddlefleet.transformer import block_attn_res
 
@@ -592,9 +589,8 @@ def _import_block_attn_res_without_extension():
     name = "paddlefleet.transformer._block_attn_res_no_fla"
     spec = importlib.util.spec_from_file_location(name, block_attn_res.__file__)
     module = importlib.util.module_from_spec(spec)
-    # `@dataclass` resolves string annotations through sys.modules, so the copy
-    # has to be registered while its body runs.  patch.dict unregisters it
-    # again, keeping the private name out of the rest of the process.
+    # @dataclass resolves string annotations through sys.modules, so the copy
+    # must be registered while its body runs; patch.dict drops it again.
     with (
         mock.patch.dict(sys.modules, {name: module}),
         mock.patch.object(builtins, "__import__", guarded_import),
@@ -606,10 +602,9 @@ def _import_block_attn_res_without_extension():
 class TestFusedAttnResUnavailable(unittest.TestCase):
     """The missing-extension gating and its once-per-process warning.
 
-    `HAVE_FUSED_ATTNRES` is patched instead of skipped: on a machine with the
-    extension these lines are otherwise unreachable, and on one without it the
-    fused tests are unreachable, so a skip in either direction means the branch
-    is never covered by the same job that covers the fused path.
+    `HAVE_FUSED_ATTNRES` is patched rather than skipped on: these lines are
+    unreachable where the extension exists and the fused tests are unreachable
+    where it does not, so skipping either way leaves the path never covered.
     """
 
     def setUp(self):
@@ -617,8 +612,7 @@ class TestFusedAttnResUnavailable(unittest.TestCase):
 
         self.mod = block_attn_res
         paddle.set_device("gpu:0" if _HAVE_GPU else "cpu")
-        # The warning is once-per-process state owned by the real module;
-        # restore it so test order cannot change what a later test observes.
+        # Once-per-process state; restore it so test order cannot matter.
         self.addCleanup(
             setattr,
             block_attn_res,
@@ -646,11 +640,7 @@ class TestFusedAttnResUnavailable(unittest.TestCase):
         return layer, warning
 
     def test_eligible_layer_reports_the_import_failure(self):
-        """An eligible layer must warn, and name why the import failed.
-
-        The recorded import error is the only clue the operator gets, so it has
-        to reach the log rather than a bare "not available".
-        """
+        """The recorded import error must reach the log, not a bare message."""
         reason = "ImportError: sentinel from test"
         with mock.patch.object(self.mod, "_FUSED_ATTNRES_IMPORT_ERROR", reason):
             layer, warning = self._build()
@@ -664,11 +654,8 @@ class TestFusedAttnResUnavailable(unittest.TestCase):
     def test_ineligible_layers_stay_quiet(self):
         """The warning tracks real eligibility, not just the missing extension.
 
-        `_use_fused` needs four things: the extension, RMSNorm, the
-        `attn_res_fusion` flag, and `deterministic_mode` off. A warning keyed on
-        only the first two would fire for a LayerNorm or deterministic-mode
-        layer that was never going to use the fused kernel, which misreads as a
-        missing extension when diagnosing performance.
+        A LayerNorm or deterministic-mode layer was never going to use the fused
+        kernel, so warning about it misreads as a missing extension.
         """
         for label, norm, kwargs in (
             ("non-RMSNorm", IdentityOp, {}),
@@ -712,24 +699,23 @@ class TestFusedAttnResUnavailable(unittest.TestCase):
         self.assertEqual(warning.call_count, 0)
 
     def test_warning_survives_an_unavailable_rank(self):
-        """`get_rank()` raises before `fleet.init`, and the warning still matters.
-
-        BlockAttnRes is built while the model is being constructed, which for
-        some entrypoints happens before the collective is up. Letting that
-        exception escape would turn a diagnostic into a crash.
-        """
+        """A failed rank lookup must be reported, not swallowed, and not crash."""
         self.mod._fused_attnres_fallback_warned = False
         with (
             mock.patch.object(
                 paddle.distributed,
                 "get_rank",
-                side_effect=RuntimeError("collective not initialized"),
+                side_effect=ValueError("bad PADDLE_TRAINER_ID"),
             ),
             mock.patch.object(self.mod.logger, "warning") as warning,
         ):
             self.mod._warn_fused_attnres_unavailable_once()
 
-        self.assertEqual(warning.call_count, 1)
+        self.assertEqual(warning.call_count, 2)
+        self.assertIn(
+            "bad PADDLE_TRAINER_ID",
+            [str(a) for call in warning.call_args_list for a in call.args],
+        )
 
     def test_module_imports_without_the_extension(self):
         """Importing with no FLA extension must degrade, not raise."""


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description

**问题**

`FusedAttnResTritonFunc.backward` 无条件返回 `(dq, dw, *d_residuals)`。Paddle 要求 PyLayer 在 `stop_gradient=True` 的 forward Tensor 位置返回 `None`，否则 `py_layer_node.cc:213` 抛 "backward function should return None at N position"。所以只要 `proj_weight`、`norm_weight` 或任一 residual 被冻结，开启 `attn_res_fusion` 训练就会在反向报错。上游 `BlockAttnResFunc` 已有这层过滤，融合路径漏了。

另外 `_use_fused` 把"扩展是否存在"和"本实例是否有资格"混在一个表达式里，扩展缺失时静默降级，性能差距很大却无日志痕迹。

**修改**

1. forward 记录 `ctx.needs_grad`（`norm_eps` 是 float 不占位），backward 按位置把冻结位置换成 `None`
2. 拆出 `fused_eligible`，仅当扩展缺失是唯一缺失项时告警，避免 LayerNorm / `deterministic_mode` 被误报
3. 新增 `_warn_fused_attnres_unavailable_once()`：进程内一次、仅 rank 0，带上真实的 import 失败原因

**影响范围**

仅 `src/paddlefleet/transformer/block_attn_res.py`，只影响 `attn_res_fusion=True` 且 FLA 扩展可用的融合路径。全部输入可训练时 backward 返回值逐位不变。无接口和默认值变更。

**验证**

新增 `tests/single_card_tests/model/test_fused_block_attn_res.py`，18 个用例：

- 融合 kernel 前反向与 eager `_block_attn_res_rmsnorm`、FLA `naive_attnres` 三方对齐，含 `(2, 7168)/8 blocks` 的 Kimi-K3 形状，bf16 下 forward `1e-2`、backward `5e-2`
- `test_backward_with_frozen_inputs` 同时冻结 `proj_weight`、`norm_weight` 和一个 completed block，修复前直接抛异常；同时校验未冻结输入梯度仍与 eager 一致，防止过滤过度
- 降级路径：`BlockAttnResFunc` 重算梯度与 autograd 对比
- 扩展缺失的门控与告警：patch `HAVE_FUSED_ATTNRES` 而非 skip，使装了扩展的机器也能覆盖；另用私有模块副本屏蔽 `paddlefleet_ops.fla.ops.attnres.fused`，覆盖 import 的 except 分支。

### 是否引起精度变化

否
