### PR TITLE
[release/0.4][config_adapter] Add --scale-seq-length, freeze parallelism by default

### DIFF
--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -1,28 +1,35 @@
 # config_adapter
 
 把面向大集群的训练 YAML 自动改写成能在**更小机器规模**上跑起来的配置：重算
-sharding 与 batch，必要时缩小 EP/PP 并联动改写 `model_config.json`，并保证改写
-后的配置满足 Fleet 的通信组约束。
+sharding 与 batch，仅 `--test-accuracy` 模式必要时缩小 EP/PP 并联动改写
+`model_config.json`，并保证改写后的配置满足 Fleet 的通信组约束。
 
 `--test-performance` 与 `--test-accuracy` 是**两个正交的、可选的**测试维度，各管
 一件事，可以单独给、同时给、也可以都不给：
 
 | 组合 | 并行度 | acc | batch 策略 | 精度开关 |
 |---|---|---|---|---|
-| 都不给 | 需要时缩小 EP/PP | 不变 | `scale_batch` | 不注入 |
+| 都不给 | 全部冻结 | 不变 | `scale_batch` | 不注入 |
 | `--test-performance` | 全部冻结 | 冻结 | `scale_batch` | 不注入 |
 | `--test-accuracy` | 需要时缩小 EP/PP | 等比放大 | `scale_accumulation` | 注入 |
 | 两个都给 | 全部冻结 | 冻结 | `scale_batch` | 注入 |
 
-- `--test-performance` 负责「测出来的单步耗时可比」：冻结 TP/PP/EP/CP/SEP 与
-  `gradient_accumulation_steps`，只动 sharding 和 `global_batch_size`。
-- `--test-accuracy` 负责「结果可复现、不 aadiff」：注入确定性开关；只要没同时给
-  `--test-performance`，就用放大 acc 的方式保持等效 batch。
+- 默认与 `--test-performance` 都**不缩规模**：缩小 EP/PP 会等比改写专家数 /
+  层数，属于模型结构变更，不允许默默发生；目标机器规模必须与源并行度兼容，
+  否则报错并列出合法节点数。batch 用 `scale_batch`：`global_batch_size`
+  随数据并行路数等比缩小，`gradient_accumulation_steps` 保持不变，单卡单步
+  计算量与源一致（`--test-performance` 据此保证测出的 step time 可比）。
+- `--test-accuracy` 负责「结果可复现、不 aadiff」：注入确定性开关，是
+  **唯一允许缩小 EP/PP** 的模式；单独给（未叠加 `--test-performance`）时用
+  `scale_accumulation`：GBS 保持不变、acc 等比放大，等效 batch 与全量作业
+  一致，loss 曲线可对齐。
 
-两种组合都遵守同一条硬规则：**源配置里大于 1 的并行度，最小只能缩到 2，不允许
-缩成 1**（EP8 最多缩到 EP2，不会变成 EP1）。把一个维度缩成 1 等于把待测的通信
-组直接去掉，测出来的结果没有参考价值。唯一例外是 VPP：框架硬断言 VPP>1 需要
-PP>2，PP 缩到 2 时 VPP 只能是 1。
+缩容（仅 `--test-accuracy`）遵守一条硬规则：**源配置里大于 1 的并行度，最小只能
+缩到 2，不允许缩成 1**（EP8 最多缩到 EP2，不会变成 EP1）。把一个维度缩成 1 等于
+把待测的通信组直接去掉，测出来的结果没有参考价值。EP 的下限还要同时满足 C3
+（`EP % (TP·SEP) == 0`）：TP·SEP > 2 时 EP 最小只能缩到 TP·SEP 的最小合法倍数，
+而不是 2。唯一例外是 VPP：框架硬断言
+VPP>1 需要 PP>2，PP 缩到 2 时 VPP 只能是 1（这条兜底在所有模式下生效）。
 
 TP 与 SEP 永远不改：减小 TP 会增大单卡显存占用，有 OOM 风险。EP 与 PP 都要缩时按
 **EP 优先于 PP** 的顺序缩（缩 EP 只损失路由专家数，缩 PP 会连带改层数与逐层配置）。
@@ -35,14 +42,15 @@ TP 与 SEP 永远不改：减小 TP 会增大单卡显存占用，有 OOM 风险
 # 1) 只看这份配置能跑在哪些机器规模上（不生成任何文件）
 python -m paddlefleet.config_adapter --input config.yaml
 
-# 2) 只要能跑起来：适配到 2 台机器（默认每台 8 卡），必要时自动缩 EP/PP
+# 2) 适配到 2 台机器（默认每台 8 卡）；默认冻结并行度，目标规模必须
+#    与源并行度兼容，否则报错并列出合法节点数（缩 EP/PP 见 --test-accuracy）
 python -m paddlefleet.config_adapter --input config.yaml --target-nodes 2
 
-# 3) 测速：冻结并行策略与 acc，只改 sharding 和 GBS
+# 3) 测速：冻结并行策略与 acc，只缩放 sharding 和 GBS
 python -m paddlefleet.config_adapter --input config.yaml \
     --target-nodes 2 --test-performance
 
-# 4) 精度测试：注入避免 aadiff 的开关，并保持等效 batch
+# 4) 精度测试：注入避免 aadiff 的开关，并允许缩小 EP/PP（唯一允许改模型结构的模式）
 python -m paddlefleet.config_adapter --input config.yaml \
     --target-nodes 1 --test-accuracy
 
@@ -62,6 +70,10 @@ python -m paddlefleet.config_adapter --input config.yaml \
 python -m paddlefleet.config_adapter --input config.yaml \
     --target-nodes 1 --test-accuracy \
     --set max_steps=10 --set n_routed_experts=32
+
+# 9) 序列长度改到 32k：max_seq_length 覆盖为 32768，CP 同比例扩大
+python -m paddlefleet.config_adapter --input config.yaml \
+    --target-nodes 8 --scale-seq-length 32768
 ```
 
 改写 YAML 时用 `ruamel.yaml` 保留注释与字段顺序，它是 paddlefleet 的运行时依赖，随包一起安装，无需额外操作。
@@ -73,10 +85,11 @@ python -m paddlefleet.config_adapter --input config.yaml \
 | `--input` | 是 | — | 源 YAML 路径 |
 | `--target-nodes N` | 否 | — | 目标机器台数；总卡数 = N × `--cards-per-node`。不传 = 只列出合法规模，不生成文件 |
 | `--cards-per-node` | 否 | 8 | 每台机器的卡数 |
-| `--test-performance` | 否 | 关 | 测速维度，可与 `--test-accuracy` 叠加 |
-| `--test-accuracy` | 否 | 关 | 精度维度，可与 `--test-performance` 叠加 |
+| `--test-performance` | 否 | 关 | 测速维度（冻结并行度与 acc，只改 sharding 和 GBS），可与 `--test-accuracy` 叠加 |
+| `--test-accuracy` | 否 | 关 | 精度维度（注入确定性开关，单独给时保持等效 batch；唯一允许缩小 EP/PP 的模式），可与 `--test-performance` 叠加 |
 | `--output-dir` | 否 | `./adapted_configs` | 输出目录；`--in-place` 时忽略 |
 | `--set [yaml:\|json:]KEY=VALUE` | 否 | — | 自定义覆盖，可重复 |
+| `--scale-seq-length N` | 否 | — | 把 `max_seq_length` 覆盖为 N，并同比例缩放 `context_parallel_size`；需配合 `--target-nodes` |
 | `-i` / `--in-place` | 否 | 关 | 就地改写源文件，并生成 `<input>.patch` |
 | `-f` / `--force` | 否 | 关 | 允许覆盖已存在的 model_config 生成目录 |
 
@@ -96,6 +109,16 @@ python -m paddlefleet.config_adapter --input config.yaml \
 改它会决定「到底加载/缩容/快照哪一份 `model_config.json`」。当某个模型
 结构字段在 `model_config.json` 里读不到（不同模型家族命名不一致）时，也用
 `--set <字段>=<值>` 兜底。
+
+`--scale-seq-length N` 覆盖 `max_seq_length` 并把 `context_parallel_size`
+按同一倍率缩放：序列变长 k 倍（N 必须是源值的整数倍），CP 也扩大 k 倍，让每卡
+分到的序列片段（进而激活显存）保持在源配置的水平，防止长序列 OOM；序列变短则
+CP 同比例缩小，下限为 1。缩放发生在并行度规划**之前**，因此 C1..C5 校验、
+sharding 重算和 batch 重算都以新 CP 为准（冻结模式 —— 默认或
+`--test-performance` —— 冻结的也是缩放后的 CP）。两个被改写的字段与 `--set`
+一样受保护。注意：CP 扩大后仍需满足 C4
+（sharding 能被 CP 整除）与 C5（SEP 与 CP 不能同时 > 1），不满足会直接报错；
+若新序列长度超过 `max_position_embeddings`，报告里会给出 WARNING。
 
 源作业卡数按两条证据推断并交叉校验：通信组
 （`DP × sharding × TP × SEP × PP`）与 batch 字段
@@ -119,18 +142,19 @@ C3/C5 只取决于并行度本身，与卡数无关：这两项冲突时不会�
   -> 删除 fa_version（与环境强绑定的 flash-attention 版本 pin）
   -> 需要时加载 model_config.json 并应用 --set json:
   -> 扫描两个文件，落定不带前缀的 --set
-  -> 规划最终 TP/PP/EP/CP/SEP（冻结或缩容）
+  -> --scale-seq-length：改写 max_seq_length 并同比例缩放 CP（并锁定两字段）
+  -> 规划最终 TP/PP/EP/CP/SEP（默认冻结；--test-accuracy 时允许缩容）
   -> 写入 model_config.json 的结构改动（专家数 / 层数）
   -> 注入精度开关（给了 --test-accuracy 时）
   -> model_config.json 有改动时另存一份，并把 model_name_or_path 指过去
   -> 应用并行度改动并复核 C1..C4
-  -> 缩放 batch、sharding、data_parallel_size
+  -> 重算 batch（策略见上表）、sharding、data_parallel_size
   -> sharding 路数变小时注入补偿开关（数据流路数 / 优化器 offload）
   -> 写出 YAML 并打印报告
 ```
 
-不冻结并行度时（默认，或只给了 `--test-accuracy`），按「改动越小越优先」的顺序
-尝试，命中第一个可行方案就停：
+只给了 `--test-accuracy`（未同时给 `--test-performance`）时进入缩容规划，按
+「改动越小越优先」的顺序尝试，命中第一个可行方案就停：
 
 ```
 维度已合法  <  只缩 EP  <  只缩 PP  <  EP+PP 联合缩
@@ -251,8 +275,8 @@ sharding  ：96 -> 2（moe_sharding=1, dense_sharding=2）
             优先于 PP 的缩容顺序，先把 EP 压到可行下限，再尽量少缩 PP（缩 PP 会连带改层
             数/VPP/尾部空层/逐层配置）
 
-  CHANGE field=gradient_accumulation_steps old=2 new=192
-      原因：保持等效 batch：GBS 保持 1536 不变，acc 放大为 2 × 768 / 8 = 192
+  CHANGE field=gradient_accumulation_steps old=2 new=96
+      原因：保持等效 batch：GBS 保持 192 不变，acc 按数据并行路数放大为 2 × 96 / 2 = 96
 
   ADD field=tensorwise_offload_optimizer new=True
       原因：sharding 路数 96 -> 2，单卡优化器状态放大 48 倍，offload 到 host 内存防 OOM

--- a/src/paddlefleet/config_adapter/__init__.py
+++ b/src/paddlefleet/config_adapter/__init__.py
@@ -14,21 +14,23 @@
 
 """Adapt a large-cluster training YAML to a smaller machine scale.
 
-Without any switch the adapter simply makes the config fit the target scale:
-it recomputes ``sharding`` / batch and, when the target is incompatible with
-the source parallelism, shrinks EP / PP (never below 2) and rewrites a copy of
-``model_config.json`` accordingly.  A smaller ``sharding`` also gets the
-compensations in :mod:`paddlefleet.config_adapter.sharding_shrink` (data-stream
-width, optimizer offload).
+Without any switch the adapter keeps every parallel dimension frozen and only
+recomputes ``sharding`` / batch, so the target scale must be compatible with
+the source parallelism (incompatible targets get an error listing the valid
+node counts).  A smaller ``sharding`` also gets the compensations in
+:mod:`paddlefleet.config_adapter.sharding_shrink` (data-stream width,
+optimizer offload).
 
 Two orthogonal, optional test dimensions refine that:
 
 * ``--test-performance`` -- freeze every parallel dimension and
   ``gradient_accumulation_steps`` so the step time stays comparable; only
   ``sharding`` and ``global_batch_size`` move.
-* ``--test-accuracy`` -- pin the determinism switches in
-  :mod:`paddlefleet.config_adapter.precision` so the run does not aadiff, and
-  (unless the performance switch froze ``acc``) keep the effective batch.
+* ``--test-accuracy`` -- the ONLY mode that may shrink EP / PP (never below
+  2, rewriting a copy of ``model_config.json`` accordingly); it also pins
+  the determinism switches in :mod:`paddlefleet.config_adapter.precision`
+  so the run does not aadiff, and (unless the performance switch froze
+  ``acc``) keeps the effective batch.
 
 Usage::
 

--- a/src/paddlefleet/config_adapter/cli.py
+++ b/src/paddlefleet/config_adapter/cli.py
@@ -36,14 +36,16 @@ EPILOG = """\
   # 1) 只看这份配置能跑在哪些机器规模上（不生成文件）
   python -m paddlefleet.config_adapter --input config.yaml
 
-  # 2) 适配到 2 台机器（默认每台 8 卡 = 16 卡），必要时自动缩小 EP/PP
+  # 2) 适配到 2 台机器（默认每台 8 卡 = 16 卡）；默认冻结并行度，
+  #    目标规模必须与源并行度兼容（缩 EP/PP 见 --test-accuracy）
   python -m paddlefleet.config_adapter --input config.yaml --target-nodes 2
 
   # 3) 测速：冻结 TP/PP/EP/CP/SEP 与 acc，只改 sharding 和 GBS
   python -m paddlefleet.config_adapter --input config.yaml \\
       --target-nodes 2 --test-performance
 
-  # 4) 精度测试：注入避免 aadiff 的开关，并保持等效 batch
+  # 4) 精度测试：注入避免 aadiff 的开关，保持等效 batch，
+  #    并允许缩小 EP/PP（唯一允许改模型结构的模式）
   python -m paddlefleet.config_adapter --input config.yaml \\
       --target-nodes 1 --test-accuracy
 
@@ -64,6 +66,10 @@ EPILOG = """\
       --target-nodes 1 --test-accuracy \\
       --set max_steps=10 --set n_routed_experts=32 \\
       --set json:some_new_field=1
+
+  # 9) 序列长度改到 32k：max_seq_length 覆盖为 32768，CP 同比例扩大
+  python -m paddlefleet.config_adapter --input config.yaml \\
+      --target-nodes 8 --scale-seq-length 32768
 """
 
 
@@ -73,8 +79,8 @@ def build_parser():
         prog="python -m paddlefleet.config_adapter",
         description=(
             "把面向大集群的训练 YAML 适配到更小的机器规模："
-            "重算 sharding 与 batch，必要时缩小 EP/PP 并联动改写 "
-            "model_config.json。"
+            "重算 sharding 与 batch；仅 --test-accuracy 模式允许缩小 "
+            "EP/PP 并联动改写 model_config.json。"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=EPILOG,
@@ -96,15 +102,16 @@ def build_parser():
     parser.add_argument(
         "--test-performance",
         action="store_true",
-        help="测速维度：冻结 TP/PP/EP/CP/SEP 与 acc，只改 sharding 和 GBS。"
-        "与 --test-accuracy 正交，可单独给、可同时给、也可都不给"
-        "（都不给时默认允许缩小 EP/PP）",
+        help="测速维度：冻结 TP/PP/EP/CP/SEP 与 acc，只改 sharding 和 "
+        "GBS。与 --test-accuracy 正交，可单独给、可同时给、也可都不给"
+        "（默认即冻结并行度；缩小 EP/PP 需 --test-accuracy）",
     )
     parser.add_argument(
         "--test-accuracy",
         action="store_true",
         help="精度维度：注入避免 aadiff 的开关；未同时指定 "
-        "--test-performance 时还会保持等效 batch（GBS 不变、acc 放大）",
+        "--test-performance 时还会保持等效 batch（GBS 不变、acc 放大），"
+        "并且是唯一允许缩小 EP/PP（改模型结构）的模式",
     )
     parser.add_argument(
         "--output-dir",
@@ -121,6 +128,16 @@ def build_parser():
         "（谁声明了这个 key 就改谁，两边都有就都改，两边都没有则新增到 "
         "yaml）；要把新字段加到 model_config.json 请显式写 json:KEY=VALUE。"
         "这些字段会被保护，不再参与自动适配",
+    )
+    parser.add_argument(
+        "--scale-seq-length",
+        type=int,
+        default=None,
+        metavar="N",
+        help="把 max_seq_length 覆盖为 N，并按同一整数倍率缩放 "
+        "context_parallel_size（序列变长时同比例扩大 CP，防止长序列 "
+        "OOM）。N 必须与源 max_seq_length 成整数倍关系；需配合 "
+        "--target-nodes 使用",
     )
     parser.add_argument(
         "-i",
@@ -216,6 +233,18 @@ def main(argv=None):
         print("错误：--cards-per-node 必须 >= 1", file=sys.stderr)
         return 1
 
+    if args.scale_seq_length is not None:
+        if args.scale_seq_length < 1:
+            print("错误：--scale-seq-length 必须 >= 1", file=sys.stderr)
+            return 1
+        if args.target_nodes is None:
+            print(
+                "错误：--scale-seq-length 需要配合 --target-nodes 使用"
+                "（不指定目标规模时只做检视，不生成任何文件）",
+                file=sys.stderr,
+            )
+            return 1
+
     try:
         yaml_overrides, json_overrides, auto_overrides = parse_overrides(
             args.overrides
@@ -264,6 +293,7 @@ def main(argv=None):
         output_dir=args.output_dir,
         in_place=args.in_place,
         force=args.force,
+        scale_seq_length=args.scale_seq_length,
     )
     ok, message = adapter.adapt(input_path)
     if not ok:

--- a/src/paddlefleet/config_adapter/constraints.py
+++ b/src/paddlefleet/config_adapter/constraints.py
@@ -72,8 +72,20 @@ def shrink_floor(degree):
 
 
 def floor_dims(tp, pp, ep, cp, sep):
-    """Dims after shrinking EP / PP as far as the no-collapse rule allows."""
-    return tp, shrink_floor(pp), shrink_floor(ep), cp, sep
+    """Dims after shrinking EP / PP as far as the no-collapse rule allows.
+
+    The EP floor additionally respects C3 (``EP % (TP*SEP) == 0``): with
+    TP*SEP > MIN_PARALLEL_DEGREE the naive floor of 2 is not a legal EP at
+    all, and feeding it to ``suggest_valid_cards`` would make
+    :func:`min_shrink_cards` wrongly conclude that *no* card count works.
+    """
+    ep_floor = shrink_floor(ep)
+    dense = tp * sep
+    if ep > 1 and dense > 1:
+        # Smallest multiple of TP*SEP at or above the generic floor,
+        # capped at the source EP (which C3 already guarantees is legal).
+        ep_floor = min(ep, -(-ep_floor // dense) * dense)
+    return tp, shrink_floor(pp), ep_floor, cp, sep
 
 
 def ep_candidates(ep_orig, tp, sep=1):

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -70,6 +70,10 @@ ADAPTER_CONTROLLED_FIELDS = frozenset(
 )
 
 
+#: YAML key that carries the training sequence length.
+SEQ_FIELD = "max_seq_length"
+
+
 def _yaml_truthy(value):
     """Loose YAML bool: accepts real bools plus "true"/"yes"/"1" spellings."""
     if isinstance(value, str):
@@ -91,6 +95,7 @@ class ConfigAdapter:
         output_dir="./adapted_configs",
         in_place=False,
         force=False,
+        scale_seq_length=None,
     ):
         self.options = options
         self.target_nodes = target_nodes
@@ -104,6 +109,10 @@ class ConfigAdapter:
         self.output_dir = Path(output_dir)
         self.in_place = in_place
         self.force = force
+        # --scale-seq-length: rewrite max_seq_length and scale CP with it.
+        self.scale_seq_length = (
+            int(scale_seq_length) if scale_seq_length is not None else None
+        )
 
         self.scale_tag = f"{self.target_cards}cards"
         self.yaml_writer = YamlWriter()
@@ -138,6 +147,12 @@ class ConfigAdapter:
                 f"以下字段由适配器统一计算，不能用 --set 锁定：{pinned}。"
                 f"锁定后生成的配置会与报告里的并行度 / sharding 不一致；"
                 f"请去掉对应的 --set，或直接改源 YAML 后再适配"
+            )
+
+        if self.scale_seq_length is not None and SEQ_FIELD in requested:
+            return False, (
+                f"--scale-seq-length 与 --set {SEQ_FIELD} 冲突："
+                f"两者都要决定序列长度，请只保留其一"
             )
 
         config = self.yaml_writer.load(input_path)
@@ -191,9 +206,15 @@ class ConfigAdapter:
 
         self._apply_auto_overrides(config, model_config, log)
 
+        dims_planned, seq_warnings, err = self._apply_seq_scaling(
+            config, dims_before, model_config, log
+        )
+        if err:
+            return False, f"{input_path.name}: {err}"
+
         plan, err = plan_parallelism(
             config,
-            dims_before,
+            dims_planned,
             self.target_cards,
             self.cards_per_node,
             self.options,
@@ -205,6 +226,7 @@ class ConfigAdapter:
         )
         if err:
             return False, f"{input_path.name}: {err}"
+        plan.warnings.extend(seq_warnings)
 
         for key, value, reason in plan.json_changes:
             log.record(
@@ -327,6 +349,122 @@ class ConfigAdapter:
                     + "）",
                 )
 
+    def _apply_seq_scaling(self, config, dims_before, model_config, log):
+        """Rewrite ``max_seq_length`` and scale CP by the same ratio.
+
+        A longer sequence multiplies activation memory per card, so growing
+        ``max_seq_length`` N-fold grows ``context_parallel_size`` N-fold to
+        keep the per-card sequence slice (and thus activation memory) at the
+        source level.  Shrinking the sequence shrinks CP the same way, floored
+        at 1.  Returns ``(dims_for_planning, warnings, error_or_None)``; the
+        two rewritten fields are pinned like ``--set`` values so no later
+        stage may touch them.
+        """
+        if self.scale_seq_length is None:
+            return dims_before, [], None
+
+        new_seq = self.scale_seq_length
+        if new_seq < 1:
+            return dims_before, [], "--scale-seq-length 必须 >= 1"
+
+        raw = config.get(SEQ_FIELD)
+        try:
+            old_seq = int(raw)
+        except (TypeError, ValueError):
+            old_seq = 0
+        if old_seq < 1:
+            return (
+                dims_before,
+                [],
+                (
+                    f"--scale-seq-length 需要源 YAML 声明 {SEQ_FIELD}"
+                    f"（当前值：{raw!r}），否则无法计算 CP 的缩放比例"
+                ),
+            )
+
+        tp, pp, ep, cp, sep = dims_before
+        warnings = []
+        if new_seq == old_seq:
+            cp_new = cp
+            warnings.append(
+                f"--scale-seq-length {new_seq} 与源 {SEQ_FIELD} 相同，"
+                f"序列长度与 CP 均保持不变"
+            )
+        elif new_seq > old_seq:
+            if new_seq % old_seq != 0:
+                return (
+                    dims_before,
+                    [],
+                    (
+                        f"--scale-seq-length {new_seq} 不是源 {SEQ_FIELD}="
+                        f"{old_seq} 的整数倍，CP 无法同比例扩大；请改用 "
+                        f"{old_seq} 的整数倍（如 {old_seq * 2} / {old_seq * 4}）"
+                    ),
+                )
+            cp_new = cp * (new_seq // old_seq)
+        else:
+            if old_seq % new_seq != 0:
+                return (
+                    dims_before,
+                    [],
+                    (
+                        f"--scale-seq-length {new_seq} 不能整除源 {SEQ_FIELD}="
+                        f"{old_seq}，CP 无法同比例缩小；请改用能整除 "
+                        f"{old_seq} 的值"
+                    ),
+                )
+            factor = old_seq // new_seq
+            cp_new, remainder = divmod(cp, factor)
+            cp_new = max(cp_new, 1)
+            if remainder:
+                warnings.append(
+                    f"序列长度缩小 {factor} 倍但源 CP={cp} 不能被整除，"
+                    f"CP 取下整为 {cp_new}（每卡序列片段比按比例缩短的值"
+                    f"更长一点，显存只会更省，不影响正确性）"
+                )
+
+        if sep > 1 and cp_new > 1:
+            return (
+                dims_before,
+                [],
+                (
+                    f"序列长度缩放要求 CP {cp} -> {cp_new}，但源配置 SEP={sep}"
+                    f" > 1，框架禁止 sep parallel 与 context parallel 同时使用"
+                    f"（C5）；请先在源 YAML 里去掉 SEP 或 CP，再做序列长度缩放"
+                ),
+            )
+
+        if model_config is not None:
+            max_pos = model_config.get("max_position_embeddings")
+            if max_pos is not None and int(max_pos) < new_seq:
+                warnings.append(
+                    f"新序列长度 {new_seq} 超过 model_config.json 的 "
+                    f"max_position_embeddings={max_pos}，训练可能因位置编码"
+                    f"越界报错；请确认模型支持长度外推，或改小序列长度"
+                )
+
+        log.record(
+            "yaml",
+            self.yaml_writer.apply_config_map(config, {SEQ_FIELD: new_seq}),
+            f"--scale-seq-length：序列长度 {old_seq} -> {new_seq}",
+        )
+        if cp_new != cp:
+            direction = "扩大" if new_seq > old_seq else "缩小"
+            log.record(
+                "yaml",
+                self.yaml_writer.apply_config_map(
+                    config, {PARALLEL_FIELDS["cp"]: cp_new}
+                ),
+                f"序列长度{direction} {max(new_seq, old_seq) // min(new_seq, old_seq)} "
+                f"倍，context parallel 同比例{direction}：CP {cp} -> {cp_new}，"
+                f"保持每卡序列片段不长于源配置，防止长序列 OOM",
+            )
+        # Pin both fields exactly like --set values: nothing later in the
+        # pipeline may rewrite what the user asked for explicitly.
+        self.yaml_overrides[SEQ_FIELD] = new_seq
+        self.yaml_overrides[PARALLEL_FIELDS["cp"]] = cp_new
+        return (tp, pp, ep, cp_new, sep), warnings, None
+
     def _load_json(self, config, input_path):
         """Load ``model_config.json`` when it may be needed.
 
@@ -339,6 +477,8 @@ class ConfigAdapter:
             self.options.needs_model_config
             or bool(self.json_overrides)
             or bool(self.auto_overrides)
+            # the seq scaling wants max_position_embeddings for its warning
+            or self.scale_seq_length is not None
         )
         if not needed:
             return None, None, None, "本次运行不需要 model_config.json"

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -414,14 +414,19 @@ class ConfigAdapter:
                     ),
                 )
             factor = old_seq // new_seq
+            # Ceil, not floor: the guarantee is "the per-card slice never
+            # exceeds the source slice" (new_seq / cp_new <= old_seq / cp),
+            # i.e. cp_new >= cp / factor.  Flooring CP=3 at factor=2 to 1
+            # would grow the slice from old_seq/3 to old_seq/2 and can OOM.
             cp_new, remainder = divmod(cp, factor)
-            cp_new = max(cp_new, 1)
             if remainder:
+                cp_new += 1
                 warnings.append(
                     f"序列长度缩小 {factor} 倍但源 CP={cp} 不能被整除，"
-                    f"CP 取下整为 {cp_new}（每卡序列片段比按比例缩短的值"
-                    f"更长一点，显存只会更省，不影响正确性）"
+                    f"CP 取上整为 {cp_new}，保证每卡序列片段不超过源配置"
+                    f"（片段比按比例缩短的值更短一点，显存只会更省）"
                 )
+            cp_new = max(cp_new, 1)
 
         if sep > 1 and cp_new > 1:
             return (

--- a/src/paddlefleet/config_adapter/options.py
+++ b/src/paddlefleet/config_adapter/options.py
@@ -17,19 +17,22 @@
 ``--test-performance`` and ``--test-accuracy`` are independent switches, not
 alternatives, and neither is required::
 
-    (none)                              缩到目标规模即可：允许缩小 EP/PP
-    --test-performance                  冻结 TP/PP/EP/CP/SEP 与 acc
-    --test-accuracy                     注入避免 aadiff 的开关，保持等效 batch
+    (none)                              并行度冻结：目标规模必须与源兼容
+    --test-performance                  冻结 TP/PP/EP/CP/SEP（同默认）
+    --test-accuracy                     允许缩小 EP/PP + 注入避免 aadiff 的开关
     --test-performance --test-accuracy  冻结并行策略 + 注入精度开关
 
 Each switch owns one concern:
 
-* ``--test-performance`` freezes the parallelism and
-  ``gradient_accumulation_steps`` so a step time stays comparable with the
-  full-scale job -- only ``sharding`` and ``global_batch_size`` move.
+* ``--test-performance`` freezes the parallelism and keeps
+  ``gradient_accumulation_steps``, so a step time stays comparable with the
+  full-scale job -- only ``sharding`` and ``global_batch_size`` move.  The
+  default freezes the dims too and shares the same batch strategy.
 * ``--test-accuracy`` pins the determinism switches in
-  :mod:`paddlefleet.config_adapter.precision`, and (unless the performance
-  switch already froze ``acc``) keeps the effective batch by raising ``acc``.
+  :mod:`paddlefleet.config_adapter.precision`.  It is also the ONLY mode
+  allowed to shrink EP/PP: shrinking rescales the expert count / layer
+  count, i.e. it changes the model structure, so it must be an explicit
+  opt-in rather than a silent default.
 """
 
 from __future__ import annotations
@@ -44,8 +47,15 @@ class AdaptOptions:
 
     @property
     def freeze_parallel(self):
-        """True when no parallel dimension (nor ``acc``) may be rewritten."""
-        return self.test_performance
+        """True when no parallel dimension may be rewritten.
+
+        Shrinking EP/PP rescales the routed-expert count or the layer count
+        -- a model-structure change -- so it is an explicit opt-in reserved
+        for ``--test-accuracy``.  The default and ``--test-performance`` both
+        freeze the dims; the performance switch additionally freezes ``acc``
+        (see :attr:`batch_strategy`).
+        """
+        return self.test_performance or not self.test_accuracy
 
     @property
     def inject_precision(self):
@@ -56,8 +66,10 @@ class AdaptOptions:
     def batch_strategy(self):
         """Batch strategy name from ``strategies.BATCH_STRATEGIES``.
 
-        The performance switch wins: it freezes ``acc``, so the only way to
-        follow the card count is to scale ``global_batch_size``.
+        Only the pure accuracy profile keeps the effective batch by raising
+        ``acc``; every other combination keeps ``acc`` and scales
+        ``global_batch_size`` with the data-parallel width (the performance
+        switch wins when both are given).
         """
         if self.test_accuracy and not self.test_performance:
             return "scale_accumulation"

--- a/src/paddlefleet/config_adapter/planner.py
+++ b/src/paddlefleet/config_adapter/planner.py
@@ -16,11 +16,13 @@
 
 :func:`plan_parallelism` picks one of two planners from the options:
 
-* frozen (``--test-performance``) -- every parallel dimension stays as the
-  source declares it; an incompatible target scale is rejected with the list
-  of legal node counts rather than forced through.
-* shrink (default) -- candidates are tried in order of increasing structural
-  intrusion and the first feasible one wins::
+* frozen (the default, and ``--test-performance``) -- every parallel
+  dimension stays as the source declares it; an incompatible target scale is
+  rejected with the list of legal node counts rather than forced through.
+  Shrinking changes the model structure, so it is never a silent default.
+* shrink (``--test-accuracy`` without ``--test-performance``) -- candidates
+  are tried in order of increasing structural intrusion and the first
+  feasible one wins::
 
       Case A (dims already legal) < EP-only < PP-only < EP+PP joint
 
@@ -82,7 +84,12 @@ def plan_parallelism(
 ):
     """Plan the final parallel dims. Returns ``(plan, error_or_None)``."""
     if options.freeze_parallel:
-        plan, err = plan_frozen(dims, target_cards, cards_per_node)
+        plan, err = plan_frozen(
+            dims,
+            target_cards,
+            cards_per_node,
+            frozen_by_performance=options.test_performance,
+        )
     else:
         plan, err = ShrinkPlanner().plan(
             config, dims, target_cards, cards_per_node, context
@@ -112,30 +119,47 @@ def enforce_vpp_limit(config, plan):
     plan.yaml_changes.append((VPP_FIELD, 1, _vpp_off_reason(vpp, plan.pp)))
 
 
-def plan_frozen(dims, target_cards, cards_per_node):
-    """Keep every parallel dim; fail when the target scale needs changes."""
+def plan_frozen(dims, target_cards, cards_per_node, frozen_by_performance=True):
+    """Keep every parallel dim; fail when the target scale needs changes.
+
+    ``frozen_by_performance`` only shapes the diagnostics: the dims are
+    frozen either because ``--test-performance`` demanded it, or because no
+    switch was given and shrinking (a model-structure change) requires the
+    explicit ``--test-accuracy`` opt-in.
+    """
     tp, pp, ep, cp, sep = dims
     validator = TopologyValidator(target_cards, cards_per_node)
     ok, message, _details = validator.validate(tp, pp, ep, cp, sep)
     if not ok:
-        return None, (
-            f"{message}\n"
-            f"  说明：--test-performance 只调整 sharding 与 "
-            f"global_batch_size，不修改 TP/PP/EP/CP/SEP 和 acc，"
-            f"因此目标机器规模必须与源并行度兼容。\n"
-            f"  建议：换用上面列出的合法节点数，"
-            f"或去掉 --test-performance（默认允许缩小 EP/PP）"
-        )
+        if frozen_by_performance:
+            why = (
+                "--test-performance 只调整 sharding 与 global_batch_size，"
+                "不修改 TP/PP/EP/CP/SEP 和 acc，"
+                "因此目标机器规模必须与源并行度兼容。"
+            )
+            hint = (
+                "换用上面列出的合法节点数；确要缩小 EP/PP 请去掉 "
+                "--test-performance 并加 --test-accuracy"
+            )
+        else:
+            why = (
+                "默认不缩小 EP/PP：缩容会等比改写专家数 / 层数，"
+                "属于模型结构变更，不应默默发生，"
+                "因此目标机器规模必须与源并行度兼容。"
+            )
+            hint = (
+                "换用上面列出的合法节点数，"
+                "或加 --test-accuracy 显式允许缩小 EP/PP"
+            )
+        return None, f"{message}\n  说明：{why}\n  建议：{hint}"
+    note = (
+        "并行度全部保持不变（--test-performance 冻结 TP/PP/EP/CP/SEP 与 acc）"
+        if frozen_by_performance
+        else "并行度全部保持不变（默认冻结；缩小 EP/PP 需显式加 "
+        "--test-accuracy）"
+    )
     return (
-        ParallelismPlan(
-            tp,
-            pp,
-            ep,
-            cp,
-            sep,
-            note="并行度全部保持不变（--test-performance 冻结 "
-            "TP/PP/EP/CP/SEP 与 acc）",
-        ),
+        ParallelismPlan(tp, pp, ep, cp, sep, note=note),
         None,
     )
 

--- a/src/paddlefleet/config_adapter/strategies.py
+++ b/src/paddlefleet/config_adapter/strategies.py
@@ -14,13 +14,14 @@
 
 """How batch settings follow the data-parallel width, one per test profile.
 
-* ``--test-performance`` -> :func:`scale_batch`: shrink ``global_batch_size``
-  proportionally and keep ``gradient_accumulation_steps``, so per-step work
-  per card is unchanged and the measured step time stays comparable.
-* ``--test-accuracy`` -> :func:`scale_accumulation`: keep
-  ``global_batch_size`` and raise ``gradient_accumulation_steps`` by the same
-  factor, so the effective batch (and therefore the loss curve) matches the
-  full-scale run.
+* default / ``--test-performance`` -> :func:`scale_batch`: shrink
+  ``global_batch_size`` proportionally and keep
+  ``gradient_accumulation_steps``, so per-step work per card is unchanged
+  and the measured step time stays comparable.
+* ``--test-accuracy`` (alone) -> :func:`scale_accumulation`: keep
+  ``global_batch_size`` and raise ``gradient_accumulation_steps`` by the
+  same factor, so the effective batch (and therefore the loss curve)
+  matches the full-scale run.
 
 Scaling must follow ``dataset_world_size`` (= cards / (TP*SEP*PP*CP)), not
 the raw card count: the trainer asserts ``GBS == micro_bs * acc *

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -177,20 +177,20 @@ class ConfigAdapterTestBase(unittest.TestCase):
 class TestOptions(unittest.TestCase):
     """The two switches are orthogonal and both optional."""
 
-    def test_default_shrinks_and_scales_batch(self):
+    def test_default_freezes_dims_and_scales_batch(self):
         options = AdaptOptions()
-        self.assertFalse(options.freeze_parallel)
+        self.assertTrue(options.freeze_parallel)
         self.assertFalse(options.inject_precision)
         self.assertEqual(options.batch_strategy, "scale_batch")
         self.assertEqual(options.label, "default")
 
-    def test_accuracy_keeps_effective_batch(self):
+    def test_accuracy_is_the_only_mode_that_may_shrink(self):
         options = AdaptOptions(test_accuracy=True)
         self.assertFalse(options.freeze_parallel)
         self.assertTrue(options.inject_precision)
         self.assertEqual(options.batch_strategy, "scale_accumulation")
 
-    def test_performance_freezes_acc_even_with_accuracy(self):
+    def test_performance_wins_the_freeze_over_accuracy(self):
         options = AdaptOptions(test_performance=True, test_accuracy=True)
         self.assertTrue(options.freeze_parallel)
         self.assertTrue(options.inject_precision)
@@ -214,6 +214,42 @@ class TestCandidates(unittest.TestCase):
         # C3 requires ep_new % (tp * sep) == 0.
         self.assertTrue(all(c % 4 == 0 for c in ep_candidates(64, tp=4)))
         self.assertTrue(all(c % 8 == 0 for c in ep_candidates(64, tp=2, sep=4)))
+
+
+class TestMinShrinkCards(unittest.TestCase):
+    """The reachable-scale floor must respect C3 for the EP axis."""
+
+    def test_ep_floor_stays_a_multiple_of_tp(self):
+        # TP=4: EP can floor to 4, not 2, so 16 cards is reachable.
+        self.assertEqual(min_shrink_cards(4, 1, 8, 4, 1, 8), 16)
+
+    def test_planner_advice_names_a_reachable_scale(self):
+        # TP=4 + CP=4 on 8 cards fails C4; the advice must point at a
+        # bigger scale instead of claiming the dims are illegal.
+        adapter = ConfigAdapter(options=AdaptOptions(), target_nodes=1)
+        yaml_map = {
+            "tensor_model_parallel_size": 4,
+            "expert_model_parallel_size": 8,
+            "context_parallel_size": 4,
+            "global_batch_size": 12,
+            "per_device_train_batch_size": 1,
+            "gradient_accumulation_steps": 6,
+        }
+        from paddlefleet.config_adapter.planner import ShrinkPlanner
+        from paddlefleet.config_adapter.utils import (
+            extract_parallel_params as _dims,
+        )
+
+        plan, err = ShrinkPlanner().plan(
+            yaml_map,
+            _dims(yaml_map),
+            8,
+            8,
+            context={"model_config": dict(MODEL_CONFIG)},
+        )
+        self.assertIsNone(plan)
+        self.assertIn("--target-nodes 2", err)
+        self.assertNotIn("任何卡数都无法适配", err)
 
 
 class TestPrecisionSwitches(unittest.TestCase):
@@ -1017,10 +1053,18 @@ class TestLayerFieldPlanning(unittest.TestCase):
 
 
 class TestDefaultAdaptation(ConfigAdapterTestBase):
-    """No switch: just make the config fit, shrinking EP/PP if needed."""
+    """No switch: dims frozen; shrinking EP/PP needs --test-accuracy."""
 
-    def test_shrinks_ep_and_pp_without_precision_switches(self):
+    def test_default_refuses_to_shrink(self):
+        # Shrinking rescales the expert / layer count -- a model-structure
+        # change -- so it may never happen silently.
         ok, message = self.adapt(target_nodes=1)
+        self.assertFalse(ok)
+        self.assertIn("默认不缩小 EP/PP", message)
+        self.assertIn("--test-accuracy", message)
+
+    def test_accuracy_shrinks_ep_and_pp(self):
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         config = self.load_output_yaml(8)
         model_config = self.load_output_json(8)
@@ -1032,15 +1076,10 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
         self.assertEqual(config["sharding_parallel_size"], 2)
         self.assertEqual(model_config["n_routed_experts"], 8)
         self.assertEqual(model_config["num_hidden_layers"], 32)
-        # Default batch strategy shrinks GBS and leaves acc alone.  GBS
-        # follows the data-parallel width (96 -> 2), not the card count:
-        # the trainer asserts GBS == micro_bs * acc * dataset_world_size,
-        # so 8 cards / PP 4 give width 2 and GBS = 1 * 2 * 2 = 4.
-        self.assertEqual(config["global_batch_size"], 4)
-        self.assertEqual(config["gradient_accumulation_steps"], 2)
-        # No determinism switches unless --test-accuracy is given.
-        self.assertEqual(config["csa_sparse_attn_backend"], "cudnn")
-        self.assertEqual(model_config["multimax_modules"], ["lm_head"])
+        # A declared GBS is never rewritten: acc absorbs the width change
+        # (96 -> 2), keeping GBS == micro_bs * acc * dataset_world_size.
+        self.assertEqual(config["global_batch_size"], 192)
+        self.assertEqual(config["gradient_accumulation_steps"], 96)
         # Environment-specific pin is always dropped.
         self.assertNotIn("fa_version", config)
 
@@ -1053,7 +1092,7 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
             + "resume_from_checkpoint: /ckpt/full_scale_base\n"
             + "load_from_hf: true\n"
         )
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         config = self.load_output_yaml(8)
         self.assertNotIn("resume_from_checkpoint", config)
@@ -1065,7 +1104,7 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
         # it off instead of shipping a config that dies on the assert.  The
         # quoted "True" also exercises the loose YAML bool parsing.
         self.write_yaml(SOURCE_YAML + 'sharding_comm_group_call_opt: "True"\n')
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         config = self.load_output_yaml(8)
         self.assertEqual(config["expert_model_parallel_size"], 2)
@@ -1074,16 +1113,16 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
     def test_comm_group_call_opt_requires_the_muon_optimizer(self):
         # PaddleFormers' TrainingArguments asserts optim == muon whenever the
         # switch is on, so satisfying the EP/moe_sharding/TP conditions is not
-        # enough: 128 nodes with the frozen source dims give EP 64 (a multiple
-        # of 8), moe_sharding 2 and TP 1, yet adamw must still drop the flag.
+        # enough: 192 nodes with the frozen source dims give EP 64 (a multiple
+        # of 8), moe_sharding 3 and TP 1, yet adamw must still drop the flag.
         self.write_yaml(
             SOURCE_YAML
             + "optim: adamw\n"
             + 'sharding_comm_group_call_opt: "True"\n'
         )
-        ok, message = self.adapt(target_nodes=128, test_performance=True)
+        ok, message = self.adapt(target_nodes=192, test_performance=True)
         self.assertTrue(ok, message)
-        config = self.load_output_yaml(1024)
+        config = self.load_output_yaml(1536)
         self.assertEqual(config["sharding_comm_group_call_opt"], False)
 
     def test_comm_group_call_opt_survives_when_all_conditions_hold(self):
@@ -1094,9 +1133,9 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
             + "optim: muon\n"
             + "sharding_comm_group_call_opt: true\n"
         )
-        ok, message = self.adapt(target_nodes=128, test_performance=True)
+        ok, message = self.adapt(target_nodes=192, test_performance=True)
         self.assertTrue(ok, message)
-        config = self.load_output_yaml(1024)
+        config = self.load_output_yaml(1536)
         self.assertEqual(config["sharding_comm_group_call_opt"], True)
 
     def test_checkpoint_refs_survive_when_structure_is_unchanged(self):
@@ -1119,7 +1158,7 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
         # EP 64 -> 2 alone cannot reach 8 cards, but it lets PP stop at 4
         # instead of 2: shrinking PP also scales num_hidden_layers, VPP, the
         # empty tail and every per-layer list, so it goes last.
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         config = self.load_output_yaml(8)
         self.assertEqual(config["pipeline_model_parallel_size"], 4)
@@ -1131,7 +1170,9 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
         # building any interleaved schedule, so PP 2 leaves VPP no choice.
         # 4 cards leave no room for PP 4: C2 wants 4 % (PP x EP) == 0 and EP
         # cannot go below 2, so the joint tier lands on EP 2 / PP 2.
-        ok, message = self.adapt(target_nodes=1, cards_per_node=4)
+        ok, message = self.adapt(
+            target_nodes=1, cards_per_node=4, test_accuracy=True
+        )
         self.assertTrue(ok, message)
         config = self.load_output_yaml(4)
         self.assertEqual(config["pipeline_model_parallel_size"], 2)
@@ -1139,14 +1180,14 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
         self.assertIn("框架断言 VPP>1 需要 PP>2", message)
 
     def test_existing_output_dir_needs_force(self):
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
 
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertFalse(ok)
         self.assertIn("--force", message)
 
-        ok, message = self.adapt(target_nodes=1, force=True)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True, force=True)
         self.assertTrue(ok, message)
 
     def test_mtp_aware_layer_alignment(self):
@@ -1173,7 +1214,7 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
         )
         self.write_json(dict(MODEL_CONFIG, num_hidden_layers=43))
 
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         config = self.load_output_yaml(8)
         model_config = self.load_output_json(8)
@@ -1195,7 +1236,9 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
 
     def test_unchanged_keys_are_not_reported(self):
         ok, message = self.adapt(
-            target_nodes=1, auto_overrides={"max_steps": 1000000}
+            target_nodes=1,
+            test_accuracy=True,
+            auto_overrides={"max_steps": 1000000},
         )
         self.assertTrue(ok, message)
         # The value equals the source value, so nothing is logged for it.
@@ -1209,6 +1252,7 @@ class TestPerformanceSwitch(ConfigAdapterTestBase):
         ok, message = self.adapt(target_nodes=64, test_performance=True)
         self.assertTrue(ok, message)
         config = self.load_output_yaml(512)
+        # GBS follows the data-parallel width (96 -> 64); acc is frozen.
         self.assertEqual(config["global_batch_size"], 128)
         self.assertEqual(config["gradient_accumulation_steps"], 2)
         self.assertEqual(config["sharding_parallel_size"], 64)
@@ -1328,7 +1372,7 @@ class TestAutoOverrideRouting(ConfigAdapterTestBase):
 
     def test_key_only_in_yaml(self):
         ok, message = self.adapt(
-            target_nodes=1, auto_overrides={"max_steps": 10}
+            target_nodes=1, test_accuracy=True, auto_overrides={"max_steps": 10}
         )
         self.assertTrue(ok, message)
         self.assertEqual(self.load_output_yaml(8)["max_steps"], 10)
@@ -1336,7 +1380,9 @@ class TestAutoOverrideRouting(ConfigAdapterTestBase):
 
     def test_key_only_in_model_config_is_also_protected(self):
         ok, message = self.adapt(
-            target_nodes=1, auto_overrides={"n_routed_experts": 128}
+            target_nodes=1,
+            test_accuracy=True,
+            auto_overrides={"n_routed_experts": 128},
         )
         self.assertTrue(ok, message)
         # Routed to the JSON, and the EP shrink may not overwrite a --set.
@@ -1347,7 +1393,9 @@ class TestAutoOverrideRouting(ConfigAdapterTestBase):
         self.write_yaml(SOURCE_YAML + "shared_flag: 1\n")
         self.write_json({**MODEL_CONFIG, "shared_flag": 1})
         ok, message = self.adapt(
-            target_nodes=1, auto_overrides={"shared_flag": 2}
+            target_nodes=1,
+            test_accuracy=True,
+            auto_overrides={"shared_flag": 2},
         )
         self.assertTrue(ok, message)
         self.assertEqual(self.load_output_yaml(8)["shared_flag"], 2)
@@ -1355,7 +1403,9 @@ class TestAutoOverrideRouting(ConfigAdapterTestBase):
 
     def test_unknown_key_is_added_to_yaml(self):
         ok, message = self.adapt(
-            target_nodes=1, auto_overrides={"brand_new_field": 7}
+            target_nodes=1,
+            test_accuracy=True,
+            auto_overrides={"brand_new_field": 7},
         )
         self.assertTrue(ok, message)
         self.assertEqual(self.load_output_yaml(8)["brand_new_field"], 7)
@@ -1363,7 +1413,9 @@ class TestAutoOverrideRouting(ConfigAdapterTestBase):
 
     def test_new_model_config_field_needs_explicit_prefix(self):
         ok, message = self.adapt(
-            target_nodes=1, json_overrides={"brand_new_field": 7}
+            target_nodes=1,
+            test_accuracy=True,
+            json_overrides={"brand_new_field": 7},
         )
         self.assertTrue(ok, message)
         self.assertEqual(self.load_output_json(8)["brand_new_field"], 7)
@@ -1380,7 +1432,7 @@ flash_device_save_steps: 50
 """
 
     def test_both_switches_land_in_the_yaml(self):
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         output = self.load_output_yaml(8)
         # 768 source cards / (TP 1 * SEP 1 * PP 8 * CP 1) = 96 source ways.
@@ -1389,7 +1441,7 @@ flash_device_save_steps: 50
 
     def test_prerequisite_chain_is_disabled(self):
         self.write_yaml(SOURCE_YAML + self.PREREQUISITES)
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         output = self.load_output_yaml(8)
         self.assertIs(output["fuse_optimizer_states"], False)
@@ -1400,6 +1452,7 @@ flash_device_save_steps: 50
         self.write_yaml(SOURCE_YAML + self.PREREQUISITES)
         ok, message = self.adapt(
             target_nodes=1,
+            test_accuracy=True,
             auto_overrides={"tensorwise_offload_optimizer": False},
         )
         self.assertTrue(ok, message)
@@ -1412,7 +1465,7 @@ flash_device_save_steps: 50
 
     def test_no_switches_when_the_data_width_is_unchanged(self):
         # 96 target ways = the source's, so nothing is amplified.
-        ok, message = self.adapt(target_nodes=96)
+        ok, message = self.adapt(target_nodes=96, test_accuracy=True)
         self.assertTrue(ok, message)
         output = self.load_output_yaml(768)
         self.assertNotIn("debug_reeao_dataset_world_size", output)
@@ -1426,7 +1479,7 @@ flash_device_save_steps: 50
             if not line.startswith(("global_batch_size", "sharding_parallel"))
         )
         self.write_yaml(hidden)
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         output = self.load_output_yaml(8)
         # The base is the source's dense_sharding = EP 64 / (TP 1 * SEP 1).
@@ -1456,7 +1509,7 @@ class TestErrorPaths(ConfigAdapterTestBase):
 
     def test_shrink_without_a_model_config(self):
         self.write_yaml(SOURCE_YAML.replace("./model_dir", "./nope"))
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertFalse(ok)
         self.assertIn("model_config.json", message)
 
@@ -1467,7 +1520,7 @@ class TestErrorPaths(ConfigAdapterTestBase):
                 "gradient_accumulation_steps: 2", ""
             )
         )
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertFalse(ok)
         self.assertIn("无法推断源作业的卡数", message)
 
@@ -1500,7 +1553,9 @@ class TestErrorPaths(ConfigAdapterTestBase):
                 "expert_model_parallel_size: 1",
             )
         )
-        ok, message = self.adapt(target_nodes=1, cards_per_node=4)
+        ok, message = self.adapt(
+            target_nodes=1, cards_per_node=4, test_accuracy=True
+        )
         self.assertFalse(ok)
         self.assertIn("num_hidden_layers", message)
 
@@ -1553,7 +1608,7 @@ class TestPinnedFieldRejection(ConfigAdapterTestBase):
 
     def test_prefix_less_fa_version_pin_is_kept(self):
         ok, message = self.adapt(
-            target_nodes=1, auto_overrides={"fa_version": 4}
+            target_nodes=1, test_accuracy=True, auto_overrides={"fa_version": 4}
         )
         self.assertTrue(ok, message)
         self.assertEqual(self.load_output_yaml(8)["fa_version"], 4)
@@ -1561,7 +1616,7 @@ class TestPinnedFieldRejection(ConfigAdapterTestBase):
 
     def test_pinned_fa_version_is_kept(self):
         ok, message = self.adapt(
-            target_nodes=1, yaml_overrides={"fa_version": 4}
+            target_nodes=1, test_accuracy=True, yaml_overrides={"fa_version": 4}
         )
         self.assertTrue(ok, message)
         # The pin wins: the field is neither deleted nor reported as deleted.
@@ -1659,7 +1714,7 @@ class TestLayerFields(ConfigAdapterTestBase):
 
     def test_lists_are_truncated_with_the_layer_count(self):
         self._with_layer_fields([128, 128, 128, -2] * 16)
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         model_config = self.load_output_json(8)
         # 64 -> 32 layers, MTP entries kept at the tail.
@@ -1684,7 +1739,7 @@ class TestLayerFields(ConfigAdapterTestBase):
                 "compress_ratios": [128, 128, 128, -2] * 16 + [-2],
             }
         )
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         model_config = self.load_output_json(8)
         self.assertEqual(model_config["num_hidden_layers"], 32)
@@ -1709,7 +1764,7 @@ class TestLayerFields(ConfigAdapterTestBase):
                 "layer_types": ["full_attention"] * 64,
             }
         )
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         ratios = self.load_output_json(8)["csa_compress_ratios"]
         self.assertEqual(len(ratios), 33)
@@ -1720,19 +1775,19 @@ class TestLayerFields(ConfigAdapterTestBase):
     def test_refuses_when_an_attention_family_would_vanish(self):
         # Every -2 layer sits beyond the shrunk layer range.
         self._with_layer_fields([128] * 60 + [-2] * 4)
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertFalse(ok)
         self.assertIn("丢掉注意力类型", message)
 
     def test_refuses_when_the_source_lists_are_inconsistent(self):
         self.write_json({**MODEL_CONFIG, "csa_compress_ratios": [128] * 10})
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertFalse(ok)
         self.assertIn("不自洽", message)
 
     def test_scalar_forms_are_left_alone(self):
         self.write_json({**MODEL_CONFIG, "window_attn_skip_freq": 4})
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         self.assertEqual(self.load_output_json(8)["window_attn_skip_freq"], 4)
 
@@ -1749,7 +1804,7 @@ class TestLayerFields(ConfigAdapterTestBase):
                 "layer_types": ["full_attention"] * 64,
             }
         )
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         model_config = self.load_output_json(8)
         self.assertEqual(model_config["num_hidden_layers"], 32)
@@ -1762,14 +1817,16 @@ class TestFailureLeavesSourcesUntouched(ConfigAdapterTestBase):
     """Nothing is written until every check has passed."""
 
     def test_batch_failure_does_not_touch_either_source(self):
-        # 1537 * 8 / 768 is not an integer, so batch scaling fails *after*
-        # the model structure has been planned.
+        # 193 * 64 / 96 is not an integer, so GBS scaling fails *after* the
+        # (frozen) planning has passed -- nothing may have been written.
         self.write_yaml(
             SOURCE_YAML.replace(
                 "global_batch_size: 192", "global_batch_size: 193"
             )
         )
-        ok, message = self.adapt(target_nodes=1, in_place=True)
+        ok, message = self.adapt(
+            target_nodes=64, test_performance=True, in_place=True
+        )
         self.assertFalse(ok)
         self.assertIn("无法整除", message)
         # Source model_config.json keeps its original structure ...
@@ -1787,7 +1844,7 @@ class TestFailureLeavesSourcesUntouched(ConfigAdapterTestBase):
                 "global_batch_size: 192", "global_batch_size: 193"
             )
         )
-        ok, _message = self.adapt(target_nodes=1)
+        ok, _message = self.adapt(target_nodes=64, test_performance=True)
         self.assertFalse(ok)
         self.assertFalse((self.output_dir / "model_config_separated").exists())
 
@@ -1818,7 +1875,7 @@ muon_configs:
 
     def test_nested_block_is_not_reindented(self):
         self.write_yaml(SOURCE_YAML + self.NESTED)
-        ok, message = self.adapt(target_nodes=1)
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
         text = (self.output_dir / "source_adapted_8cards.yaml").read_text(
             encoding="utf-8"
@@ -1876,7 +1933,9 @@ class TestGeneratedPaths(ConfigAdapterTestBase):
     def test_absolute_when_output_escapes_the_yaml_dir(self):
         outside = Path(tempfile.mkdtemp())
         try:
-            ok, message = self.adapt(target_nodes=1, output_dir=outside)
+            ok, message = self.adapt(
+                target_nodes=1, test_accuracy=True, output_dir=outside
+            )
             self.assertTrue(ok, message)
             path = YamlWriter().load(outside / "source_adapted_8cards.yaml")[
                 "model_name_or_path"
@@ -1913,12 +1972,14 @@ class TestCli(ConfigAdapterTestBase):
         return code, buffer.getvalue()
 
     def test_target_without_any_switch_still_adapts(self):
+        # 64 nodes is the frozen-compatible scale of the source dims: the
+        # default may not shrink, so an incompatible target would be refused.
         code, out = self._run(
             [
                 "--input",
                 str(self.yaml_path),
                 "--target-nodes",
-                "1",
+                "64",
                 "--output-dir",
                 str(self.output_dir),
             ]
@@ -1965,6 +2026,142 @@ class TestCli(ConfigAdapterTestBase):
         text = patch.read_text(encoding="utf-8")
         self.assertIn("pipeline_model_parallel_size", text)
         self.assertIn("model_config.json", text)
+
+
+class TestScaleSeqLength(ConfigAdapterTestBase):
+    """--scale-seq-length rewrites max_seq_length and scales CP with it."""
+
+    #: 32 cards: sharding 32, CP 2 -> dataset_world_size 16, GBS 32.
+    SEQ_YAML = """\
+model_name_or_path: ./model_dir
+max_seq_length: 8192
+global_batch_size: 32
+per_device_train_batch_size: 1
+gradient_accumulation_steps: 2
+sharding_parallel_size: 32
+data_parallel_size: 1
+tensor_model_parallel_size: 1
+pipeline_model_parallel_size: 1
+context_parallel_size: 2
+max_steps: 100
+"""
+
+    def setUp(self):
+        super().setUp()
+        self.write_yaml(self.SEQ_YAML)
+
+    def test_scale_up_scales_cp_by_the_same_ratio(self):
+        ok, message = self.adapt(2, scale_seq_length=16384)
+        self.assertTrue(ok, message)
+        out = self.load_output_yaml(16)
+        self.assertEqual(out["max_seq_length"], 16384)
+        self.assertEqual(out["context_parallel_size"], 4)
+        # sharding = 16 / (TP*SEP*PP) = 16; C4: 16 % CP(4) == 0.
+        self.assertEqual(out["sharding_parallel_size"], 16)
+        self.assertIn("CP 2 -> 4", message)
+
+    def test_scale_down_shrinks_cp_with_a_floor_of_one(self):
+        ok, message = self.adapt(2, scale_seq_length=2048)
+        self.assertTrue(ok, message)
+        out = self.load_output_yaml(16)
+        self.assertEqual(out["max_seq_length"], 2048)
+        self.assertEqual(out["context_parallel_size"], 1)
+
+    def test_equal_length_keeps_cp_and_warns(self):
+        ok, message = self.adapt(2, scale_seq_length=8192)
+        self.assertTrue(ok, message)
+        out = self.load_output_yaml(16)
+        self.assertEqual(out["max_seq_length"], 8192)
+        self.assertEqual(out["context_parallel_size"], 2)
+        self.assertIn("保持不变", message)
+
+    def test_non_integer_ratio_is_rejected(self):
+        ok, message = self.adapt(2, scale_seq_length=12000)
+        self.assertFalse(ok)
+        self.assertIn("整数倍", message)
+
+    def test_missing_source_seq_field_is_rejected(self):
+        self.write_yaml(self.SEQ_YAML.replace("max_seq_length: 8192\n", ""))
+        ok, message = self.adapt(2, scale_seq_length=16384)
+        self.assertFalse(ok)
+        self.assertIn("max_seq_length", message)
+
+    def test_conflicts_with_a_set_override(self):
+        ok, message = self.adapt(
+            2,
+            scale_seq_length=16384,
+            auto_overrides={"max_seq_length": 999},
+        )
+        self.assertFalse(ok)
+        self.assertIn("冲突", message)
+
+    def test_sep_and_scaled_cp_cannot_coexist(self):
+        self.write_yaml(
+            self.SEQ_YAML.replace(
+                "context_parallel_size: 2", "sep_parallel_size: 2"
+            )
+        )
+        ok, message = self.adapt(2, scale_seq_length=16384)
+        self.assertFalse(ok)
+        self.assertIn("C5", message)
+
+    def test_warns_when_beyond_max_position_embeddings(self):
+        data = dict(MODEL_CONFIG)
+        data["max_position_embeddings"] = 8192
+        self.write_json(data)
+        ok, message = self.adapt(2, scale_seq_length=16384)
+        self.assertTrue(ok, message)
+        self.assertIn("max_position_embeddings", message)
+
+    def test_performance_freeze_still_applies_the_scaled_cp(self):
+        # --test-performance freezes the dims *after* the explicit seq
+        # scaling: CP 2 -> 4 must survive the frozen planner.
+        ok, message = self.adapt(
+            2, test_performance=True, scale_seq_length=16384
+        )
+        self.assertTrue(ok, message)
+        out = self.load_output_yaml(16)
+        self.assertEqual(out["context_parallel_size"], 4)
+
+    def test_cli_requires_target_nodes(self):
+        buffer, err = io.StringIO(), io.StringIO()
+        with (
+            contextlib.redirect_stdout(buffer),
+            contextlib.redirect_stderr(err),
+        ):
+            code = main(
+                [
+                    "--input",
+                    str(self.yaml_path),
+                    "--scale-seq-length",
+                    "16384",
+                ]
+            )
+        self.assertEqual(code, 1)
+        self.assertIn("--target-nodes", err.getvalue())
+
+    def test_cli_passes_the_value_through(self):
+        buffer = io.StringIO()
+        with (
+            contextlib.redirect_stdout(buffer),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            code = main(
+                [
+                    "--input",
+                    str(self.yaml_path),
+                    "--target-nodes",
+                    "2",
+                    "--scale-seq-length",
+                    "16384",
+                    "--output-dir",
+                    str(self.output_dir),
+                ]
+            )
+        self.assertEqual(code, 0, buffer.getvalue())
+        out = self.load_output_yaml(16)
+        self.assertEqual(out["max_seq_length"], 16384)
+        self.assertEqual(out["context_parallel_size"], 4)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -2067,6 +2067,25 @@ max_steps: 100
         self.assertEqual(out["max_seq_length"], 2048)
         self.assertEqual(out["context_parallel_size"], 1)
 
+    def test_non_divisible_cp_is_ceiled_so_the_slice_never_grows(self):
+        # Regression for the P1 review finding: with CP=3 and a 2x shorter
+        # sequence, flooring CP to 1 would grow the per-card slice from
+        # 8192/3 (~2731) to 4096 and could OOM.  The ceil (CP=2) keeps the
+        # slice at 4096/2 = 2048 <= 2731.
+        self.write_yaml(
+            self.SEQ_YAML.replace(
+                "sharding_parallel_size: 32", "sharding_parallel_size: 24"
+            )
+            .replace("context_parallel_size: 2", "context_parallel_size: 3")
+            .replace("global_batch_size: 32", "global_batch_size: 16")
+        )
+        ok, message = self.adapt(1, scale_seq_length=4096)
+        self.assertTrue(ok, message)
+        out = self.load_output_yaml(8)
+        self.assertEqual(out["max_seq_length"], 4096)
+        self.assertEqual(out["context_parallel_size"], 2)
+        self.assertIn("取上整", message)
+
     def test_equal_length_keeps_cp_and_warns(self):
         ok, message = self.adapt(2, scale_seq_length=8192)
         self.assertTrue(ok, message)


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
New features

### Description

Cherry-pick of the config_adapter upgrade to `release/0.4`.

Merged in dev: #1985

- **Add `--scale-seq-length N`**: overrides `max_seq_length` and scales `context_parallel_size` by the same ratio, so the per-card sequence slice (and activation memory) stays at the source level and long sequences do not OOM. Both rewritten fields are pinned exactly like `--set` values. Requires `--target-nodes`; validates C4/C5 and warns when N exceeds `max_position_embeddings`.
- **Freeze parallelism by default**: shrinking EP/PP rescales the expert/layer count, i.e. changes the model structure, so it is no longer a silent default. Only `--test-accuracy` may shrink; the default and `--test-performance` require the target scale to be compatible with the source parallelism (invalid targets get an error listing the valid node counts).
- **EP floor honors C3**: when `TP*SEP > 2`, EP shrinks to the smallest valid multiple of `TP*SEP` instead of 2.
- Batch strategies unchanged: default/`--test-performance` use `scale_batch` (acc frozen, GBS follows the data-parallel width); `--test-accuracy` alone uses `scale_accumulation` (GBS kept, acc scaled up).
- CLI help, README and unit tests updated (182 tests pass on release/0.4; `ruff` clean).
- Verified against all release YAMLs (ERNIE-5.1 / ERNIELite / DeepSeek-V4-Flash / GLM-4.5-Air / MiMo-V2-Flash).

### 是否引起精度变化
否
