### PR TITLE
Support FA4 global sliding window and big-headdim deterministic

### DIFF
--- a/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
+++ b/packages/paddlefleet_ops/src/paddlefleet_ops/flash_mask_facade.py
@@ -84,6 +84,39 @@ def _reset_fa3_backend() -> None:
     FLASHMASK_FA3_USE_CUTEDSL = True
 
 
+def _cutedsl_hdim_ok(fa_version: int, head_dim: int, head_dim_v: int) -> bool:
+    """Whether the cutedsl kernels serve ``(head_dim, head_dim_v)``.
+
+    One whitelist for both callers in :func:`_dispatch_fa_version` -- the FA4
+    branch is reached with ``FLASHMASK_FA3_USE_CUTEDSL`` either way (FA4 is
+    cutedsl-only), so the two used to hold the same literal pairs twice.
+
+    ``deterministic`` is not a parameter: no pair in this whitelist is
+    deterministic-only. FA3 on cutedsl has an ordered-accumulation backward, and
+    FA4's big-head-dim backward gained an ordered (semaphore-serialised)
+    reduction in flash-attention ``5007a05``.
+
+    Args:
+        fa_version: 3 or 4. Only FA4 serves the big head dims.
+        head_dim: Query/Key head dim.
+        head_dim_v: Value head dim, already defaulted by the caller.
+
+    Returns:
+        ``True`` when the pair is served; ``False`` means degrade to FA2.
+    """
+    if (
+        (head_dim <= 128 and head_dim_v <= 128)
+        or (head_dim == 192 and head_dim_v == 128)
+        or (head_dim == 256 and head_dim_v == 256)
+    ):
+        return True
+    # FA4 additionally supports larger head dims, via its big-head-dim backward.
+    return fa_version == 4 and (
+        (head_dim == 512 and head_dim_v == 512)
+        or (head_dim == 576 and head_dim_v == 512)
+    )
+
+
 def _dispatch_fa_version(
     head_dim: int,
     head_dim_v: int | None = None,
@@ -102,29 +135,19 @@ def _dispatch_fa_version(
         the cutedsl backend FA3 needs no such degrade -- its backward has an
         ordered-accumulation variant, so deterministic holds for every head dim
         in the cutedsl whitelist below.
-      * FA4 is only used when both ``hdim_ok`` and ``mask_ok`` hold:
-
-        - ``hdim_ok``: one of
-          * ``head_dim <= 128`` and ``head_dim_v <= 128``
-          * ``head_dim == 192`` and ``head_dim_v == 128``
-          * ``head_dim == 256`` and ``head_dim_v == 256``
-          * ``head_dim == 512`` and ``head_dim_v == 512``, unless deterministic
-            is required
-          * ``head_dim == 576`` and ``head_dim_v == 512``, unless deterministic
-            is required -- both of these pairs take FA4's big-head-dim backward,
-            which has no ordered-accumulation variant.
-        - ``mask_ok``: ``startend_row_indices is None`` or
-          ``startend_row_indices.shape[-1] != 4``
-
-        When ``startend_row_indices`` is not provided (``None``), ``mask_ok``
-        is treated as ``True`` -- this covers the ``flash_attention`` path
-        which has no mask tensor. Aligned with flash-attention ``interface.py``.
+      * FA3 and FA4 on cutedsl are used only for the head-dim pairs in
+        :func:`_cutedsl_hdim_ok`; every other pair degrades to FA2. That
+        whitelist does not narrow under ``FLAGS_cudnn_deterministic`` -- see the
+        note there.
 
     Args:
         head_dim: Query/Key head dim (always equal).
         head_dim_v: Value head dim. Defaults to ``head_dim`` when not provided.
-        startend_row_indices: FlashMask indices tensor. Pass ``None`` (default)
-            for the plain ``flash_attention`` path where no mask check is needed.
+        startend_row_indices: Accepted and ignored, so the flashmask path can
+            hand over what it already has. FA4 used to refuse a 4-column
+            (global sliding window) mask and this function degraded to FA2 for
+            it; since flash-attention ``5007a05`` FA4 serves ``num_vec == 4``,
+            so the mask takes no part in dispatch.
 
     Returns:
         The FlashAttention version to use (2, 3 or 4).
@@ -144,60 +167,19 @@ def _dispatch_fa_version(
         if not is_flash_mask_available():
             return 2
 
+    _head_dim_v = head_dim_v if head_dim_v is not None else head_dim
+
     if FLASHMASK_FA3_USE_CUTEDSL:
         if fa_version in (3, 4):
-            _head_dim_v = head_dim_v if head_dim_v is not None else head_dim
-            cutedsl_hdim_ok = (
-                (head_dim <= 128 and _head_dim_v <= 128)
-                or (head_dim == 192 and _head_dim_v == 128)
-                or (head_dim == 256 and _head_dim_v == 256)
-            )
-            # FA4 additionally supports larger head dims (non-deterministic only)
-            if fa_version == 4 and not deterministic:
-                cutedsl_hdim_ok = cutedsl_hdim_ok or (
-                    (head_dim == 512 and _head_dim_v == 512)
-                    or (head_dim == 576 and _head_dim_v == 512)
-                )
-            if not cutedsl_hdim_ok:
+            if not _cutedsl_hdim_ok(fa_version, head_dim, _head_dim_v):
                 return 2
-            # Only FA4 is restricted here: the FA4 kernel does not serve a
-            # 4-column flashmask, while FA3 on cutedsl accepts it. Not a missing
-            # FA3 branch.
-            fa4_mask_ok = (
-                startend_row_indices is None
-                or startend_row_indices.shape[-1] != 4
-            )
-            if fa_version == 4:
-                if not fa4_mask_ok:
-                    return 2
     else:
         if fa_version == 3:
             if deterministic and head_dim > 128:
                 return 2
 
         if fa_version == 4:
-            _head_dim_v = head_dim_v if head_dim_v is not None else head_dim
-            fa4_hdim_ok = (
-                (head_dim <= 128 and _head_dim_v <= 128)
-                or (head_dim == 192 and _head_dim_v == 128)
-                or (head_dim == 256 and _head_dim_v == 256)
-                # Both of these exceed 256 and so take FA4's big-head-dim backward,
-                # which asserts ``not deterministic`` (``flash_mask/cute/
-                # interface.py``: ``is_bigd_bwd`` -> "deterministic reduction is not
-                # supported by big-headdim bwd"). Degrade instead of aborting, the
-                # same way FA3 degrades above.
-                or (
-                    head_dim == 512 and _head_dim_v == 512 and not deterministic
-                )
-                or (
-                    head_dim == 576 and _head_dim_v == 512 and not deterministic
-                )
-            )
-            fa4_mask_ok = (
-                startend_row_indices is None
-                or startend_row_indices.shape[-1] != 4
-            )
-            if not (fa4_hdim_ok and fa4_mask_ok):
+            if not _cutedsl_hdim_ok(4, head_dim, _head_dim_v):
                 return 2
 
     return fa_version

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -1895,10 +1895,12 @@ class MQALatentAttention(FleetLayer):
         process-global flags, so all three inputs go into the message -- the
         head-dim pair alone rarely explains the answer. In particular
         ``FLAGS_flash_attn_version`` must be 4, which production sets from the
-        compute capability (``TrainingArguments.__post_init__``, SM100 -> 4), and
-        ``FLAGS_cudnn_deterministic`` must be off, since FA4's big-head-dim
-        backward has no ordered-accumulation variant
-        (``flash_mask/cute/interface.py:1238,1249``).
+        compute capability (``TrainingArguments.__post_init__``, SM100 -> 4).
+        ``FLAGS_cudnn_deterministic`` is *not* a rejection condition: FA4's
+        big-head-dim backward gained an ordered (semaphore-serialised) reduction
+        in flash-attention ``5007a05``, so this pair stays on FA4 under
+        determinism. Its value is still reported, because it is one of the two
+        flags the answer is derived from.
 
         ``get_fa_version`` answers from flags alone and never checks that an FA4
         backend exists, so the extension's availability is a separate condition
@@ -1931,10 +1933,8 @@ class MQALatentAttention(FleetLayer):
                 f"{flags['FLAGS_cudnn_deterministic']}. Run on a device whose "
                 "compute capability selects FA4 (SM100+, which is also what the "
                 "sparse phase-3 kernels require) with the flash_mask (cute) "
-                "extension built into paddlefleet_ops, leave "
-                "FLAGS_flash_attn_version at the value the trainer derives, and "
-                "keep FLAGS_cudnn_deterministic off -- FA4 has no deterministic "
-                "backward for this head-dim pair."
+                "extension built into paddlefleet_ops, and leave "
+                "FLAGS_flash_attn_version at the value the trainer derives."
             )
 
     def _dense_attn(

--- a/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_7.py
+++ b/tests/single_card_tests/ai_edited_test/recompute/test_ai_flash_attn_7.py
@@ -196,6 +196,87 @@ class TestGetFAVersionDeterministic(unittest.TestCase):
         result = get_fa_version(64)
         self.assertEqual(result, 3)
 
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", True)
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+        lambda: True,
+    )
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_device",
+        return_value="gpu:0",
+    )
+    @patch("paddlefleet_ops.flash_mask_facade.paddle.base.framework.get_flags")
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_flags",
+        return_value={"FLAGS_cudnn_deterministic": True},
+    )
+    def test_deterministic_keeps_4_for_the_big_head_dims(
+        self, mock_get_flags, mock_base_flags, mock_device
+    ):
+        """The big-head-dim pairs are no longer deterministic-only degrades.
+
+        FA4's big-head-dim backward used to accumulate dQ / dK / dV with
+        unordered ``red.global.add`` and asserted ``not deterministic``; since
+        flash-attention ``5007a05`` a global semaphore pins the reduction order,
+        so both pairs stay on FA4 under ``FLAGS_cudnn_deterministic``.
+        """
+        mock_base_flags.return_value = {"FLAGS_flash_attn_version": 4}
+        self.assertEqual(get_fa_version(512, 512), 4)
+        self.assertEqual(get_fa_version(576, 512), 4)
+
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", True)
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+        lambda: True,
+    )
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_device",
+        return_value="gpu:0",
+    )
+    @patch("paddlefleet_ops.flash_mask_facade.paddle.base.framework.get_flags")
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_flags",
+        return_value={"FLAGS_cudnn_deterministic": True},
+    )
+    def test_head_dim_pair_outside_the_whitelist_still_degrades(
+        self, mock_get_flags, mock_base_flags, mock_device
+    ):
+        """The whitelist widened for two pairs, it did not become open-ended."""
+        mock_base_flags.return_value = {"FLAGS_flash_attn_version": 4}
+        self.assertEqual(get_fa_version(384, 384), 2)
+
+
+class TestGetFAVersionFourColumnMask(unittest.TestCase):
+    """A 4-column FlashMask no longer decides the version.
+
+    The FA4 kernel used to serve only ``num_vec <= 2``, so a 4-column mask (the
+    global sliding window layout) degraded to FA2 even for a whitelisted
+    head-dim pair. flash-attention ``5007a05`` added ``num_vec == 4``, and the
+    mask argument is now accepted and ignored -- worth pinning, because the
+    argument is still in the signature and reads as if it mattered.
+    """
+
+    @patch.object(flash_mask_facade, "FLASHMASK_FA3_USE_CUTEDSL", True)
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.is_flash_mask_available",
+        lambda: True,
+    )
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_device",
+        return_value="gpu:0",
+    )
+    @patch("paddlefleet_ops.flash_mask_facade.paddle.base.framework.get_flags")
+    @patch(
+        "paddlefleet_ops.flash_mask_facade.paddle.get_flags",
+        return_value={"FLAGS_cudnn_deterministic": False},
+    )
+    def test_four_column_mask_keeps_4(
+        self, mock_get_flags, mock_base_flags, mock_device
+    ):
+        mock_base_flags.return_value = {"FLAGS_flash_attn_version": 4}
+        mask = paddle.zeros([1, 2, 8, 4], dtype="int32")
+        self.assertEqual(get_fa_version(128, 128, mask), 4)
+
 
 class TestGetFAVersionNonDeterministic(unittest.TestCase):
     """Tests for get_fa_version with non-deterministic mode."""
@@ -357,7 +438,6 @@ class TestFacadeEntryRouting(unittest.TestCase):
         self.k = paddle.zeros(self.shape, dtype="float32")
         self.v = paddle.zeros(self.shape, dtype="float32")
         self.out = paddle.zeros(self.shape, dtype="float32")
-        # 1 column, so the FA4 4-column mask restriction never applies here.
         self.mask = paddle.zeros([1, 2, 4, 1], dtype="int32")
 
     def test_flash_attention_routes_to_cpp_backend(self):

--- a/tests/single_card_tests/transformer/test_flash_mask_sink.py
+++ b/tests/single_card_tests/transformer/test_flash_mask_sink.py
@@ -285,15 +285,13 @@ class TestCuteFlashmaskSink(unittest.TestCase):
     def test_small_head_dim_sink(self):
         self._run(2, 128, 4, 4, 64, causal=False, use_sink=True)
 
-    def test_fixed_sink_backward_returns_dsink_slot(self):
-        # A FIXED (stop_gradient=True) bf16 sink is a valid forward input, but
-        # FlashMaskFunc.backward chooses its return arity from
-        # ``learnable_sink is None`` alone (interface.py:1770-1772) -- it does
-        # NOT consult stop_gradient. So a non-None fixed sink makes backward
-        # return the 4-tuple (dq, dk, dv, dsink); Paddle's PyLayer then rejects
-        # it because the sink forward input has stop_gradient=True and its slot
-        # must be None. We assert the forward is still numerically correct and
-        # that backward raises this ValueError, documenting the limitation.
+    def test_fixed_sink_backward_skips_dsink_slot(self):
+        # A FIXED (stop_gradient=True) bf16 sink is a valid forward input, and
+        # Paddle requires the PyLayer's backward to return None at that slot.
+        # FlashMaskFunc records which inputs want a gradient in its forward
+        # (``ctx.needs_grad``) and honours it, so backward returns the 4-tuple
+        # (dq, dk, dv, None) rather than an unconditional dsink: q/k/v get their
+        # gradients and the frozen sink receives nothing.
         from paddlefleet_ops.flash_mask.cute.interface import (
             flashmask_attention,
         )
@@ -328,11 +326,16 @@ class TestCuteFlashmaskSink(unittest.TestCase):
             (out - out_ref).abs().max().item(), 2e-2 + fwd_atol
         )
 
-        with self.assertRaises(ValueError):
-            out.backward(paddle.randn(out.shape, dtype=out.dtype))
+        out.backward(paddle.randn(out.shape, dtype=out.dtype))
+        for name, t in (("dq", q), ("dk", k), ("dv", v)):
+            self.assertIsNotNone(t.grad, f"{name} missing")
+        self.assertTrue(sink.stop_gradient)
+        self.assertIsNone(sink.grad)
 
-    def test_sink_dtype_assert(self):
-        # The cute kernel asserts learnable_sink is bf16; fp32 must raise.
+    def test_sink_dtype_contract(self):
+        # flash-attention 5007a05 ("fp16/fp32 sink") widened the bf16-only
+        # assert to _LEARNABLE_SINK_DTYPES = (fp16, bf16, fp32); anything else
+        # still raises.
         from paddlefleet_ops.flash_mask.cute.interface import (
             flashmask_attention,
         )
@@ -342,8 +345,21 @@ class TestCuteFlashmaskSink(unittest.TestCase):
         q = paddle.randn([b, s, h, d], dtype=DTYPE)
         k = paddle.randn([b, s, h, d], dtype=DTYPE)
         v = paddle.randn([b, s, h, d], dtype=DTYPE)
-        sink_fp32 = paddle.zeros([h], dtype=paddle.float32)
         idx = _startend_row_indices(b, s, causal=True)
+
+        # fp32 is now a supported sink dtype: the forward runs and stays finite.
+        out = flashmask_attention(
+            q,
+            k,
+            v,
+            startend_row_indices=idx,
+            causal=True,
+            learnable_sink=paddle.zeros([h], dtype=paddle.float32),
+        )
+        self.assertEqual(list(out.shape), [b, s, h, d])
+        self.assertTrue(paddle.isfinite(out.astype("float32")).all().item())
+
+        # fp64 is not.
         with self.assertRaises(AssertionError):
             flashmask_attention(
                 q,
@@ -351,7 +367,7 @@ class TestCuteFlashmaskSink(unittest.TestCase):
                 v,
                 startend_row_indices=idx,
                 causal=True,
-                learnable_sink=sink_fp32,
+                learnable_sink=paddle.zeros([h], dtype=paddle.float64),
             )
 
 
@@ -559,6 +575,11 @@ class TestDotProductAttentionSinkForward(unittest.TestCase):
         if softmax_type == "learnable":
             self.assertIsNotNone(attn.softmax_offset.grad)
             self.assertEqual(attn.softmax_offset.grad.dtype, paddle.bfloat16)
+        elif softmax_type == "off-by-one":
+            # A fixed offset must stay frozen and gradient-free: FlashMaskFunc
+            # returns None at its slot instead of an unconditional dsink.
+            self.assertTrue(attn.softmax_offset.stop_gradient)
+            self.assertIsNone(attn.softmax_offset.grad)
 
     def test_forward_vanilla(self):
         self._run("vanilla")
@@ -567,10 +588,10 @@ class TestDotProductAttentionSinkForward(unittest.TestCase):
         self._run("learnable")
 
     def test_forward_offbyone(self):
-        # off-by-one builds an fp32 zeros offset; the cute kernel asserts bf16,
-        # so this path is expected to raise on the fa4 sink branch.
-        with self.assertRaises(AssertionError):
-            self._run("off-by-one")
+        # off-by-one builds a fixed fp32 zeros offset. fp32 sinks are accepted
+        # since flash-attention 5007a05, and the frozen sink no longer trips the
+        # PyLayer's None-slot contract, so this runs end to end.
+        self._run("off-by-one")
 
 
 @unittest.skipUnless(_SINK_AVAILABLE, _SKIP_REASON)
@@ -658,31 +679,23 @@ class TestRefinedRecomputeFlashMaskSink(unittest.TestCase):
             max_diff, 1e-2, f"rr fwd max diff {max_diff} vs non-rr too large"
         )
 
-        # A fixed (stop_gradient) sink makes the non-rr flashmask_attention
-        # PyLayer return a dsink slot that Paddle rejects on backward (a known
-        # limitation of that op, covered by test_fixed_sink_backward_returns_
-        # dsink_slot). So only run the reference backward when the sink is not a
-        # fixed tensor; the rr backward is always exercised below.
-        ref_backward_safe = not (use_sink and not sink_trainable)
-
+        # A fixed (stop_gradient) sink used to make the non-rr
+        # flashmask_attention PyLayer return a dsink slot that Paddle rejected on
+        # backward, so the reference backward had to be skipped there. The op now
+        # returns None at that slot, so both paths are always comparable.
         g = paddle.randn(out.shape, dtype=out.dtype)
         out.backward(g.clone())
-        if ref_backward_safe:
-            out_ref.backward(g.clone())
-            for name, a, ref in (
-                ("dq", q.grad, q_ref.grad),
-                ("dk", k.grad, k_ref.grad),
-                ("dv", v.grad, v_ref.grad),
-            ):
-                self.assertIsNotNone(a, f"{name} grad is None")
-                diff = (a - ref).abs().max().item()
-                self.assertLessEqual(
-                    diff, 2e-2, f"rr {name} max diff {diff} vs non-rr too large"
-                )
-        else:
-            # Still assert the rr backward produced q/k/v grads.
-            for name, a in (("dq", q.grad), ("dk", k.grad), ("dv", v.grad)):
-                self.assertIsNotNone(a, f"{name} grad is None")
+        out_ref.backward(g.clone())
+        for name, a, ref in (
+            ("dq", q.grad, q_ref.grad),
+            ("dk", k.grad, k_ref.grad),
+            ("dv", v.grad, v_ref.grad),
+        ):
+            self.assertIsNotNone(a, f"{name} grad is None")
+            diff = (a - ref).abs().max().item()
+            self.assertLessEqual(
+                diff, 2e-2, f"rr {name} max diff {diff} vs non-rr too large"
+            )
 
         if use_sink and sink_trainable:
             self.assertIsNotNone(sink.grad)
@@ -695,8 +708,9 @@ class TestRefinedRecomputeFlashMaskSink(unittest.TestCase):
                 f"rr dsink max diff {sink_diff} vs non-rr too large",
             )
         elif use_sink and not sink_trainable:
-            # Fixed sink is stop_gradient -> rr returns no sink grad.
+            # Fixed sink is stop_gradient -> neither path returns a sink grad.
             self.assertIsNone(sink.grad)
+            self.assertIsNone(sink_ref.grad)
 
     def test_rr_causal_trainable_sink(self):
         self._run(causal=True, use_sink=True)

--- a/tests/single_card_tests/transformer/test_hybrid_mla_warmup_dense_fa4.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_warmup_dense_fa4.py
@@ -241,14 +241,13 @@ class TestBackendSelection(unittest.TestCase):
             _forward(module, tensors, row_end, w_v)
         return calls
 
-    def _assert_forward_refuses(self, module, fa_version=4, deterministic=0):
+    def _assert_forward_refuses(self, module, fa_version=4):
         """The forward must raise, and must do so before touching a backend."""
         seqlen = 256
         row_end = _row_end([seqlen], seqlen)
         tensors, w_v = _inputs(seqlen)
         with (
             _flash_attn_version(fa_version),
-            _cudnn_deterministic(deterministic),
             _backend_spy(module) as calls,
             self.assertRaisesRegex(RuntimeError, "requires FA4"),
         ):
@@ -309,37 +308,43 @@ class TestBackendSelection(unittest.TestCase):
         ):
             module._assert_dense_fa4(576, 511, row_end)
 
-    def test_deterministic_raises(self):
-        """(576, 512) has no deterministic FA4 backward.
+    def test_deterministic_is_not_a_rejection_condition(self):
+        """``FLAGS_cudnn_deterministic`` keeps (576, 512) on FA4.
 
-        FA4 solves it with the big-head-dim kernel, which asserts
-        ``not deterministic`` (``flash_mask/cute/interface.py:1238,1249``), so
-        ``get_fa_version`` degrades the pair under ``FLAGS_cudnn_deterministic``.
-        For these phases that degradation is not usable, and a Python error
-        naming the flag is more actionable than the kernel's own assert firing in
-        the middle of a backward.
+        It used to degrade the pair: FA4 serves it with the big-head-dim
+        backward, which accumulated dQ / dK / dV with unordered
+        ``red.global.add`` and asserted ``not deterministic``. flash-attention
+        ``5007a05`` pins that order with a global semaphore, so the pair stays
+        FA4 and the layer has nothing left to refuse. Pinned because the flag is
+        still one of the two inputs ``get_fa_version`` reads, and a re-tightening
+        on either side would otherwise surface as a mid-backward failure.
         """
         module = _module()
         row_end = _row_end([256], 256)
-        with (
-            _flash_attn_version(4),
-            _cudnn_deterministic(1),
-            self.assertRaisesRegex(RuntimeError, "cudnn_deterministic"),
-        ):
-            module._assert_dense_fa4(576, 512, row_end)
-        # Nothing else about the layer changed: the same call is fine again
-        # once determinism is off.
+        with _flash_attn_version(4), _cudnn_deterministic(1):
+            self.assertIsNone(module._assert_dense_fa4(576, 512, row_end))
         with _flash_attn_version(4), _cudnn_deterministic(0):
             self.assertIsNone(module._assert_dense_fa4(576, 512, row_end))
 
-    def test_deterministic_forward_raises_before_the_backward(self):
-        """The error has to arrive in the forward, not in the backward.
+    def test_deterministic_forward_still_takes_the_dense_path(self):
+        """The whole forward, not just the assertion, survives determinism.
 
-        Reaching the kernel's own ``assert not deterministic`` would mean a step
-        that had already spent its forward, with a message that names neither
-        the layer nor the flag.
+        ``_assert_dense_fa4`` is only one of two places the flag could bite; the
+        forward also has to reach ``_dense_attn`` rather than a substituted
+        backend, so the spy is what decides this rather than the absence of a
+        raise.
         """
-        self._assert_forward_refuses(_module(), deterministic=1)
+        seqlen = 256
+        module = _module()
+        row_end = _row_end([seqlen], seqlen)
+        tensors, w_v = _inputs(seqlen)
+        with (
+            _flash_attn_version(4),
+            _cudnn_deterministic(1),
+            _backend_spy(module) as calls,
+        ):
+            _forward(module, tensors, row_end, w_v)
+        self.assertEqual(calls, ["dense"])
 
     def test_missing_flash_mask_extension_raises(self):
         """FA4 as a flag value is not FA4 as a backend.


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | User Experience | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
New features

### Description
<!-- Describe what you’ve done -->
1. fa4 支持 d576/dv512 d512/dv512 的确定性
2. fa4 支持 global sliding window
3. fa4 sink 支持 fp32/bf16/fp16

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
是