### PR TITLE
Fix fused_h_res_h_post_bda recompute trigger

### DIFF
--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -888,7 +888,9 @@ class HyperConnectionModule(nn.Layer):
 
     # ==================== Fused kernel placeholder ====================
 
-    def bda_span_pays_off(self, dropout_prob: float, training: bool) -> bool:
+    def bda_span_pays_off(
+        self, dropout_prob: float, training: bool, bias=None
+    ) -> bool:
         """Whether wrapping ``fused_h_res_h_post_bda`` in a recompute span saves.
 
         Two things are worth hiding from the live set:
@@ -910,6 +912,10 @@ class HyperConnectionModule(nn.Layer):
         if dropout_prob > 0.0 and training:
             return True
         if not self.config.high_precision_mhc:
+            return False
+        # Mirrors the ``fuse_cast`` predicate in fused_h_res_h_post_bda; keep the
+        # two in step, they decide the same thing from opposite ends.
+        if self._widen_in_kernel and bias is None:
             return False
         return not _use_accuracy_compatible_kernel()
 

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -1388,11 +1388,14 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             "training": self.training,
             "fused": self.config.bias_dropout_fusion,
         }
+        x, bias = layer_output_with_bias
         # Only wrap when the call actually retains something the span can hide;
         # ``bda_span_pays_off`` owns that predicate because it depends on which
-        # path ``fused_h_res_h_post_bda`` takes.
+        # path ``fused_h_res_h_post_bda`` takes. ``bias`` is part of that: it is
+        # half of the ``fuse_cast`` condition, and with the up-casts fused into
+        # the kernel the span has nothing left to hide.
         if not hyper_connection.bda_span_pays_off(
-            self.hidden_dropout_prob, self.training
+            self.hidden_dropout_prob, self.training, bias
         ):
             enable_recompute = False
         if not enable_recompute:
@@ -1404,8 +1407,6 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 **bda_kwargs,
             )
             return output, None
-
-        x, bias = layer_output_with_bias
 
         def _fused(h_res, original_residual, h_post, x, bias):
             return hyper_connection.fused_h_res_h_post_bda(

--- a/tests/single_card_tests/transformer/test_mhc_compute_h_native.py
+++ b/tests/single_card_tests/transformer/test_mhc_compute_h_native.py
@@ -257,16 +257,39 @@ class TestBdaSpanPaysOff(unittest.TestCase):
     pays for a replay that saves nothing. Only the ``high_precision_mhc=True``
     branches are reachable now that the config rejects the low-precision mHC
     combination.
+
+    Without dropout the answer tracks what the BDA site actually pins: the span
+    is worth it only when the fp32 up-casts are materialized in Python, which is
+    exactly when ``fuse_cast`` in ``fused_h_res_h_post_bda`` is off.
     """
 
-    def test_high_precision_pays(self):
-        m = _module(use_fused_mhc=True, high_precision_mhc=True)
+    def test_python_upcasts_pay(self):
+        """No kernel widening -- the fp32 copies are live and worth hiding."""
+        m = _module(use_fused_mhc=False, high_precision_mhc=True)
+        self.assertFalse(m._widen_in_kernel)
         self.assertTrue(m.bda_span_pays_off(0.0, training=True))
+
+    def test_kernel_widening_without_bias_does_not_pay(self):
+        """``fuse_cast`` is on, so there is no fp32 copy left to hide."""
+        m = _module(use_fused_mhc=True, high_precision_mhc=True)
+        self.assertFalse(m.bda_span_pays_off(0.0, training=True))
+        self.assertFalse(m.bda_span_pays_off(0.0, training=True, bias=None))
+
+    def test_bias_opts_back_in(self):
+        """A bias makes the kernel decline ``fuse_cast``; the copies are back."""
+        m = _module(use_fused_mhc=True, high_precision_mhc=True)
+        bias = paddle.zeros([_C], dtype="float32")
+        self.assertTrue(m.bda_span_pays_off(0.0, training=True, bias=bias))
 
     def test_dropout_pays_too(self):
         """The mask is one byte per element of the [..., n*C] output."""
         m = _module(use_fused_mhc=True, high_precision_mhc=True)
         self.assertTrue(m.bda_span_pays_off(0.1, training=True))
+        self.assertTrue(
+            m.bda_span_pays_off(
+                0.1, training=True, bias=paddle.zeros([_C], dtype="float32")
+            )
+        )
 
 
 class TestSingleStreamInit(unittest.TestCase):


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
User Experience 

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Bug fixes

### Description
<!-- Describe what you’ve done -->
在https://github.com/PaddlePaddle/PaddleFleet/pull/1793 中实现了cast融合，因此当前fused_h_res_h_post_bda包含的重计算无用了，不应该开启。
merged in dev: #1993

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否