### PR TITLE
[W4A8] Apply routed_scaling_factor after the down projection

### DIFF
--- a/src/paddlefleet/transformer/moe/fp8_utils.py
+++ b/src/paddlefleet/transformer/moe/fp8_utils.py
@@ -916,6 +916,7 @@ class ExpertsGroupGemmContiguousNode:
         use_accuracy_compatible=False,
         use_w4a8=False,
         use_w4a8_fused_quant=False,
+        w4a8_route_factor_post_w2=None,
     ):
         """
             Initializes the experts group gemm contiguous node.
@@ -1012,6 +1013,18 @@ class ExpertsGroupGemmContiguousNode:
         )
         self.use_w4a8 = use_w4a8
         self.use_w4a8_fused_quant = use_w4a8_fused_quant
+        # Scalar the router deliberately did not fold into probs; applied after
+        # the down projection so the FP8 activation quantizer sees the same
+        # tensor the inference stack quantizes. None means the router folded it.
+        self.w4a8_route_factor_post_w2 = w4a8_route_factor_post_w2
+        if w4a8_route_factor_post_w2 is not None and not use_w4a8:
+            # The router already dropped the factor from probs; only the W4A8
+            # down path puts it back. Any other path would silently emit
+            # outputs scaled down by routed_scaling_factor, so fail loudly.
+            raise ValueError(
+                "w4a8_route_factor_post_w2 is only supported on the W4A8 down "
+                f"path, but use_w4a8={use_w4a8}"
+            )
         if use_w4a8:
             assert moe_expert_fusion and moe_deep_gemm and use_fp8_mlp, (
                 "use_w4a8 需要 moe_expert_fusion + moe_deep_gemm + use_fp8_mlp"
@@ -1359,6 +1372,11 @@ class ExpertsGroupGemmContiguousNode:
             o3 = paddle.empty(o3_shape, dtype=paddle.bfloat16)
         if numpy.prod(o2_fp8.shape) != 0:
             self._w4a8_grouped_gemm(o2_fp8, o2_sf, w2_fp4, w2_sf, o3)
+        if self.w4a8_route_factor_post_w2 is not None:
+            # Mirrors the inference-side contract of applying
+            # routed_scaling_factor after the down projection. In place because
+            # o3 may be a caller-provided output buffer (see fwd_down's o3 arg).
+            o3.scale_(self.w4a8_route_factor_post_w2)
         return o3
 
     def _bwd_down_input_w4a8(
@@ -2856,6 +2874,18 @@ class ExpertsGroupGemmContiguousNode:
             )
         else:
             o1 = self.o1
+
+        if self.w4a8_route_factor_post_w2 is not None:
+            # Chain rule for the forward's post-w2 scale. This node hand-writes
+            # its backward, so the factor has to be applied explicitly, and it
+            # has to happen before out_grad fans out: it feeds both the dgrad
+            # (bwd_down_input_fp8) and the w2 wgrad (bf16_weight_grad /
+            # bwd_down_weight below). Scaling only one of them would leave the
+            # other short by routed_scaling_factor -- training still runs and the
+            # loss still looks sane, it just learns the wrong thing.
+            # In place because out_grad is later reused as the dx output buffer
+            # and the subbatch path asserts `tmp_dx is tmp_out_grad`.
+            out_grad.scale_(self.w4a8_route_factor_post_w2)
 
         # do2
         do1, o2_s, probs_grad = self.bwd_down_input_fp8(

--- a/src/paddlefleet/transformer/moe/fusion_layer_utils.py
+++ b/src/paddlefleet/transformer/moe/fusion_layer_utils.py
@@ -404,6 +404,7 @@ class MlpNode:
         use_accuracy_compatible=False,
         use_w4a8=False,
         use_w4a8_fused_quant=False,
+        w4a8_route_factor_post_w2=None,
     ):
         """
         Constructor
@@ -510,6 +511,7 @@ class MlpNode:
                     use_accuracy_compatible=use_accuracy_compatible,
                     use_w4a8=use_w4a8,
                     use_w4a8_fused_quant=use_w4a8_fused_quant,
+                    w4a8_route_factor_post_w2=w4a8_route_factor_post_w2,
                 )
                 for local_expert_id in range(self.num_experts_per_device)
             ]
@@ -531,6 +533,7 @@ class MlpNode:
                 use_accuracy_compatible=use_accuracy_compatible,
                 use_w4a8=use_w4a8,
                 use_w4a8_fused_quant=use_w4a8_fused_quant,
+                w4a8_route_factor_post_w2=w4a8_route_factor_post_w2,
             )
         self.unzip_node = UnZipNode(self.token_dispatcher)
         self.zip_node = ZipNode(self.token_dispatcher)
@@ -3189,6 +3192,7 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
         use_accuracy_compatible=False,
         use_w4a8=False,
         use_w4a8_fused_quant=False,
+        w4a8_route_factor_post_w2=None,
     ):
         """
         根据给定的参数执行前向传播操作。
@@ -3228,6 +3232,7 @@ class FusionMoePyLayer(paddle.autograd.PyLayer):
             use_accuracy_compatible=use_accuracy_compatible,
             use_w4a8=use_w4a8,
             use_w4a8_fused_quant=use_w4a8_fused_quant,
+            w4a8_route_factor_post_w2=w4a8_route_factor_post_w2,
         )
 
         if fp8_dispatched_handle is not None:

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -54,7 +54,10 @@ from paddlefleet.transformer.dw_overlap import (
     install_sonic_moe_dw_deferral,
 )
 from paddlefleet.transformer.paddle_norm import WrappedPaddleNorm
-from paddlefleet.transformer.transformer_config import dw_overlap_enabled
+from paddlefleet.transformer.transformer_config import (
+    dw_overlap_enabled,
+    w4a8_route_factor_post_w2_scale,
+)
 from paddlefleet.transformer.utils import profile
 
 from .fp8_utils import fused_stack_quant_without_cache
@@ -225,6 +228,9 @@ class MoELayer(nn.Layer):
         self.use_ue8m0 = config.use_ue8m0
         self.use_w4a8 = config.use_w4a8
         self.use_w4a8_fused_quant = config.use_w4a8_fused_quant
+        # Non-None means the router skipped folding routed_scaling_factor into probs
+        # and the fused expert node must apply it after the down projection instead.
+        self.w4a8_route_factor_post_w2 = w4a8_route_factor_post_w2_scale(config)
         # Two independent expert deferral points, one per expert weight:
         #   defer_expert_up_gate_dw -> w1 (up_gate_proj) weight grad
         #   defer_expert_down_dw    -> w2 (down_proj) weight grad, which
@@ -1368,6 +1374,7 @@ class MoELayer(nn.Layer):
                     ),
                     use_w4a8=self.use_w4a8,
                     use_w4a8_fused_quant=self.use_w4a8_fused_quant,
+                    w4a8_route_factor_post_w2=self.w4a8_route_factor_post_w2,
                 )
 
         hidden_states = inspect_tensor(
@@ -1617,6 +1624,7 @@ class MoELayer(nn.Layer):
                     ),
                     use_w4a8=self.use_w4a8,
                     use_w4a8_fused_quant=self.use_w4a8_fused_quant,
+                    w4a8_route_factor_post_w2=self.w4a8_route_factor_post_w2,
                 )
 
             if is_first_fwd:

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -55,7 +55,10 @@ from paddlefleet.parallel_state import (
 )
 from paddlefleet.train_infer_consistent_ops.inspect_util import inspect_tensor
 from paddlefleet.transformer.moe.moe_utils import apply_random_logits
-from paddlefleet.transformer.transformer_config import dw_overlap_enabled
+from paddlefleet.transformer.transformer_config import (
+    dw_overlap_enabled,
+    w4a8_route_factor_post_w2_scale,
+)
 
 # MD5 logging for MoE router precision debugging
 _LOG_LAYER_MD5 = os.environ.get("LOG_LAYER_MD5", "0") == "1"
@@ -1359,7 +1362,11 @@ class StandardMoERouter(nn.Layer):
                 top_gate, top_idx, self.routed_scaling_factor_param
             )
         elif abs(self.routed_scaling_factor - 1.0) > 1e-6:
-            top_gate = top_gate * self.routed_scaling_factor
+            # Hash layers reach this fold and then return, never touching the fold in
+            # TopKRouter.forward, so the skip has to be repeated here. Both sites read
+            # the same helper, which is what keeps them from disagreeing.
+            if w4a8_route_factor_post_w2_scale(self.config) is None:
+                top_gate = top_gate * self.routed_scaling_factor
 
         return top_gate, top_idx
 
@@ -1925,7 +1932,11 @@ class TopKRouter(StandardMoERouter):
                 top_gate, top_idx, self.routed_scaling_factor_param
             )
         elif abs(self.routed_scaling_factor - 1.0) > 1e-6:
-            top_gate = top_gate * self.routed_scaling_factor
+            # Skipped when the factor is applied after the W4A8 down projection
+            # instead; see w4a8_route_factor_post_w2_scale for why the ordering
+            # matters under UE8M0 (power-of-two) activation scales.
+            if w4a8_route_factor_post_w2_scale(self.config) is None:
+                top_gate = top_gate * self.routed_scaling_factor
 
         # Reconstruct probs (combine weights in [S, E] sparse layout) from final top_gate.
         probs = paddle.zeros_like(gates, dtype=top_gate.dtype).put_along_axis_(

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -151,6 +151,43 @@ def dw_overlap_enabled(config, point: str) -> bool:
     )
 
 
+def w4a8_route_factor_post_w2_scale(config):
+    """Scale to apply after the W4A8 down projection, or ``None`` to keep folding.
+
+    ``routed_scaling_factor`` is normally folded into ``top_gate`` (and hence into
+    ``probs``) by the router, so the W4A8 activation quantizer sees
+    ``swiglu(o1) * prob * routed_scaling_factor``. Inference stacks such as SGLang's
+    MegaMoE instead apply the factor *after* the down projection.
+
+    That ordering is not free: the FP8 activation scale is ``ceil_to_ue8m0(amax/448)``,
+    i.e. restricted to powers of two. Pre-multiplying by ``s`` multiplies ``amax`` by
+    ``s`` and therefore bumps the exponent of about ``log2(s) mod 1`` of the 1x32
+    blocks into the next bucket, so the two sides quantize on different grids and
+    round independently. Measured on DeepSeek-V4 shapes with ``s = 1.5``: 58.6% of
+    blocks shift bucket, each path sits 2.65% from the unquantized reference, but the
+    two paths sit 3.74% from *each other*. Matching the order makes that divergence
+    exactly zero, which is what train/rollout consistency cares about -- agreement,
+    not accuracy.
+
+    Returns the scalar when the post-w2 ordering applies, else ``None``. Callers on
+    both sides (the router that skips folding and the fused expert node that applies
+    the factor) must key off this single helper so they cannot disagree.
+
+    Gated on ``use_w4a8_fused_quant`` so W4A8 keeps a single knob. Excluded cases:
+      - ``routed_scaling_factor_learnable``: the scale is a per-(token, expert) gather,
+        which is not a scalar that can be hoisted past the grouped GEMM.
+      - ``routed_scaling_factor == 1``: nothing to move.
+    """
+    if not getattr(config, "use_w4a8", False):
+        return None
+    if not getattr(config, "use_w4a8_fused_quant", False):
+        return None
+    if getattr(config, "routed_scaling_factor_learnable", False):
+        return None
+    scale = float(getattr(config, "routed_scaling_factor", 1.0))
+    return scale if abs(scale - 1.0) > 1e-6 else None
+
+
 @dataclass
 class TransformerConfig(ModelParallelConfig):
     """Configuration object for transformers."""

--- a/tests/single_card_tests/fp8/test_w4a8_route_factor_post_w2.py
+++ b/tests/single_card_tests/fp8/test_w4a8_route_factor_post_w2.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for applying routed_scaling_factor after the W4A8 down projection.
+
+Three things are worth locking down, in decreasing order of how badly they bite:
+
+1. The router-side skip and the expert-side apply must be driven by the *same*
+   predicate, and every fold site must honour it. ``StandardMoERouter._hash_routing``
+   folds and then returns early, so it never reaches the fold in
+   ``TopKRouter.forward``; missing it leaves the first ``moe_n_hash_layers`` MoE layers
+   with outputs scaled down by ``routed_scaling_factor``.
+2. The backward has to scale ``out_grad`` before it fans out to the dgrad and the w2
+   wgrad. Scaling one but not the other leaves that gradient short by the factor --
+   training still runs and the loss still looks sane.
+3. Paths without a post-w2 apply point must reject the scale rather than silently
+   drop it.
+"""
+
+import ast
+import inspect
+import unittest
+from types import SimpleNamespace
+
+from paddlefleet.transformer.moe import moe_router
+from paddlefleet.transformer.moe.fp8_utils import ExpertsGroupGemmContiguousNode
+from paddlefleet.transformer.transformer_config import (
+    w4a8_route_factor_post_w2_scale,
+)
+
+
+def _cfg(**kwargs):
+    base = dict(
+        use_w4a8=True,
+        use_w4a8_fused_quant=True,
+        routed_scaling_factor=1.5,
+        routed_scaling_factor_learnable=False,
+    )
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+class TestPostW2ScalePredicate(unittest.TestCase):
+    def test_enabled_returns_scalar(self):
+        self.assertEqual(w4a8_route_factor_post_w2_scale(_cfg()), 1.5)
+
+    def test_requires_w4a8(self):
+        self.assertIsNone(w4a8_route_factor_post_w2_scale(_cfg(use_w4a8=False)))
+
+    def test_requires_fused_quant_switch(self):
+        self.assertIsNone(
+            w4a8_route_factor_post_w2_scale(_cfg(use_w4a8_fused_quant=False))
+        )
+
+    def test_learnable_factor_is_excluded(self):
+        # A learnable factor is a per-(token, expert) gather, not a scalar that can
+        # be hoisted past the grouped GEMM.
+        self.assertIsNone(
+            w4a8_route_factor_post_w2_scale(
+                _cfg(routed_scaling_factor_learnable=True)
+            )
+        )
+
+    def test_unit_factor_is_a_noop(self):
+        self.assertIsNone(
+            w4a8_route_factor_post_w2_scale(_cfg(routed_scaling_factor=1.0))
+        )
+
+    def test_tolerates_configs_without_the_fields(self):
+        self.assertIsNone(w4a8_route_factor_post_w2_scale(SimpleNamespace()))
+
+
+class TestEveryFoldSiteIsGated(unittest.TestCase):
+    """Each `top_gate * self.routed_scaling_factor` must sit behind the predicate.
+
+    Guards against the failure that actually happened: only the fold in
+    ``TopKRouter.forward`` was gated, while ``_hash_routing`` kept folding, so on a
+    model with ``moe_n_hash_layers > 0`` the first MoE layers double-counted the skip.
+    """
+
+    def test_all_fold_sites_check_the_predicate(self):
+        tree = ast.parse(inspect.getsource(moe_router))
+        folds = []
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Assign) and isinstance(node.value, ast.BinOp)):
+                continue
+            if not isinstance(node.value.op, ast.Mult):
+                continue
+            right = node.value.right
+            if isinstance(right, ast.Attribute) and right.attr == "routed_scaling_factor":
+                folds.append(node.lineno)
+        self.assertTrue(folds, "no routed_scaling_factor fold found; test is stale")
+
+        gated = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            calls = [
+                c
+                for c in ast.walk(node.test)
+                if isinstance(c, ast.Call)
+                and getattr(c.func, "id", None) == "w4a8_route_factor_post_w2_scale"
+            ]
+            if not calls:
+                continue
+            body_lines = {
+                x.lineno for stmt in node.body for x in ast.walk(stmt)
+                if hasattr(x, "lineno")
+            }
+            gated.extend(body_lines)
+
+        ungated = [ln for ln in folds if ln not in gated]
+        self.assertEqual(
+            ungated,
+            [],
+            f"routed_scaling_factor folded without checking the predicate at lines {ungated}",
+        )
+
+
+class TestBackwardScalesBeforeFanOut(unittest.TestCase):
+    def test_out_grad_is_scaled_before_any_consumer(self):
+        tree = ast.parse(inspect.getsource(ExpertsGroupGemmContiguousNode))
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "backward_impl_fp8"
+        )
+        scale_lines = [
+            c.lineno
+            for c in ast.walk(fn)
+            if isinstance(c, ast.Call)
+            and isinstance(c.func, ast.Attribute)
+            and c.func.attr == "scale_"
+            and getattr(c.func.value, "id", None) == "out_grad"
+        ]
+        self.assertEqual(len(scale_lines), 1, "expected exactly one out_grad.scale_")
+        reads = sorted(
+            {
+                c.lineno
+                for c in ast.walk(fn)
+                if isinstance(c, ast.Name)
+                and c.id == "out_grad"
+                and isinstance(c.ctx, ast.Load)
+                and c.lineno != scale_lines[0]
+            }
+        )
+        early = [ln for ln in reads if ln < scale_lines[0]]
+        self.assertEqual(
+            early,
+            [],
+            "out_grad is consumed before it is scaled, so that consumer's gradient "
+            f"is short by routed_scaling_factor (lines {early})",
+        )
+
+    def test_scaling_is_in_place(self):
+        # out_grad is reused as the dx output buffer and the subbatch path asserts
+        # `tmp_dx is tmp_out_grad`; rebinding it would break that invariant. Note
+        # paddle's `x *= s` also rebinds, so only scale_ is acceptable.
+        src = inspect.getsource(ExpertsGroupGemmContiguousNode)
+        self.assertNotIn("out_grad = out_grad *", src)
+
+
+class TestUnsupportedPathIsRejected(unittest.TestCase):
+    def test_non_w4a8_node_rejects_the_scale(self):
+        with self.assertRaises(ValueError):
+            ExpertsGroupGemmContiguousNode(
+                SimpleNamespace(experts=[], grouped_gemm_experts=None),
+                use_fp8_mlp=False,
+                use_w4a8=False,
+                w4a8_route_factor_post_w2=1.5,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Apply routed_scaling_factor after the W4A8 down projection instead of folding it into router probabilities before activation quantization. The router and fused expert paths use the same gating logic, while existing behavior is preserved when W4A8 fused quantization is disabled.