### PR TITLE
[CI] Upload arm ops wheels to paddle-release path

### DIFF
--- a/.github/workflows/manual_build_wheel_ops.yml
+++ b/.github/workflows/manual_build_wheel_ops.yml
@@ -473,11 +473,11 @@ jobs:
             python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-whl/nightly/${{ matrix.cuda.bos_CUDA }}/paddlefleet-ops
             export AK=paddle
             export SK=paddle
-            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}
+            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}/paddle-release
             PY_VERSION="${{ matrix.python_version }}"
             PY_VERSION_SHORT="${PY_VERSION//./}"
             mv paddlefleet_ops-*.whl paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_aarch64.whl
-            python ../bos/BosClient.py paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_aarch64.whl paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}
+            python ../bos/BosClient.py paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_aarch64.whl paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}/paddle-release
           fi
           curl https://www.paddlepaddle.org.cn/inner/whl/update/path/new
           '

--- a/.github/workflows/pr_update_ops.yml
+++ b/.github/workflows/pr_update_ops.yml
@@ -530,7 +530,7 @@ jobs:
             python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-whl/nightly/${{ matrix.cuda.bos_CUDA }}/paddlefleet-ops
             export AK=paddle
             export SK=paddle
-            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}
+            python ../bos/BosClient.py paddlefleet_ops-*.whl paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}/${{ matrix.cuda.bos_CUDA }}/paddle-release
             python ../bos/BosClient.py paddlefleet_ops-arm-${{ matrix.cuda.bos_CUDA }}-linux_aarch64.whl.name paddle-github-action/PaddleFleet/${BRANCH}/${COMMIT_ID}
             PY_VERSION="${{ matrix.python_version }}"
             PY_VERSION_SHORT="${PY_VERSION//./}"
@@ -538,7 +538,7 @@ jobs:
             newest_ops_commit=$( ( source /root/proxy; curl -s -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "X-GitHub-Api-Version: 2022-11-28" "https://api.github.com/repos/${GITHUB_REPO_NAME}/commits?sha=${BRANCH}&path=packages&per_page=1" ) | grep -oE "\"sha\": *\"[0-9a-f]{40}\"" | head -1 | grep -oE "[0-9a-f]{40}" )
             if [[ -z "${newest_ops_commit}" || "${newest_ops_commit}" == "${COMMIT_ID}" ]]; then
               mv paddlefleet_ops-*.whl paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_aarch64.whl
-              python ../bos/BosClient.py paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_aarch64.whl paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}
+              python ../bos/BosClient.py paddlefleet_ops-0.0.0-cp${PY_VERSION_SHORT}-cp${PY_VERSION_SHORT}-linux_aarch64.whl paddle-github-action/PaddleFleet/${BRANCH}/latest/${{ matrix.cuda.bos_CUDA }}/paddle-release
             else
               echo "Skip latest/ upload: ${COMMIT_ID} is not the newest packages/ commit on ${BRANCH} (newest: ${newest_ops_commit})"
             fi
@@ -585,6 +585,7 @@ jobs:
           - {label: paddle-release, bos_CUDA: cu132, python_version: "3.13", artifact_name: "whl-name-paddle-release-cu132-py3.13-linux_x86_64", name_key: "paddlefleet_ops-paddle-release-cu132-py313-linux_x86_64.whl.name"}
           # arm: linux_aarch64 wheels published to paddle-whl/nightly/${cuda}/paddlefleet-ops
           - {label: arm, bos_CUDA: cu130, python_version: "3.12", artifact_name: "whl-name-arm-cu130-py3.12-linux_aarch64", name_key: "paddlefleet_ops-arm-cu130-linux_aarch64.whl.name"}
+          - {label: arm, bos_CUDA: cu132, python_version: "3.12", artifact_name: "whl-name-arm-cu132-py3.12-linux_aarch64", name_key: "paddlefleet_ops-arm-cu132-linux_aarch64.whl.name"}
     steps:
       - name: Download wheel name artifact
         if: github.ref_type != 'tag' && matrix.flavor.label != 'arm'


### PR DESCRIPTION
## 背景

`paddlefleet_ops` 的 x86 release 构建上传到：

`PaddleFleet/${BRANCH}/latest/${cuda}/paddle-release/paddlefleet_ops-0.0.0-cp312-cp312-linux_x86_64.whl`

而 arm 构建（`pr_update_ops.yml` 与 `manual_build_wheel_ops.yml` 中的 `publish-ops-wheel-arm`）上传时**缺少 `paddle-release` 这一层**：

`PaddleFleet/${BRANCH}/latest/${cuda}/paddlefleet_ops-0.0.0-cp312-cp312-linux_aarch64.whl`

导致消费方无法用一个 URL 模板（仅替换 `x86_64` → `aarch64`）同时拉取两个架构的包。

## 修改

1. **`pr_update_ops.yml`**（`publish-ops-wheel-arm`）：
   - `PaddleFleet/${BRANCH}/${COMMIT_ID}/${cuda}` → 增加 `/paddle-release` 子目录
   - `PaddleFleet/${BRANCH}/latest/${cuda}` → 增加 `/paddle-release` 子目录
   - `upload-to-paddletest` 通知矩阵补齐缺失的 **cu132 arm** 条目（此前仅注册 cu130，导致 cu132 arm 包构建上传后未被注册到 paddletest）
2. **`manual_build_wheel_ops.yml`**（`publish-ops-wheel-arm`）：同上，arm 上传路径均补上 `/paddle-release`

## 说明

- arm 构建产物保持 `linux_aarch64` 平台名与 x86 的 `linux_x86_64` 仅差架构后缀，URL 模板可统一。
- 仅新增 `paddle-release` 路径，`paddle-whl/nightly|stable/${cuda}/paddlefleet-ops` 与 `.whl.name` 通知文件的上传/下载路径不变。