### PR TITLE
[release/0.4][config_adapter] Keep fa_version verbatim instead of dropping it

### DIFF
--- a/src/paddlefleet/config_adapter/README.md
+++ b/src/paddlefleet/config_adapter/README.md
@@ -139,7 +139,6 @@ C3/C5 只取决于并行度本身，与卡数无关：这两项冲突时不会�
 ```
 加载 YAML
   -> 应用 --set yaml:（并锁定这些字段）
-  -> 删除 fa_version（与环境强绑定的 flash-attention 版本 pin）
   -> 需要时加载 model_config.json 并应用 --set json:
   -> 扫描两个文件，落定不带前缀的 --set
   -> --scale-seq-length：改写 max_seq_length 并同比例缩放 CP（并锁定两字段）

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -19,7 +19,6 @@
     load YAML
       -> apply --set yaml: overrides (and pin them: nothing else may touch
          those keys afterwards)
-      -> drop fa_version (an environment-specific flash-attention pin)
       -> load model_config.json + apply --set json: overrides, when the
          profile or the user needs it
       -> profile.plan(): decide the final TP/PP/EP/CP/SEP
@@ -164,18 +163,6 @@ class ConfigAdapter:
                 "yaml",
                 self.yaml_writer.apply_config_map(config, self.yaml_overrides),
                 "用户通过 --set yaml: 指定，自动适配不会再覆盖该字段",
-            )
-
-        fa_pinned = "fa_version" in self.yaml_overrides or (
-            "fa_version" in self.auto_overrides
-        )
-        if "fa_version" in config and not fa_pinned:
-            log.record_removed(
-                "yaml",
-                "fa_version",
-                config.pop("fa_version"),
-                "fa_version 是与环境强绑定的 flash-attention 版本 pin，"
-                "适配后的配置不携带",
             )
 
         dims_before = extract_parallel_params(config)

--- a/src/paddlefleet/config_adapter/core.py
+++ b/src/paddlefleet/config_adapter/core.py
@@ -214,6 +214,13 @@ class ConfigAdapter:
         if err:
             return False, f"{input_path.name}: {err}"
         plan.warnings.extend(seq_warnings)
+        if "fa_version" in config:
+            plan.warnings.append(
+                f"fa_version={config['fa_version']} 按源配置原样保留：适配的"
+                f"前提是目标机器与源作业同构（同 GPU 架构 / 同镜像）。若目标"
+                f"环境缺少对应的 flash-attention kernel，请用 "
+                f"--set fa_version=<版本> 改写或手动删除该字段"
+            )
 
         for key, value, reason in plan.json_changes:
             log.record(

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -1080,8 +1080,11 @@ class TestDefaultAdaptation(ConfigAdapterTestBase):
         # (96 -> 2), keeping GBS == micro_bs * acc * dataset_world_size.
         self.assertEqual(config["global_batch_size"], 192)
         self.assertEqual(config["gradient_accumulation_steps"], 96)
-        # Environment-specific pin is always dropped.
-        self.assertNotIn("fa_version", config)
+        # fa_version is an ordinary field now: kept verbatim.  The adapter
+        # only shrinks scale on identical hardware, so dropping the kernel
+        # pin would silently change the attention code path and break the
+        # comparability that the test modes exist for.
+        self.assertEqual(config["fa_version"], 3)
 
     def test_stale_checkpoint_refs_are_dropped_when_structure_shrinks(self):
         # Shrinking EP/PP rescales n_routed_experts / num_hidden_layers, so a
@@ -1606,21 +1609,13 @@ class TestPinnedFieldRejection(ConfigAdapterTestBase):
         self.assertFalse(ok)
         self.assertIn("pipeline_model_parallel_size", message)
 
-    def test_prefix_less_fa_version_pin_is_kept(self):
-        ok, message = self.adapt(
-            target_nodes=1, test_accuracy=True, auto_overrides={"fa_version": 4}
-        )
+    def test_fa_version_is_kept_verbatim(self):
+        # fa_version used to be dropped as an "environment pin"; the adapter
+        # now targets same-hardware shrinks only, so the field is an ordinary
+        # passthrough (and --set can still rewrite it like any other key).
+        ok, message = self.adapt(target_nodes=1, test_accuracy=True)
         self.assertTrue(ok, message)
-        self.assertEqual(self.load_output_yaml(8)["fa_version"], 4)
-        self.assertNotIn("DELETE field=fa_version", message)
-
-    def test_pinned_fa_version_is_kept(self):
-        ok, message = self.adapt(
-            target_nodes=1, test_accuracy=True, yaml_overrides={"fa_version": 4}
-        )
-        self.assertTrue(ok, message)
-        # The pin wins: the field is neither deleted nor reported as deleted.
-        self.assertEqual(self.load_output_yaml(8)["fa_version"], 4)
+        self.assertEqual(self.load_output_yaml(8)["fa_version"], 3)
         self.assertNotIn("DELETE field=fa_version", message)
 
 

--- a/tests/single_card_tests/config_adapter/test_config_adapter.py
+++ b/tests/single_card_tests/config_adapter/test_config_adapter.py
@@ -1617,6 +1617,24 @@ class TestPinnedFieldRejection(ConfigAdapterTestBase):
         self.assertTrue(ok, message)
         self.assertEqual(self.load_output_yaml(8)["fa_version"], 3)
         self.assertNotIn("DELETE field=fa_version", message)
+        # A same-hardware assumption travels with the pin: say so.
+        self.assertIn("fa_version=3 按源配置原样保留", message)
+
+    def test_prefix_less_set_rewrites_fa_version(self):
+        ok, message = self.adapt(
+            target_nodes=1, test_accuracy=True, auto_overrides={"fa_version": 4}
+        )
+        self.assertTrue(ok, message)
+        self.assertEqual(self.load_output_yaml(8)["fa_version"], 4)
+        self.assertNotIn("DELETE field=fa_version", message)
+
+    def test_yaml_set_rewrites_fa_version(self):
+        ok, message = self.adapt(
+            target_nodes=1, test_accuracy=True, yaml_overrides={"fa_version": 4}
+        )
+        self.assertTrue(ok, message)
+        self.assertEqual(self.load_output_yaml(8)["fa_version"], 4)
+        self.assertNotIn("DELETE field=fa_version", message)
 
 
 class TestCliErrorPaths(ConfigAdapterTestBase):


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
Improvements

### Description

Cherry-pick to `release/0.4`.

Merged in dev: #2000

Remove the rule that unconditionally drops `fa_version` from adapted YAMLs. The adapter is only used to shrink a config to fewer nodes on identical hardware, so the 'environment-specific pin' rationale no longer applies — and dropping the field silently switched the flash-attention kernel path on the adapted run, breaking the comparability that `--test-performance` and `--test-accuracy` exist to preserve. `fa_version` is now an ordinary passthrough field; `--set fa_version=...` can still rewrite it.

### 是否引起精度变化
否
