### PR TITLE
[SP] move sequence_parallel and set it according to TP

### DIFF
--- a/src/paddlefleet/model_parallel_config.py
+++ b/src/paddlefleet/model_parallel_config.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -380,14 +381,22 @@ class ModelParallelConfig:
         if self.tensor_model_parallel_size <= 1:
             self.sequence_parallel = False
 
+        # expert + tensor parallelism requires sequence_parallel.
+        if (
+            self.expert_model_parallel_size > 1
+            and self.tensor_model_parallel_size > 1
+            and not self.sequence_parallel
+        ):
+            warnings.warn(
+                "sequence_parallel is forced to True because expert_model_parallel_size > 1 "
+                "and tensor_model_parallel_size > 1 (expert parallelism requires "
+                "sequence parallelism).",
+                stacklevel=3,
+            )
+            self.sequence_parallel = True
+
         if getattr(self, "use_accuracy_compatible", False):
             self.deterministic_mode = True
-
-        if self.sequence_parallel:
-            if self.tensor_model_parallel_size <= 1:
-                raise ValueError(
-                    "Can not use sequence paralllelism without tensor parallelism"
-                )
 
         if self.expert_tensor_parallel_size is None:
             self.expert_tensor_parallel_size = self.tensor_model_parallel_size
@@ -415,16 +424,6 @@ class ModelParallelConfig:
             raise ValueError(
                 "Wgrad deferral limit should be greater than or equal to 0 when it is enabled!"
             )
-
-        if (
-            self.expert_model_parallel_size > 1
-            and self.tensor_model_parallel_size > 1
-        ):
-            if self.sequence_parallel is False:
-                raise ValueError(
-                    "When using expert parallelism and tensor parallelism, "
-                    "sequence parallelism must be used"
-                )
 
         if self.microbatch_group_size_per_vp_stage is None:
             self.microbatch_group_size_per_vp_stage = (

--- a/tests/single_card_tests/coverage_test/distributed/test_coverage_model_parallel_config.py
+++ b/tests/single_card_tests/coverage_test/distributed/test_coverage_model_parallel_config.py
@@ -164,17 +164,38 @@ class TestModelParallelConfig(unittest.TestCase):
         self.assertTrue(config.defer_embedding_wgrad_compute)
         self.assertEqual(config.wgrad_deferral_limit, 5)
 
-    def test_expert_and_tensor_parallel_requires_sequence_parallel(self):
-        """Test that expert + tensor parallel requires sequence parallel."""
+    def test_sequence_parallel_stays_user_controllable(self):
+        """sequence_parallel remains user-configurable; tp>1 does NOT force it on by itself."""
         from paddlefleet.model_parallel_config import ModelParallelConfig
 
-        with self.assertRaises(ValueError) as ctx:
+        # tp>1 without expert parallelism: sp follows the user's explicit setting
+        self.assertFalse(
             ModelParallelConfig(
-                expert_model_parallel_size=2,
-                tensor_model_parallel_size=2,
-                sequence_parallel=False,
-            )
-        self.assertIn("sequence parallelism must be used", str(ctx.exception))
+                tensor_model_parallel_size=2, sequence_parallel=False
+            ).sequence_parallel
+        )
+        self.assertTrue(
+            ModelParallelConfig(
+                tensor_model_parallel_size=2, sequence_parallel=True
+            ).sequence_parallel
+        )
+        # tp<=1: sp is auto-corrected to False (SP requires tensor parallelism)
+        self.assertFalse(
+            ModelParallelConfig(
+                tensor_model_parallel_size=1, sequence_parallel=True
+            ).sequence_parallel
+        )
+
+    def test_expert_and_tensor_parallel_auto_enables_sequence_parallel(self):
+        """Expert + tensor parallel: missing sequence_parallel is auto-enabled (corrected), no error raised."""
+        from paddlefleet.model_parallel_config import ModelParallelConfig
+
+        config = ModelParallelConfig(
+            expert_model_parallel_size=2,
+            tensor_model_parallel_size=2,
+            sequence_parallel=False,  # auto-corrected to True
+        )
+        self.assertTrue(config.sequence_parallel)
 
     def test_expert_and_tensor_parallel_with_sequence_parallel_ok(self):
         """Test that expert + tensor + sequence parallel is valid."""


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
User Experience

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Deprecations

### Description
<!-- Describe what you’ve done -->
TP>1且EP>1的时候，将SP的配置调整为自适应，升级方式为**自适应兼容性升级**，避免潜在的不兼容风险。（见 https://github.com/PaddlePaddle/PaddleFleet/pull/2016 ）

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否