### PR TITLE
[CI] Run the single-card unit test files 4 at a time

### DIFF
--- a/ci/single_card_test.sh
+++ b/ci/single_card_test.sh
@@ -38,11 +38,10 @@ is_disabled() {
 export FLAGS_embedding_deterministic=1
 export FLAGS_cudnn_deterministic=1
 
-# pytest-xdist worker count. The job holds a single GPU, so the workers share
-# it -- 4 is the value this change measures against the previous serial run.
+# How many test files run at the same time. Each one still gets its own pytest
+# process, exactly as before -- only the loop is parallel. The job holds a
+# single GPU, so the concurrent files share it.
 workers="${PYTEST_WORKERS:-4}"
-
-python -c "import xdist" 2>/dev/null || pip install pytest-xdist
 
 test_files=()
 for test_file in $(find $test_dir -type f -name "test_*.py"); do
@@ -55,42 +54,72 @@ for test_file in $(find $test_dir -type f -name "test_*.py"); do
 done
 
 run_count=${#test_files[@]}
-echo -e "\033[34mRunning $run_count single card test files on $workers workers\033[0m"
+echo -e "\033[34mRunning $run_count single card test files, $workers at a time\033[0m"
 
 if [ "$run_count" -eq 0 ]; then
     echo -e "\033[32mNo single card test to run.\033[0m"
     exit 0
 fi
 
-# One pytest invocation over every file, instead of one invocation per file:
-# the files are what parallelises. ``--dist loadfile`` keeps all tests of a file
-# inside one worker, because these suites set process-global paddle/fleet state
-# at import time and cannot be split mid-file.
+# One pytest process per test file, unchanged -- these suites set
+# process-global paddle/fleet state at import time and cannot share a process.
+# Only the loop is parallel now: `xargs -P` keeps $workers files in flight.
 #
-# ``-s`` is dropped -- xdist workers do not stream stdout back live -- and
-# ``-rA`` takes its place so the captured output of passing tests stays in the
-# report, which is where the printed MD5 baselines are read from.
-pytest_args=(
-    -n "$workers"
-    --dist loadfile
-    -rA
-    --junitxml=single_card.xml
-    "${test_files[@]}"
-)
-if [[ "${WITH_COVERAGE:-OFF}" == "ON" ]]; then
-    coverage run -m pytest "${pytest_args[@]}"
-else
-    pytest "${pytest_args[@]}"
-fi
-exit_code=$?
+# Output of each file goes to its own log instead of straight to stdout,
+# because $workers concurrent processes would interleave into something
+# unreadable. Logs of failing files are dumped at the end; passing files just
+# print one status line, and their log is left on disk.
+status_dir=$(mktemp -d)
+trap 'rm -rf "$status_dir"' EXIT
+
+run_one_test() {
+    local test_file="$1"
+    local log="./$(basename "${test_file%.*}")_single_card.log"
+    echo "Running single card test: $test_file"
+    # --parallel-mode: several `coverage run` processes are alive at once, so
+    # each needs its own data file. Workflows that consume the data already run
+    # `coverage combine`.
+    if [[ "${WITH_COVERAGE:-OFF}" == "ON" ]]; then
+        coverage run --parallel-mode -m pytest -s "$test_file" >"$log" 2>&1
+    else
+        pytest -s "$test_file" >"$log" 2>&1
+    fi
+    local exit_code=$?
+    if [ $exit_code -ne 0 ]; then
+        echo "$test_file" >"$status_dir/$(basename "$test_file").failed"
+        echo "Test FAILED: $test_file, see log for details..."
+    fi
+    return $exit_code
+}
+export -f run_one_test
+export status_dir WITH_COVERAGE
+
+printf '%s\n' "${test_files[@]}" |
+    xargs -P "$workers" -n 1 bash -c 'run_one_test "$0"'
+
+failed_tests=()
+for marker in "$status_dir"/*.failed; do
+    [ -e "$marker" ] || continue
+    failed_tests+=("$(cat "$marker")")
+done
+
+for test_file in "${failed_tests[@]}"; do
+    echo "--------------------------------------"
+    echo -e "\033[31mLog of failed test: $test_file\033[0m"
+    echo "--------------------------------------"
+    cat "./$(basename "${test_file%.*}")_single_card.log"
+done
 
 echo "======================================"
 echo -e "\033[34mTest files executed: $run_count\033[0m"
-if [ $exit_code -eq 0 ]; then
+if [ ${#failed_tests[@]} -eq 0 ]; then
     echo -e "\033[32mAll single card tests passed!\033[0m"
     echo "======================================"
 else
-    echo -e "::error:: \033[31mSome single card tests failed, see the pytest summary above.\033[0m"
+    echo -e "::error:: \033[31m${#failed_tests[@]} single card test files failed:\033[0m"
+    for test_file in "${failed_tests[@]}"; do
+        echo -e "::error:: \033[31m  $test_file\033[0m"
+    done
     echo "======================================"
     exit 1
 fi

--- a/ci/single_card_test.sh
+++ b/ci/single_card_test.sh
@@ -38,50 +38,59 @@ is_disabled() {
 export FLAGS_embedding_deterministic=1
 export FLAGS_cudnn_deterministic=1
 
-run_count=0
-failed_tests=()
+# pytest-xdist worker count. The job holds a single GPU, so the workers share
+# it -- 4 is the value this change measures against the previous serial run.
+workers="${PYTEST_WORKERS:-4}"
+
+python -c "import xdist" 2>/dev/null || pip install pytest-xdist
+
+test_files=()
 for test_file in $(find $test_dir -type f -name "test_*.py"); do
     filename=$(basename "$test_file")
     if is_disabled "$filename"; then
         echo "Skipping disabled test: $filename"
         continue
     fi
-
-    echo "Running single card test: $test_file"
-    run_count=$((run_count + 1))
-    if [[ "${WITH_COVERAGE:-OFF}" == "ON" ]];then
-        # uv run -m coverage run -m pytest -s "$test_file"
-        coverage run -m pytest -s "$test_file"
-    else
-        # uv run pytest -s "$test_file"
-        pytest -s "$test_file"
-    fi
-    exit_code=$?
-    if [ $exit_code -ne 0 ]; then
-        echo "Test FAILED: $test_file, see log for details..."
-        python $work_dir/ci/check_log_for_exitcode.py "./$(basename ${test_file%.*})_single_card.log" "OK"
-        check_exit_code=${PIPESTATUS[0]}
-        if [ $check_exit_code -ne 0 ]; then
-            failed_tests+=("$test_file")
-            echo "Log check failed for $test_file."
-        else
-            echo "Log check passed for $test_file."
-        fi
-    else
-        echo "Test PASSED: $test_file"
-    fi
+    test_files+=("$test_file")
 done
 
+run_count=${#test_files[@]}
+echo -e "\033[34mRunning $run_count single card test files on $workers workers\033[0m"
+
+if [ "$run_count" -eq 0 ]; then
+    echo -e "\033[32mNo single card test to run.\033[0m"
+    exit 0
+fi
+
+# One pytest invocation over every file, instead of one invocation per file:
+# the files are what parallelises. ``--dist loadfile`` keeps all tests of a file
+# inside one worker, because these suites set process-global paddle/fleet state
+# at import time and cannot be split mid-file.
+#
+# ``-s`` is dropped -- xdist workers do not stream stdout back live -- and
+# ``-rA`` takes its place so the captured output of passing tests stays in the
+# report, which is where the printed MD5 baselines are read from.
+pytest_args=(
+    -n "$workers"
+    --dist loadfile
+    -rA
+    --junitxml=single_card.xml
+    "${test_files[@]}"
+)
+if [[ "${WITH_COVERAGE:-OFF}" == "ON" ]]; then
+    coverage run -m pytest "${pytest_args[@]}"
+else
+    pytest "${pytest_args[@]}"
+fi
+exit_code=$?
+
 echo "======================================"
-echo -e "\033[34mTests executed: $run_count\033[0m"
-if [ ${#failed_tests[@]} -eq 0 ]; then
+echo -e "\033[34mTest files executed: $run_count\033[0m"
+if [ $exit_code -eq 0 ]; then
     echo -e "\033[32mAll single card tests passed!\033[0m"
     echo "======================================"
 else
-    echo -e "::error:: Some single card tests failed:"
-    for fail in "${failed_tests[@]}"; do
-        echo -e "::error:: \033[31m- $fail\033[0m"
-    done
+    echo -e "::error:: \033[31mSome single card tests failed, see the pytest summary above.\033[0m"
     echo "======================================"
     exit 1
 fi

--- a/ci/single_card_test.sh
+++ b/ci/single_card_test.sh
@@ -43,6 +43,14 @@ export FLAGS_cudnn_deterministic=1
 # single GPU, so the concurrent files share it.
 workers="${PYTEST_WORKERS:-4}"
 
+# Validated before it reaches xargs. A non-numeric value makes xargs fail
+# immediately without running anything, and 0 means "no concurrency limit" in
+# GNU xargs -- 600 pytest processes at once on one GPU.
+if ! [[ "$workers" =~ ^[1-9][0-9]*$ ]]; then
+    echo -e "::error:: \033[31mPYTEST_WORKERS must be a positive integer, got '$workers'\033[0m"
+    exit 1
+fi
+
 test_files=()
 for test_file in $(find $test_dir -type f -name "test_*.py"); do
     filename=$(basename "$test_file")
@@ -69,12 +77,24 @@ fi
 # because $workers concurrent processes would interleave into something
 # unreadable. Logs of failing files are dumped at the end; passing files just
 # print one status line, and their log is left on disk.
-status_dir=$(mktemp -d)
+status_dir=$(mktemp -d) || exit 1
 trap 'rm -rf "$status_dir"' EXIT
+
+# Per-file log and marker names are derived from the whole path, not the
+# basename: 22 basenames occur in more than one directory under
+# $test_dir, and two of those running at once would write the same file.
+slug_for() {
+    local p="${1#./}"
+    p="${p#"$test_dir/"}"
+    p="${p%.py}"
+    printf '%s' "${p//\//_}"
+}
 
 run_one_test() {
     local test_file="$1"
-    local log="./$(basename "${test_file%.*}")_single_card.log"
+    local slug
+    slug=$(slug_for "$test_file")
+    local log="./${slug}_single_card.log"
     echo "Running single card test: $test_file"
     # --parallel-mode: several `coverage run` processes are alive at once, so
     # each needs its own data file. Workflows that consume the data already run
@@ -85,17 +105,23 @@ run_one_test() {
         pytest -s "$test_file" >"$log" 2>&1
     fi
     local exit_code=$?
+    # Written for every file, pass or fail, so the parent can tell "all green"
+    # apart from "xargs never got round to this file".
+    echo "$test_file" >"$status_dir/$slug.done"
     if [ $exit_code -ne 0 ]; then
-        echo "$test_file" >"$status_dir/$(basename "$test_file").failed"
+        echo "$test_file" >"$status_dir/$slug.failed"
         echo "Test FAILED: $test_file, see log for details..."
     fi
     return $exit_code
 }
-export -f run_one_test
-export status_dir WITH_COVERAGE
+export -f run_one_test slug_for
+export status_dir WITH_COVERAGE test_dir
 
 printf '%s\n' "${test_files[@]}" |
     xargs -P "$workers" -n 1 bash -c 'run_one_test "$0"'
+xargs_code=$?
+
+ran_count=$(find "$status_dir" -name '*.done' | wc -l | tr -d '[:space:]')
 
 failed_tests=()
 for marker in "$status_dir"/*.failed; do
@@ -107,11 +133,28 @@ for test_file in "${failed_tests[@]}"; do
     echo "--------------------------------------"
     echo -e "\033[31mLog of failed test: $test_file\033[0m"
     echo "--------------------------------------"
-    cat "./$(basename "${test_file%.*}")_single_card.log"
+    cat "./$(slug_for "$test_file")_single_card.log"
 done
 
 echo "======================================"
-echo -e "\033[34mTest files executed: $run_count\033[0m"
+echo -e "\033[34mTest files executed: $ran_count / $run_count\033[0m"
+
+# The completion markers, not xargs' exit code, are the primary invariant: the
+# code for "an invocation failed" is 123 on GNU xargs but 1 on BSD, and 1 is
+# also GNU's code for "xargs itself failed" (an invalid -P, for one). A short
+# count covers every one of those cases -- nothing launched, launched and gave
+# up part way -- and cannot be confused with a green run.
+if [ "$ran_count" -ne "$run_count" ]; then
+    echo -e "::error:: \033[31mOnly $ran_count of $run_count test files ran (xargs exited $xargs_code)\033[0m"
+    echo "======================================"
+    exit 1
+fi
+if [ "$xargs_code" -ne 0 ] && [ ${#failed_tests[@]} -eq 0 ]; then
+    echo -e "::error:: \033[31mxargs exited $xargs_code but no test file reported a failure\033[0m"
+    echo "======================================"
+    exit 1
+fi
+
 if [ ${#failed_tests[@]} -eq 0 ]; then
     echo -e "\033[32mAll single card tests passed!\033[0m"
     echo "======================================"

--- a/ci/single_card_test.sh
+++ b/ci/single_card_test.sh
@@ -38,14 +38,10 @@ is_disabled() {
 export FLAGS_embedding_deterministic=1
 export FLAGS_cudnn_deterministic=1
 
-# How many test files run at the same time. Each one still gets its own pytest
-# process, exactly as before -- only the loop is parallel. The job holds a
-# single GPU, so the concurrent files share it.
+# How many test files run at the same time, each still in its own pytest process.
 workers="${PYTEST_WORKERS:-4}"
 
-# Validated before it reaches xargs. A non-numeric value makes xargs fail
-# immediately without running anything, and 0 means "no concurrency limit" in
-# GNU xargs -- 600 pytest processes at once on one GPU.
+# xargs -P runs nothing on a non-numeric value and drops the limit entirely on 0.
 if ! [[ "$workers" =~ ^[1-9][0-9]*$ ]]; then
     echo -e "::error:: \033[31mPYTEST_WORKERS must be a positive integer, got '$workers'\033[0m"
     exit 1
@@ -69,20 +65,11 @@ if [ "$run_count" -eq 0 ]; then
     exit 0
 fi
 
-# One pytest process per test file, unchanged -- these suites set
-# process-global paddle/fleet state at import time and cannot share a process.
-# Only the loop is parallel now: `xargs -P` keeps $workers files in flight.
-#
-# Output of each file goes to its own log instead of straight to stdout,
-# because $workers concurrent processes would interleave into something
-# unreadable. Logs of failing files are dumped at the end; passing files just
-# print one status line, and their log is left on disk.
+# Still one process per file; only the loop is parallel, so logs must not interleave.
 status_dir=$(mktemp -d) || exit 1
 trap 'rm -rf "$status_dir"' EXIT
 
-# Per-file log and marker names are derived from the whole path, not the
-# basename: 22 basenames occur in more than one directory under
-# $test_dir, and two of those running at once would write the same file.
+# From the full path, not the basename: 22 basenames repeat across directories.
 slug_for() {
     local p="${1#./}"
     p="${p#"$test_dir/"}"
@@ -96,17 +83,14 @@ run_one_test() {
     slug=$(slug_for "$test_file")
     local log="./${slug}_single_card.log"
     echo "Running single card test: $test_file"
-    # --parallel-mode: several `coverage run` processes are alive at once, so
-    # each needs its own data file. Workflows that consume the data already run
-    # `coverage combine`.
+    # --parallel-mode: concurrent coverage processes each need their own data file.
     if [[ "${WITH_COVERAGE:-OFF}" == "ON" ]]; then
         coverage run --parallel-mode -m pytest -s "$test_file" >"$log" 2>&1
     else
         pytest -s "$test_file" >"$log" 2>&1
     fi
     local exit_code=$?
-    # Written for every file, pass or fail, so the parent can tell "all green"
-    # apart from "xargs never got round to this file".
+    # Written pass or fail, so a short count means xargs skipped files.
     echo "$test_file" >"$status_dir/$slug.done"
     if [ $exit_code -ne 0 ]; then
         echo "$test_file" >"$status_dir/$slug.failed"
@@ -139,11 +123,7 @@ done
 echo "======================================"
 echo -e "\033[34mTest files executed: $ran_count / $run_count\033[0m"
 
-# The completion markers, not xargs' exit code, are the primary invariant: the
-# code for "an invocation failed" is 123 on GNU xargs but 1 on BSD, and 1 is
-# also GNU's code for "xargs itself failed" (an invalid -P, for one). A short
-# count covers every one of those cases -- nothing launched, launched and gave
-# up part way -- and cannot be confused with a green run.
+# Markers, not xargs' exit code, decide: that code is 123 on GNU but 1 on BSD.
 if [ "$ran_count" -ne "$run_count" ]; then
     echo -e "::error:: \033[31mOnly $ran_count of $run_count test files ran (xargs exited $xargs_code)\033[0m"
     echo "======================================"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,6 @@ test = [
     "wrapt",
     "matplotlib",
     "pytest",
-    "pytest-xdist",
     "pyyaml",
     "parameterized",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ test = [
     "wrapt",
     "matplotlib",
     "pytest",
+    "pytest-xdist",
     "pyyaml",
     "parameterized",
 ]


### PR DESCRIPTION
### PR Category

Execute Infrastructure

### PR Types

Devs

### Description

把单卡单测的执行并行度改成 4，用来压缩总时长。

**workflow job**：跑 pytest 的是 `single_card_test`（`Unit test (single card)`，走 `ci/single_card_test.sh`）。

**原来的写法**：脚本对每个测试文件单独起一个 pytest 进程并等它结束，600 个文件严格串行，而这个 job 独占一整张卡。基线耗时 **81m42s**。

#### 本 PR 采用的方案：保持一文件一进程，只并行循环

`xargs -P 4 -n 1` 让 4 个文件同时在跑，每个文件仍然是自己独立的 pytest 进程，进程级全局状态不会跨文件泄漏，语义与串行完全一致。

配套的几点：

- 每个文件的输出写到 `<name>_single_card.log`：4 个进程同时往 stdout 写会交织成不可读的东西。失败文件在最后把整份 log 打出来，并额外给一行 `::error::` 点名；通过的文件只打一行状态，log 留在磁盘上。
- per-file 的 `check_log_for_exitcode.py` 兜底不再保留。它在单卡路径上本来就没起作用：单卡这边从没有人写过它要找的 `<name>_single_card.log`（`multi-card_test.sh` 是 `tee` 了一个的），所以此前 pytest 非 0 退出实际上就等于失败，现在维持这个判定，不做放宽。
- `coverage run` 加 `--parallel-mode`：同时有多个 coverage 进程存活，各自需要独立数据文件。读取覆盖率的 workflow 本来就会 `coverage combine`，`ci/.coveragerc` 本来也是 `parallel = True`，所以只是把这件事显式化。
- `PYTEST_WORKERS` 可覆盖并发文件数，方便对比 1 / 2 / 4 的耗时。

### 是否引起精度变化

否。只改 CI 执行方式，不涉及框架代码与测试内容，每个测试文件的运行环境（独立进程、独立 paddle 初始化）与串行时相同。唯一的环境变化是 4 个进程共享一张卡，若个别用例显存占用偏大可能出现 OOM —— 这是这次 CI 要观察的点。
