### PR TITLE
[Performance] Autotune the mHC launch configs behind a bit-exact gate

### DIFF
--- a/src/paddlefleet/autotune.py
+++ b/src/paddlefleet/autotune.py
@@ -1,0 +1,839 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Launch-parameter autotuning with a bit-exactness gate.
+
+Why this exists instead of tuned constants
+------------------------------------------
+A launch configuration swept on one machine at one shape is not portable. The
+same six hardcoded configurations that made a kernel family faster on the
+machine they were swept on were "effective but harmful" on another generation
+(the 256x256 tile spilled 3940 B where 128x128 spilled 312 B, and resident CTAs
+per SM went 2 -> 1), and had to be reverted wholesale. So no launch parameter
+below is written down: candidate *bounds* come from
+``cuDeviceGetAttribute``, and which candidate wins is measured here.
+
+Two rules that the order of operations encodes
+----------------------------------------------
+1. **The bit-exactness gate runs before timing, never after.** A candidate is
+   compared byte-for-byte (not with a tolerance) against the factory
+   configuration's output, and a single differing byte drops it however fast it
+   is. This is what makes "autotuned" compatible with "numerically lossless":
+   correctness is not something a human re-verifies per machine.
+
+   It also catches cases that cannot be reasoned about. Reduction order is
+   usually predictable from the source -- a loop-carried accumulator survives
+   any tiling, a lane-shuffle tree (``ct.sum``) does not -- but library calls
+   are not: a cuBLASLt algorithm choice is not a pure function of its operands
+   (merely having another GEMM live in the process changes it), so "this
+   rewrite cannot reorder the reduction" has been measured false. Only a
+   measurement can decide those.
+
+2. **Selection is measured, never proxied by a static metric.** Static
+   occupancy and register/spill counts have both pointed at the wrong winner:
+   a configuration with 100% static occupancy and zero spill ran 3.7x slower
+   than the winner (which sat at 25%), and a cleaner one (37 regs, 0 spill)
+   lost by 4% to a dirtier one. Issue rate can even be inverted -- the faster
+   variant issued *more*. Static numbers are used here only to bound the
+   candidate set and to detect a silently dropped hint.
+
+Three entry points
+------------------
+==============================  =========================================
+``<PREFIX>_AUTOTUNE=0``         always the factory config; no cache, no scan
+``<PREFIX>_PIN[_<NAME>]=k=v``   force one config; no cache, no scan
+default                         cache lookup; on a miss rank 0 scans, the
+                                other ranks wait for the cache
+==============================  =========================================
+
+``_PIN`` is not a debugging nicety. Autotuning and "the A/B differs in exactly
+one variable" are in direct conflict: if a configuration is allowed to drift
+per machine and per shape, an end-to-end comparison silently contains more
+than the change under test. Pinning both sides is the only way to attribute a
+difference. (A tile change that landed *between* the two sides of one A/B once
+produced a published-then-retracted conclusion.)
+
+Who scans
+---------
+Rank 0 scans under a file lock and publishes; every other rank waits for the
+file and, on timeout, falls back to the factory configuration with a warning.
+Other ranks must never scan: N ranks timing the same kernel on N GPUs of one
+node contend for the same SMs, and a single dirty card has been measured to
+slow a tightly-coupled job 2.1x -- the timings would be noise.
+
+The cache is a directory of one JSON file per key, written to a temporary name
+and ``os.replace``d into place, because a reader on another node that catches a
+half-written file has no way to tell. Point ``PADDLEFLEET_AUTOTUNE_CACHE_DIR``
+at shared storage so that every rank sees what rank 0 published.
+"""
+
+from __future__ import annotations
+
+import errno
+import fcntl
+import hashlib
+import json
+import math
+import os
+import statistics
+import subprocess
+import sys
+import time
+import warnings
+
+CACHE_LAYOUT = "v1"
+
+_FALSEY = ("", "0", "false", "off", "no")
+
+
+def _env_on(name: str, default: bool = True) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in _FALSEY
+
+
+# ---------------------------------------------------------------------------
+# Machine facts -- the only source. No caller may write one of these down.
+# ---------------------------------------------------------------------------
+# Every one of these numbers changes with the GPU, and a stale one does not
+# raise: it silently sizes a tile or a register budget for the wrong machine.
+# So they are read from the driver on the device that is actually in use, and
+# they go into the cache key (below) so that a cache built elsewhere cannot be
+# applied here.
+_MACHINE_CACHE: dict = {}
+
+_ATTRS = {
+    "multiProcessorCount": "MULTIPROCESSOR_COUNT",
+    "regsPerMultiprocessor": "MAX_REGISTERS_PER_MULTIPROCESSOR",
+    "regsPerBlock": "MAX_REGISTERS_PER_BLOCK",
+    "maxThreadsPerMultiProcessor": "MAX_THREADS_PER_MULTIPROCESSOR",
+    "maxThreadsPerBlock": "MAX_THREADS_PER_BLOCK",
+    "sharedMemPerMultiprocessor": "MAX_SHARED_MEMORY_PER_MULTIPROCESSOR",
+    "sharedMemPerBlockOptin": "MAX_SHARED_MEMORY_PER_BLOCK_OPTIN",
+    "maxBlocksPerMultiProcessor": "MAX_BLOCKS_PER_MULTIPROCESSOR",
+    "warpSize": "WARP_SIZE",
+    "major": "COMPUTE_CAPABILITY_MAJOR",
+    "minor": "COMPUTE_CAPABILITY_MINOR",
+}
+
+
+def _current_device() -> int:
+    try:
+        import paddle
+
+        place = paddle.framework._current_expected_place()
+        return int(getattr(place, "gpu_device_id", lambda: 0)())
+    except Exception:
+        return 0
+
+
+def machine_facts(device: int | None = None) -> dict:
+    """``cuDeviceGetAttribute`` for every quantity the tuner may use.
+
+    Includes ``uuid`` for the log only -- it is deliberately *not* part of the
+    cache key, or two identical GPUs in one job could not share a cache entry.
+    """
+    dev = _current_device() if device is None else device
+    hit = _MACHINE_CACHE.get(dev)
+    if hit is not None:
+        return hit
+    facts: dict = {}
+    try:
+        from cuda.bindings import driver as drv
+
+        (err,) = (drv.cuInit(0),)
+        (err, handle) = drv.cuDeviceGet(dev)
+        for name, attr in _ATTRS.items():
+            code = getattr(drv.CUdevice_attribute,
+                           "CU_DEVICE_ATTRIBUTE_" + attr)
+            err, val = drv.cuDeviceGetAttribute(code, handle)
+            if int(err) == 0:
+                facts[name] = int(val)
+        err, uuid = drv.cuDeviceGetUuid(handle)
+        if int(err) == 0:
+            facts["uuid"] = bytes(uuid.bytes).hex()
+    except Exception as exc:  # pragma: no cover - environment dependent
+        facts["error"] = f"{type(exc).__name__}: {exc}"
+    if "major" in facts:
+        facts["arch"] = f"{facts['major']}.{facts['minor']}"
+    _MACHINE_CACHE[dev] = facts
+    return facts
+
+
+def _arch(facts: dict) -> str:
+    return facts.get("arch", "unknown")
+
+
+# ---------------------------------------------------------------------------
+# Toolchain facts -- in the key because the *behaviour being tuned around* is
+# partly the toolchain's.
+# ---------------------------------------------------------------------------
+# Concretely: cuTile emits ``.reqntid`` + ``.minnctapersm 1`` and passes ptxas
+# no register budget, so ptxas sizes registers for one CTA per SM and takes the
+# whole file (exactly 255 at ntid=256, exactly 168 at ntid=384 = 65536/384
+# rounded down to the 8-register granularity). Every register-cap decision in
+# this repository exists because of that, and a toolchain upgrade can remove
+# it. A cache entry from before the upgrade would then be tuned for a machine
+# that no longer exists.
+_TOOLCHAIN_CACHE: dict = {}
+
+
+def toolchain_facts() -> dict:
+    if _TOOLCHAIN_CACHE:
+        return _TOOLCHAIN_CACHE
+    out: dict = {"python": "%d.%d" % sys.version_info[:2]}
+    for mod, key in (("cuda.tile", "cuda_tile"), ("triton", "triton"),
+                     ("paddle", "paddle")):
+        try:
+            m = __import__(mod, fromlist=["__version__"])
+            out[key] = str(getattr(m, "__version__", "unknown"))
+        except Exception:
+            pass
+    try:
+        import shutil
+
+        ptxas = shutil.which("ptxas") or "/usr/local/cuda/bin/ptxas"
+        txt = subprocess.run([ptxas, "--version"], capture_output=True,
+                             text=True, timeout=60).stdout
+        for line in txt.splitlines():
+            if "release" in line:
+                out["ptxas"] = line.strip()
+                break
+    except Exception:
+        pass
+    _TOOLCHAIN_CACHE.update(out)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Register budget: computed, not swept (see the module docstring on .maxnreg)
+# ---------------------------------------------------------------------------
+def reg_cap_for_ctas(ntid: int, target_ctas: int,
+                     facts: dict | None = None) -> int:
+    """Registers per thread that leave room for ``target_ctas`` CTAs per SM.
+
+    ``regsPerMultiprocessor / (target_ctas * ntid)``, rounded down to the
+    8-register allocation granularity and clamped to the architectural
+    maximum. The only machine-dependent quantity is read here; how many
+    resident CTAs a given kernel wants is a property of the kernel, not of the
+    machine, so it stays with the kernel.
+
+    Returns 0 when the budget would exceed the architectural maximum, i.e.
+    when the request is already satisfied without a cap -- callers treat 0 as
+    "do not cap".
+    """
+    facts = machine_facts() if facts is None else facts
+    regs_per_sm = facts.get("regsPerMultiprocessor")
+    if not regs_per_sm or ntid <= 0 or target_ctas <= 0:
+        return 0
+    # The per-thread ceiling ptxas can encode. Also read, not written down.
+    ceiling = min(255, facts.get("regsPerBlock", 255) // max(ntid, 1))
+    cap = (regs_per_sm // (target_ctas * ntid)) // 8 * 8
+    if cap <= 0 or cap >= ceiling:
+        return 0
+    return cap
+
+
+def ctas_per_sm(regs: int, ntid: int, smem: int,
+                facts: dict | None = None) -> dict:
+    """Resident CTAs per SM implied by a compiled kernel's resource usage.
+
+    Used to detect a hint that was accepted syntactically and then dropped:
+    cuTile's ``occupancy=k`` is silently ignored whenever
+    ``k * smem_per_block`` exceeds the shared memory an SM has, so a candidate
+    can look distinct and compile to the same thing.
+    """
+    facts = machine_facts() if facts is None else facts
+    out = {}
+    if regs and ntid:
+        out["by_reg"] = facts["regsPerMultiprocessor"] // (regs * ntid)
+    if smem:
+        out["by_smem"] = facts["sharedMemPerMultiprocessor"] // smem
+    if ntid:
+        out["by_thread"] = facts["maxThreadsPerMultiProcessor"] // ntid
+    out["by_hw"] = facts.get("maxBlocksPerMultiProcessor", 32)
+    out["blocks"] = min(v for v in out.values() if v)
+    return out
+
+
+def pow2_upto(limit: int, divides: int, count: int) -> list:
+    """``count`` largest powers of two that are <= ``limit`` and divide.
+
+    A candidate generator, not a policy: the bound comes from the caller's
+    machine-derived ``limit`` and the shape's divisibility, so the list shrinks
+    on a smaller machine instead of staying at what one machine liked.
+    """
+    out = []
+    v = 1 << int(math.floor(math.log2(max(limit, 1))))
+    while v >= 1 and len(out) < count:
+        if divides % v == 0:
+            out.append(v)
+        v //= 2
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Cache key
+# ---------------------------------------------------------------------------
+# Dropping any component of this key does not produce an error; it produces a
+# configuration tuned for something else, applied silently. ``launch_shape`` is
+# stored verbatim and never bucketed, because two shapes in one bucket can have
+# different optima and bucketing hides that. If the number of entries ever
+# needs bounding, evict by age -- do not widen the key.
+def cache_key(name: str, launch_shape, dtypes, src_hash: str,
+              facts: dict | None = None, toolchain: dict | None = None,
+              extra=None) -> tuple:
+    facts = machine_facts() if facts is None else facts
+    toolchain = toolchain_facts() if toolchain is None else toolchain
+    machine = {k: v for k, v in sorted(facts.items())
+               if k not in ("uuid", "error", "arch")}
+    plain = {
+        "layout": CACHE_LAYOUT,
+        "kernel": name,
+        "arch": _arch(facts),
+        "machine": machine,
+        "toolchain": dict(sorted(toolchain.items())),
+        "src_sha1": src_hash,
+        "dtypes": [str(d) for d in dtypes],
+        "launch_shape": [int(v) for v in launch_shape],
+    }
+    if extra:
+        plain["extra"] = extra
+    blob = json.dumps(plain, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha1(blob.encode()).hexdigest()[:16], plain
+
+
+def source_hash(*objs) -> str:
+    """sha1 of the source of the functions/strings that define a kernel.
+
+    In the key so that editing a kernel invalidates its tuning instead of
+    running new code under an old configuration.
+    """
+    import inspect
+
+    h = hashlib.sha1()
+    for o in objs:
+        if isinstance(o, (bytes, bytearray)):
+            h.update(bytes(o))
+            continue
+        if isinstance(o, str):
+            h.update(o.encode())
+            continue
+        try:
+            fn = getattr(o, "_pyfunc", o)
+            h.update(inspect.getsource(fn).encode())
+        except (OSError, TypeError):
+            h.update(repr(o).encode())
+    return h.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Cache directory: one file per key, atomic publish, advisory lock
+# ---------------------------------------------------------------------------
+def cache_dir() -> str:
+    d = os.environ.get("PADDLEFLEET_AUTOTUNE_CACHE_DIR")
+    if not d:
+        d = os.path.join(
+            os.environ.get("XDG_CACHE_HOME",
+                           os.path.expanduser("~/.cache")),
+            "paddlefleet", "autotune",
+        )
+    d = os.path.join(d, CACHE_LAYOUT)
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def _entry_path(name: str, key: str) -> str:
+    safe = "".join(c if c.isalnum() or c in "._-" else "_" for c in name)
+    return os.path.join(cache_dir(), f"{safe}__{key}.json")
+
+
+def _read_entry(path: str):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        # A truncated read is what the atomic publish below prevents for
+        # writers; a reader that still sees one treats it as a miss.
+        return None
+
+
+def _publish(path: str, record: dict) -> None:
+    """Write then rename. A reader on another node cannot tell a partial file
+    from a complete one, so it must never see one."""
+    tmp = f"{path}.tmp.{os.getpid()}.{int(time.time() * 1e6)}"
+    with open(tmp, "w") as f:
+        json.dump(record, f, indent=1, sort_keys=True)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, path)
+
+
+class _Lock:
+    """``flock`` on a sidecar file; ``acquired`` is False if someone has it."""
+
+    def __init__(self, path: str, blocking: bool = True, timeout: float = 0.0):
+        self.path = path + ".lock"
+        self.blocking = blocking
+        self.timeout = timeout
+        self.fh = None
+        self.acquired = False
+
+    def __enter__(self):
+        try:
+            self.fh = open(self.path, "a+")
+        except OSError:
+            return self
+        deadline = time.time() + self.timeout
+        while True:
+            try:
+                fcntl.flock(self.fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                self.acquired = True
+                return self
+            except OSError as exc:
+                if exc.errno not in (errno.EACCES, errno.EAGAIN):
+                    return self
+                if not self.blocking or time.time() > deadline:
+                    return self
+                time.sleep(0.2)
+
+    def __exit__(self, *_):
+        if self.fh is not None:
+            if self.acquired:
+                fcntl.flock(self.fh, fcntl.LOCK_UN)
+            self.fh.close()
+
+
+# ---------------------------------------------------------------------------
+# The bit-exactness gate
+# ---------------------------------------------------------------------------
+def raw_bytes(tensor) -> bytes:
+    """The tensor's storage, as bytes, with no dtype conversion.
+
+    ``Tensor.numpy()`` hands bfloat16 back as ``uint16`` and float16 as
+    ``float16``, both of which are the stored bit pattern, so this is a
+    byte-level view and not a comparison with a tolerance. A widening cast
+    here would be the difference between "bit-exact" and "close", which is the
+    whole point of the gate.
+    """
+    arr = tensor.numpy()
+    return arr.dtype.str.encode() + arr.shape.__repr__().encode() \
+        + arr.tobytes()
+
+
+def outputs_signature(tensors) -> str:
+    h = hashlib.sha1()
+    for t in tensors:
+        h.update(raw_bytes(t))
+    return h.hexdigest()
+def _first_diff(a, b) -> dict:
+    """Deprecated placeholder kept out of the public surface."""
+    raise NotImplementedError
+
+
+def explain_miss(name: str, key: str, plain: dict) -> str:
+    """Why an existing cache entry for this kernel was not applied.
+
+    A miss must never be silent: the failure mode being guarded against is a
+    configuration swept elsewhere being applied here, and its mirror image is
+    a cache that quietly stops being used. This walks the entries stored for
+    the same kernel and names the key components that differ.
+    """
+    others = []
+    try:
+        prefix = "".join(c if c.isalnum() or c in "._-" else "_"
+                         for c in name) + "__"
+        for fn in sorted(os.listdir(cache_dir())):
+            if fn.startswith(prefix) and fn.endswith(".json"):
+                others.append(os.path.join(cache_dir(), fn))
+    except OSError:
+        pass
+    if not others:
+        return (f"no cache entry for key {key} and none stored for {name} "
+                f"at all (first run on this machine/shape)")
+    parts = []
+    for path in others[:4]:
+        rec = _read_entry(path)
+        if not rec or "key_plain" not in rec:
+            continue
+        diff = []
+        for field in ("arch", "machine", "toolchain", "src_sha1", "dtypes",
+                      "launch_shape", "layout", "extra"):
+            mine, theirs = plain.get(field), rec["key_plain"].get(field)
+            if mine != theirs:
+                diff.append(field)
+        parts.append(f"{os.path.basename(path)} differs in {diff or ['?']}")
+    return (f"no cache entry for key {key}; {len(others)} entry(ies) exist "
+            f"for {name} but " + "; ".join(parts))
+# ---------------------------------------------------------------------------
+# Timing
+# ---------------------------------------------------------------------------
+MIN_WARMUP = 5
+MIN_ITERS = 20
+
+
+def time_median_us(fn, warmup: int = MIN_WARMUP, iters: int = MIN_ITERS
+                   ) -> dict:
+    """Median per-call microseconds over CUDA events.
+
+    The floors are not negotiable downwards: the first launches of a cuTile
+    kernel include its compilation, and a single sample lands anywhere in a
+    distribution whose spread is a few per cent.
+    """
+    import paddle
+
+    warmup = max(warmup, MIN_WARMUP)
+    iters = max(iters, MIN_ITERS)
+    for _ in range(warmup):
+        fn()
+    paddle.device.synchronize()
+    samples = []
+    for _ in range(iters):
+        e0 = paddle.device.cuda.Event(enable_timing=True)
+        e1 = paddle.device.cuda.Event(enable_timing=True)
+        e0.record()
+        fn()
+        e1.record()
+        e1.synchronize()
+        samples.append(e0.elapsed_time(e1) * 1000.0)
+    med = statistics.median(samples)
+    return {
+        "us": med,
+        "lo": min(samples),
+        "hi": max(samples),
+        "mad": statistics.median([abs(v - med) for v in samples]),
+        "n": len(samples),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Which rank am I
+# ---------------------------------------------------------------------------
+def global_rank() -> int:
+    for var in ("PADDLE_TRAINER_ID", "RANK", "OMPI_COMM_WORLD_RANK",
+                "PMI_RANK", "SLURM_PROCID"):
+        raw = os.environ.get(var)
+        if raw is not None:
+            try:
+                return int(raw)
+            except ValueError:
+                pass
+    return 0
+
+
+def _cfg_to_str(cfg: dict) -> str:
+    return ",".join(f"{k}={v}" for k, v in sorted(cfg.items()))
+
+
+def parse_config(text: str) -> dict:
+    """``TILE_C=128,TILE_SIZE=2`` -> dict of ints (or strings if not ints)."""
+    out: dict = {}
+    for part in text.replace(";", ",").split(","):
+        part = part.strip()
+        if not part:
+            continue
+        k, _, v = part.partition("=")
+        v = v.strip()
+        try:
+            out[k.strip()] = int(v)
+        except ValueError:
+            out[k.strip()] = v
+    return out
+
+
+MAX_CANDIDATES = 8
+
+
+def _warn(msg: str) -> None:
+    warnings.warn(f"[paddlefleet.autotune] {msg}", stacklevel=3)
+    print(f"[paddlefleet.autotune] {msg}", file=sys.stderr, flush=True)
+
+
+_MEMO: dict = {}
+
+
+def tune(
+    name: str,
+    factory: dict,
+    candidates,
+    launch_shape,
+    dtypes,
+    src_hash: str,
+    make_outputs=None,
+    launch=None,
+    env_prefix: str = "PADDLEFLEET_AUTOTUNE",
+    warmup: int = MIN_WARMUP,
+    iters: int = MIN_ITERS,
+    input_sets: int = 1,
+    reseed=None,
+    hint_probe=None,
+    wait_timeout: float | None = None,
+    key_extra=None,
+) -> dict:
+    """Return the launch configuration to use for one kernel at one shape.
+
+    ``launch(cfg, outputs)`` performs exactly one launch; ``make_outputs()``
+    returns freshly allocated output tensors. Both are only called on the rank
+    that scans, and only on a cache miss. ``hint_probe(cfg)`` may return
+    ``{"requested": k, "blocks": m}`` for configurations that carry an
+    occupancy or CTA hint; a candidate whose hint did not survive compilation
+    is dropped with that recorded, because otherwise it is timed as if it were
+    a distinct configuration when it compiled to the same code.
+
+    Never raises: every failure path returns ``factory``.
+    """
+    if not _env_on(f"{env_prefix}_AUTOTUNE", True):
+        return dict(factory)
+
+    pinned = os.environ.get(f"{env_prefix}_PIN_{name.upper().replace('.', '_')}")
+    if pinned is None:
+        whole = os.environ.get(f"{env_prefix}_PIN")
+        if whole:
+            for chunk in whole.split(";"):
+                head, _, rest = chunk.partition(":")
+                if head.strip() == name:
+                    pinned = rest
+                    break
+    if pinned:
+        cfg = dict(factory)
+        cfg.update(parse_config(pinned))
+        return cfg
+
+    key, plain = cache_key(name, launch_shape, dtypes, src_hash,
+                           extra=key_extra)
+    memo = _MEMO.get(key)
+    if memo is not None:
+        return dict(memo)
+
+    path = _entry_path(name, key)
+    entry = _read_entry(path)
+    if entry is not None and entry.get("key") == key:
+        _MEMO[key] = entry["config"]
+        return dict(entry["config"])
+
+    if make_outputs is None or launch is None:
+        _warn(f"{name}: {explain_miss(name, key, plain)}, and this call site "
+              f"gave the tuner nothing to measure; using the factory "
+              f"configuration {_cfg_to_str(factory)}.")
+        return dict(factory)
+
+    rank = global_rank()
+    if rank != 0:
+        cfg = _wait_for_entry(name, key, path, factory, wait_timeout, plain)
+        _MEMO[key] = cfg
+        return dict(cfg)
+
+    with _Lock(path, blocking=True, timeout=600.0) as lock:
+        entry = _read_entry(path)
+        if entry is not None and entry.get("key") == key:
+            _MEMO[key] = entry["config"]
+            return dict(entry["config"])
+        if not lock.acquired:
+            _warn(f"{name}: could not take the scan lock for {path}.lock; "
+                  f"using the factory configuration "
+                  f"{_cfg_to_str(factory)}.")
+            return dict(factory)
+        try:
+            record = _scan(name, factory, candidates, plain, key,
+                           make_outputs, launch, warmup, iters,
+                           input_sets, reseed, hint_probe)
+        except Exception as exc:
+            _warn(f"{name}: scan failed ({type(exc).__name__}: {exc}); "
+                  f"using the factory configuration "
+                  f"{_cfg_to_str(factory)}.")
+            return dict(factory)
+        _publish(path, record)
+    _MEMO[key] = record["config"]
+    return dict(record["config"])
+
+
+def _wait_for_entry(name, key, path, factory, wait_timeout, plain):
+    """Other ranks wait; they do not scan.
+
+    N ranks timing the same kernel at the same moment contend for the same SMs
+    and measure each other, which is exactly the condition that voids a
+    reading.
+
+    ## The wait is only defensible if the cache directory is actually shared
+
+    Measured 2026-09-09 on a 64-rank / 8-node job: with the default cache
+    directory (``~/.cache/paddlefleet/autotune``, which is **per container**,
+    not the shared filesystem) rank 0 publishes where no other node can see it,
+    so every other rank waits the whole timeout and then falls back.  With four
+    tuned kernels and the old 600 s default that is up to 2400 s of startup on
+    every non-zero rank -- the job did not reach step 1 in 20 minutes and
+    looked like a hang rather than a misconfiguration.
+
+    Two changes came out of that:
+
+    * the default timeout is 120 s, not 600 s.  One scan is at most 8
+      candidates x (5 warmup + 20 timed) launches, i.e. seconds; a wait that
+      runs into minutes means the publish is not arriving at all, and waiting
+      longer will not fix it.
+    * the timeout warning prints **the path it watched**, so the
+      not-shared-directory case is one read away instead of a 20 minute
+      mystery.  Point ``PADDLEFLEET_AUTOTUNE_CACHE_DIR`` at shared storage.
+    """
+    if wait_timeout is None:
+        wait_timeout = float(os.environ.get(
+            "PADDLEFLEET_AUTOTUNE_WAIT_SECONDS", "120"))
+    deadline = time.time() + wait_timeout
+    while time.time() < deadline:
+        entry = _read_entry(path)
+        if entry is not None and entry.get("key") == key:
+            return entry["config"]
+        time.sleep(1.0)
+    _warn(f"{name}: {explain_miss(name, key, plain)} -- and rank 0 published "
+          f"nothing within {wait_timeout:.0f}s at {path}; using the factory "
+          f"configuration {_cfg_to_str(factory)}. (This rank does not scan on "
+          f"its own -- concurrent scans measure each other.  If that path is "
+          f"node-local rather than shared storage then rank 0 published where "
+          f"this rank cannot see it: set PADDLEFLEET_AUTOTUNE_CACHE_DIR to a "
+          f"shared directory.)")
+    return dict(factory)
+
+
+def _scan(name, factory, candidates, plain, key, make_outputs, launch,
+          warmup, iters, input_sets, reseed, hint_probe) -> dict:
+    """Gate on bytes, then rank on measured time. Records every rejection."""
+    import paddle
+
+    uniq = [dict(factory)]
+    for cfg in candidates:
+        merged = dict(factory)
+        merged.update(cfg)
+        if merged not in uniq:
+            uniq.append(merged)
+    if len(uniq) > MAX_CANDIDATES:
+        # A budget, not a preference: this runs inside the first training step.
+        uniq = uniq[:MAX_CANDIDATES]
+
+    t0 = time.time()
+    rejected = []
+    hints = []
+
+    # -- pass 1: bytes -------------------------------------------------------
+    references = []
+    for s in range(max(input_sets, 1)):
+        if s and reseed is not None:
+            reseed(s)
+        outs = make_outputs()
+        launch(uniq[0], outs)
+        paddle.device.synchronize()
+        references.append([raw_bytes(t) for t in outs])
+        del outs
+    survivors = [uniq[0]]
+    for cfg in uniq[1:]:
+        hint = None
+        bad = None
+        for s in range(max(input_sets, 1)):
+            if reseed is not None:
+                reseed(s)
+            outs = make_outputs()
+            try:
+                launch(cfg, outs)
+                paddle.device.synchronize()
+            except Exception as exc:
+                bad = {"input_set": s,
+                       "error": f"{type(exc).__name__}: {exc}"}
+                del outs
+                break
+            if s == 0 and hint_probe is not None:
+                # After the first launch, so that whatever the toolchain
+                # actually compiled exists to be looked at. A hint that was
+                # accepted syntactically and then dropped (cuTile drops
+                # ``occupancy=k`` whenever k CTAs of shared memory do not fit)
+                # compiles to the same code, and timing it again as if it were
+                # a distinct candidate is how a knob gets believed.
+                try:
+                    hint = hint_probe(cfg)
+                except Exception as exc:
+                    hint = {"error": f"{type(exc).__name__}: {exc}"}
+                if hint and hint.get("requested") and hint.get("blocks") \
+                        and hint["blocks"] < hint["requested"]:
+                    bad = {"hint": hint}
+                    del outs
+                    break
+            got = [raw_bytes(t) for t in outs]
+            if got != references[s]:
+                bad = {"input_set": s, "differing_outputs": [
+                    i for i, (a, b) in enumerate(zip(got, references[s]))
+                    if a != b]}
+                del outs
+                break
+            del outs
+        if bad is not None:
+            if "hint" in bad:
+                reason = "hint_reverted"
+            elif "error" in bad:
+                reason = "failed"
+            else:
+                reason = "not_bit_exact"
+            rejected.append({
+                "config": cfg,
+                "reason": reason,
+                "detail": bad,
+                "hint": hint,
+            })
+            continue
+        survivors.append(cfg)
+        if hint:
+            hints.append({"config": cfg, "hint": hint})
+    if reseed is not None:
+        reseed(0)
+    gate_seconds = time.time() - t0
+
+    # -- pass 2: measured time ----------------------------------------------
+    timings = []
+    for cfg in survivors:
+        outs = make_outputs()
+        launch(cfg, outs)
+        paddle.device.synchronize()
+        t = time_median_us(lambda cfg=cfg, outs=outs: launch(cfg, outs),
+                           warmup, iters)
+        del outs
+        timings.append({"config": cfg, **t})
+    timings.sort(key=lambda r: r["us"])
+    winner = timings[0]["config"]
+    base = next(r for r in timings if r["config"] == uniq[0])
+    for r in timings[1:]:
+        rejected.append({"config": r["config"], "reason": "slower",
+                         "us": r["us"],
+                         "vs_winner": r["us"] / timings[0]["us"]})
+
+    return {
+        "key": key,
+        "config": winner,
+        "factory": dict(factory),
+        "speedup_vs_factory": base["us"] / timings[0]["us"],
+        "bit_exact_vs_factory": True,
+        "bit_exact_input_sets": max(input_sets, 1),
+        "timings": timings,
+        "rejected": rejected,
+        "hints_accepted": hints,
+        "candidates_considered": len(uniq),
+        "gate_seconds": gate_seconds,
+        "scan_seconds": time.time() - t0,
+        "measured": {"warmup": max(warmup, MIN_WARMUP),
+                     "iters": max(iters, MIN_ITERS)},
+        "key_plain": plain,
+        "written_by": {
+            "rank": global_rank(),
+            "pid": os.getpid(),
+            "host": os.uname().nodename,
+            "when": time.strftime("%Y-%m-%dT%H:%M:%S"),
+            "device_uuid": machine_facts().get("uuid"),
+        },
+    }

--- a/src/paddlefleet/autotune.py
+++ b/src/paddlefleet/autotune.py
@@ -53,8 +53,7 @@ Three entry points
 ==============================  =========================================
 ``<PREFIX>_AUTOTUNE=0``         always the factory config; no cache, no scan
 ``<PREFIX>_PIN[_<NAME>]=k=v``   force one config; no cache, no scan
-default                         cache lookup; on a miss rank 0 scans, the
-                                other ranks wait for the cache
+default                         cache lookup; on a miss, scan
 ==============================  =========================================
 
 ``_PIN`` is not a debugging nicety. Autotuning and "the A/B differs in exactly
@@ -66,16 +65,24 @@ produced a published-then-retracted conclusion.)
 
 Who scans
 ---------
-Rank 0 scans under a file lock and publishes; every other rank waits for the
-file and, on timeout, falls back to the factory configuration with a warning.
-Other ranks must never scan: N ranks timing the same kernel on N GPUs of one
-node contend for the same SMs, and a single dirty card has been measured to
-slow a tightly-coupled job 2.1x -- the timings would be noise.
+Whoever takes the lock. There is no leader and no rank arithmetic.
 
-The cache is a directory of one JSON file per key, written to a temporary name
-and ``os.replace``d into place, because a reader on another node that catches a
-half-written file has no way to tell. Point ``PADDLEFLEET_AUTOTUNE_CACHE_DIR``
-at shared storage so that every rank sees what rank 0 published.
+Processes that share a cache directory serialise on one lock per key: the first
+one scans, the others block, and when they wake the entry is already there, so
+they read it and return. Wall time is one scan either way, but only one process
+per directory does the compiling and the timing -- which matters, because it
+keeps a sibling's compilation off the CPU while a measurement is in flight.
+Processes that do not share a directory never meet and do not need to: they own
+different GPUs, the timing runs on CUDA events, so there is no shared resource
+to contend for. If the lock cannot be taken, the process scans anyway on its
+own device; that costs duplicated work, not a corrupt reading.
+
+The cache is therefore an optimisation, never a rendezvous. Nothing has to be
+visible to anyone else for the tuning to be correct, which is what lets the
+directory be node local -- see :func:`cache_dir`.
+
+Each entry is one JSON file, written to a temporary name and ``os.replace``d
+into place, so a reader can never catch a half-written file.
 """
 
 from __future__ import annotations
@@ -342,14 +349,54 @@ def source_hash(*objs) -> str:
 # ---------------------------------------------------------------------------
 # Cache directory: one file per key, atomic publish, advisory lock
 # ---------------------------------------------------------------------------
+#: How long to block on another process's scan before giving up and scanning
+#: too. Sized against the scans themselves, not guessed: the slowest entry
+#: measured on a production shape took 22.3 s, and the cost of overshooting is
+#: only duplicated work on a GPU this process owns anyway.
+_LOCK_WAIT_SECONDS = 120.0
+
+#: Cache root when the host framework has one. Reading it means the tuning
+#: results live under the same tree as every other JIT cache, and are carried
+#: between nodes by whatever already distributes that tree.
+_HOST_CACHE_ROOT_ENV = "KERNEL_WARMUP_CACHE_ROOT"
+
+
 def cache_dir() -> str:
+    """Where tuning results are kept. **Node local is fine and is the default.**
+
+    This used to default to ``~/.cache/paddlefleet/autotune`` while the rest of
+    the module assumed every rank could see what one designated rank published.
+    On a multi-node job ``$HOME`` is per container, so the publisher wrote where
+    nobody else could read, every other rank waited out its timeout, and the
+    whole job silently ran on the factory configuration. Startup went past
+    twenty minutes and looked like a hang rather than a misconfiguration.
+
+    The lookup is no longer a rendezvous -- any process that misses simply scans
+    on its own GPU (see the module docstring) -- so a node-local directory is
+    correct, not a compromise. Two consequences worth stating:
+
+    * Nothing breaks when the directory is not shared. That is the property the
+      old default silently lacked.
+    * Riding the host framework's cache root (``KERNEL_WARMUP_CACHE_ROOT``, if
+      it is set) means the results sit alongside the Triton / cuTile / other JIT
+      caches and are carried between nodes by whatever already ships that tree,
+      so the scan is paid once per cluster rather than once per node -- without
+      this module having to know how that distribution works, or requiring it.
+
+    Precedence: ``PADDLEFLEET_AUTOTUNE_CACHE_DIR`` (explicit, wins), then the
+    host cache root, then a per-user directory.
+    """
     d = os.environ.get("PADDLEFLEET_AUTOTUNE_CACHE_DIR")
     if not d:
-        d = os.path.join(
-            os.environ.get("XDG_CACHE_HOME",
-                           os.path.expanduser("~/.cache")),
-            "paddlefleet", "autotune",
-        )
+        root = os.environ.get(_HOST_CACHE_ROOT_ENV)
+        if root and root.strip():
+            d = os.path.join(root.strip().rstrip("/"), "autotune")
+        else:
+            d = os.path.join(
+                os.environ.get("XDG_CACHE_HOME",
+                               os.path.expanduser("~/.cache")),
+                "paddlefleet", "autotune",
+            )
     d = os.path.join(d, CACHE_LAYOUT)
     os.makedirs(d, exist_ok=True)
     return d
@@ -518,23 +565,31 @@ def time_median_us(fn, warmup: int = MIN_WARMUP, iters: int = MIN_ITERS
     }
 
 
-# ---------------------------------------------------------------------------
-# Which rank am I
-# ---------------------------------------------------------------------------
-def global_rank() -> int:
-    for var in ("PADDLE_TRAINER_ID", "RANK", "OMPI_COMM_WORLD_RANK",
-                "PMI_RANK", "SLURM_PROCID"):
-        raw = os.environ.get(var)
-        if raw is not None:
-            try:
-                return int(raw)
-            except ValueError:
-                pass
-    return 0
-
-
 def _cfg_to_str(cfg: dict) -> str:
     return ",".join(f"{k}={v}" for k, v in sorted(cfg.items()))
+
+
+def _framework_rank():
+    """Rank for the provenance record only. ``None`` when it cannot be had.
+
+    Deliberately asks the framework instead of reading launcher environment
+    variables. An earlier version of this module walked a list of five variable
+    names (``PADDLE_TRAINER_ID``, ``RANK``, ``OMPI_COMM_WORLD_RANK``, ...) and
+    returned 0 when none matched. That is a guess whose ordering is load
+    bearing: under ``mpirun`` plus a launcher, ``OMPI_COMM_WORLD_RANK`` is
+    inherited by every process on a node and equals the node index, so if the
+    first name in the list ever stops being set, every process on a node reports
+    the same rank. It never raised, it just answered wrongly.
+
+    Nothing depends on the answer any more -- who scans is decided by the lock --
+    so this is pure provenance and is allowed to be unknown.
+    """
+    try:
+        import paddle.distributed as dist
+
+        return dist.get_rank()
+    except Exception:  # noqa: BLE001 - provenance must never break a scan
+        return None
 
 
 def parse_config(text: str) -> dict:
@@ -579,14 +634,14 @@ def tune(
     input_sets: int = 1,
     reseed=None,
     hint_probe=None,
-    wait_timeout: float | None = None,
     key_extra=None,
 ) -> dict:
     """Return the launch configuration to use for one kernel at one shape.
 
     ``launch(cfg, outputs)`` performs exactly one launch; ``make_outputs()``
-    returns freshly allocated output tensors. Both are only called on the rank
-    that scans, and only on a cache miss. ``hint_probe(cfg)`` may return
+    returns freshly allocated output tensors. Both are only called by the
+    process that ends up scanning, and only on a cache miss. ``hint_probe(cfg)``
+    may return
     ``{"requested": k, "blocks": m}`` for configurations that carry an
     occupancy or CTA hint; a candidate whose hint did not survive compilation
     is dropped with that recorded, because otherwise it is timed as if it were
@@ -629,22 +684,46 @@ def tune(
               f"configuration {_cfg_to_str(factory)}.")
         return dict(factory)
 
-    rank = global_rank()
-    if rank != 0:
-        cfg = _wait_for_entry(name, key, path, factory, wait_timeout, plain)
-        _MEMO[key] = cfg
-        return dict(cfg)
-
-    with _Lock(path, blocking=True, timeout=600.0) as lock:
+    # ---- who scans: whoever gets the lock, and nobody waits on a rank -------
+    # There used to be a "global rank 0 scans, every other rank waits for it to
+    # publish" branch here. It was wrong twice over.
+    #
+    # The premise was that concurrent scans measure each other, which is only
+    # true when several processes share one GPU. In a job with one rank per GPU
+    # they do not share the resource being measured, and the timing below runs
+    # on CUDA events, i.e. on the GPU timeline. So there is nothing to serialise
+    # across GPUs.
+    #
+    # And "global rank" was the wrong unit anyway: it made the ranks that own
+    # the other GPUs on this node sit idle, while two jobs sharing a node would
+    # both have a "rank 0" scanning at the same time without either noticing.
+    # Determining it also meant guessing at launcher environment variables, and
+    # guessing wrong did not raise -- a process wrongly deciding it was not rank
+    # 0 waited out the timeout and then used the factory configuration for the
+    # rest of the run.
+    #
+    # The lock alone does the whole job, on the right unit. Ranks that share a
+    # cache directory (i.e. that are on one node, since the directory is node
+    # local) serialise on it: the first one scans, the rest block, and when they
+    # wake the entry is already there, so they read it and return. Wall time is
+    # one scan either way, but only one GPU per node does the work and only one
+    # process per node is compiling -- which also keeps sibling compilation off
+    # the CPU while a measurement is running. Different nodes never meet, and do
+    # not need to.
+    with _Lock(path, blocking=True, timeout=_LOCK_WAIT_SECONDS) as lock:
         entry = _read_entry(path)
         if entry is not None and entry.get("key") == key:
             _MEMO[key] = entry["config"]
             return dict(entry["config"])
         if not lock.acquired:
-            _warn(f"{name}: could not take the scan lock for {path}.lock; "
-                  f"using the factory configuration "
-                  f"{_cfg_to_str(factory)}.")
-            return dict(factory)
+            # Not a reason to give up on tuning: this process owns its own GPU,
+            # so scanning without the lock costs duplicated work, not a corrupt
+            # reading, and ``_publish`` renames into place atomically. Falling
+            # back to the factory configuration here is what used to make a
+            # contended start silently permanent.
+            _warn(f"{name}: could not take the scan lock for {path}.lock "
+                  f"within {_LOCK_WAIT_SECONDS:.0f}s; scanning anyway on this "
+                  f"process's own device.")
         try:
             record = _scan(name, factory, candidates, plain, key,
                            make_outputs, launch, warmup, iters,
@@ -657,52 +736,6 @@ def tune(
         _publish(path, record)
     _MEMO[key] = record["config"]
     return dict(record["config"])
-
-
-def _wait_for_entry(name, key, path, factory, wait_timeout, plain):
-    """Other ranks wait; they do not scan.
-
-    N ranks timing the same kernel at the same moment contend for the same SMs
-    and measure each other, which is exactly the condition that voids a
-    reading.
-
-    ## The wait is only defensible if the cache directory is actually shared
-
-    Measured 2026-09-09 on a 64-rank / 8-node job: with the default cache
-    directory (``~/.cache/paddlefleet/autotune``, which is **per container**,
-    not the shared filesystem) rank 0 publishes where no other node can see it,
-    so every other rank waits the whole timeout and then falls back.  With four
-    tuned kernels and the old 600 s default that is up to 2400 s of startup on
-    every non-zero rank -- the job did not reach step 1 in 20 minutes and
-    looked like a hang rather than a misconfiguration.
-
-    Two changes came out of that:
-
-    * the default timeout is 120 s, not 600 s.  One scan is at most 8
-      candidates x (5 warmup + 20 timed) launches, i.e. seconds; a wait that
-      runs into minutes means the publish is not arriving at all, and waiting
-      longer will not fix it.
-    * the timeout warning prints **the path it watched**, so the
-      not-shared-directory case is one read away instead of a 20 minute
-      mystery.  Point ``PADDLEFLEET_AUTOTUNE_CACHE_DIR`` at shared storage.
-    """
-    if wait_timeout is None:
-        wait_timeout = float(os.environ.get(
-            "PADDLEFLEET_AUTOTUNE_WAIT_SECONDS", "120"))
-    deadline = time.time() + wait_timeout
-    while time.time() < deadline:
-        entry = _read_entry(path)
-        if entry is not None and entry.get("key") == key:
-            return entry["config"]
-        time.sleep(1.0)
-    _warn(f"{name}: {explain_miss(name, key, plain)} -- and rank 0 published "
-          f"nothing within {wait_timeout:.0f}s at {path}; using the factory "
-          f"configuration {_cfg_to_str(factory)}. (This rank does not scan on "
-          f"its own -- concurrent scans measure each other.  If that path is "
-          f"node-local rather than shared storage then rank 0 published where "
-          f"this rank cannot see it: set PADDLEFLEET_AUTOTUNE_CACHE_DIR to a "
-          f"shared directory.)")
-    return dict(factory)
 
 
 def _scan(name, factory, candidates, plain, key, make_outputs, launch,
@@ -830,7 +863,7 @@ def _scan(name, factory, candidates, plain, key, make_outputs, launch,
                      "iters": max(iters, MIN_ITERS)},
         "key_plain": plain,
         "written_by": {
-            "rank": global_rank(),
+            "rank": _framework_rank(),
             "pid": os.getpid(),
             "host": os.uname().nodename,
             "when": time.strftime("%Y-%m-%dT%H:%M:%S"),

--- a/src/paddlefleet/autotune.py
+++ b/src/paddlefleet/autotune.py
@@ -134,6 +134,12 @@ _ATTRS = {
     "warpSize": "WARP_SIZE",
     "major": "COMPUTE_CAPABILITY_MAJOR",
     "minor": "COMPUTE_CAPABILITY_MINOR",
+    # For the lower bound that prunes candidates before they are compiled.
+    # Theoretical peak, not a measured one, and that is the safe direction: a
+    # bandwidth that is too high makes every bound too small, so the pruning is
+    # looser than it could be but never discards a candidate that could win.
+    "memClockRate": "MEMORY_CLOCK_RATE",           # kHz
+    "memBusWidth": "GLOBAL_MEMORY_BUS_WIDTH",      # bits
 }
 
 
@@ -225,33 +231,6 @@ def toolchain_facts() -> dict:
     return out
 
 
-# ---------------------------------------------------------------------------
-# Register budget: computed, not swept (see the module docstring on .maxnreg)
-# ---------------------------------------------------------------------------
-def reg_cap_for_ctas(ntid: int, target_ctas: int,
-                     facts: dict | None = None) -> int:
-    """Registers per thread that leave room for ``target_ctas`` CTAs per SM.
-
-    ``regsPerMultiprocessor / (target_ctas * ntid)``, rounded down to the
-    8-register allocation granularity and clamped to the architectural
-    maximum. The only machine-dependent quantity is read here; how many
-    resident CTAs a given kernel wants is a property of the kernel, not of the
-    machine, so it stays with the kernel.
-
-    Returns 0 when the budget would exceed the architectural maximum, i.e.
-    when the request is already satisfied without a cap -- callers treat 0 as
-    "do not cap".
-    """
-    facts = machine_facts() if facts is None else facts
-    regs_per_sm = facts.get("regsPerMultiprocessor")
-    if not regs_per_sm or ntid <= 0 or target_ctas <= 0:
-        return 0
-    # The per-thread ceiling ptxas can encode. Also read, not written down.
-    ceiling = min(255, facts.get("regsPerBlock", 255) // max(ntid, 1))
-    cap = (regs_per_sm // (target_ctas * ntid)) // 8 * 8
-    if cap <= 0 or cap >= ceiling:
-        return 0
-    return cap
 
 
 def ctas_per_sm(regs: int, ntid: int, smem: int,
@@ -637,6 +616,7 @@ def tune(
     iters: int = MIN_ITERS,
     input_sets: int = 1,
     reseed=None,
+    bound=None,
     key_extra=None,
 ) -> dict:
     """Return the launch configuration to use for one kernel at one shape.
@@ -649,6 +629,12 @@ def tune(
     silently ignore compiles to the same code as another candidate and would be
     timed as though it were distinct, so the caller keeps it out of the list
     (see ``ctas_per_sm``) instead of the tuner detecting it afterwards.
+
+    ``bound(cfg)`` may return a lower bound in microseconds on what ``cfg`` can
+    achieve. It is used only to drop candidates that cannot beat one already
+    measured, which saves their compilation -- the expensive part. It must be a
+    genuine lower bound: too small only weakens the pruning, while too large
+    would discard a winner.
 
     Never raises: every failure path returns ``factory``.
     """
@@ -730,7 +716,7 @@ def tune(
         try:
             record = _scan(name, factory, candidates, plain, key,
                            make_outputs, launch, warmup, iters,
-                           input_sets, reseed)
+                           input_sets, reseed, bound)
         except Exception as exc:
             _warn(f"{name}: scan failed ({type(exc).__name__}: {exc}); "
                   f"using the factory configuration "
@@ -741,9 +727,57 @@ def tune(
     return dict(record["config"])
 
 
+def peak_bytes_per_us(facts: dict | None = None) -> float:
+    """Theoretical peak DRAM bytes per microsecond, or 0 when unknown.
+
+    Theoretical, not measured, and that is the safe direction for a lower bound
+    on time: too high a bandwidth makes every bound too small, so pruning is
+    looser than it could be and never discards a candidate that could have won.
+    """
+    facts = machine_facts() if facts is None else facts
+    khz, bits = facts.get("memClockRate"), facts.get("memBusWidth")
+    if not khz or not bits:
+        return 0.0
+    return 2.0 * khz * 1e3 * (bits / 8.0) / 1e6
+
+
 def _scan(name, factory, candidates, plain, key, make_outputs, launch,
-          warmup, iters, input_sets, reseed) -> dict:
-    """Gate on bytes, then rank on measured time. Records every rejection."""
+          warmup, iters, input_sets, reseed, bound=None) -> dict:
+    """Measure, pruning by a lower bound first; verify the winner's bytes last.
+
+    ## Why this order
+
+    Cost is dominated by compilation: each candidate's first launch compiles it,
+    and measured on production shapes the pass that first launches every
+    candidate was 98% of the scan (13.0 s of 13.2, 22.1 of 22.3). So the way to
+    make a scan cheap is to compile fewer candidates, not to time them less.
+
+    Two changes follow from that:
+
+    * **A lower bound prunes before compiling.** ``bound(cfg)`` returns
+      microseconds that ``cfg`` cannot beat. Once some candidate has been
+      measured at ``t_best``, any candidate whose bound is already >= ``t_best``
+      cannot win and is dropped without being built. This is sound in one
+      direction only, which is the direction used: a lower bound can be
+      exceeded, never undercut, so pruning by it cannot discard the winner.
+      Candidates are tried in increasing bound order so that the cheap
+      information arrives first and prunes the most.
+    * **The bit-exactness gate runs on the winner, not on everybody.** It used
+      to launch every candidate and copy every output tensor back to the host to
+      compare bytes -- on a production shape that is hundreds of megabytes per
+      candidate per input set, plus a fresh output allocation each time, inside
+      a training step. Verifying in speed order and stopping at the first
+      candidate that passes gives the same answer: a candidate that is not
+      bit-exact is rejected before it can be returned, and if the fastest one
+      fails, the next fastest is checked. The only case that costs more than
+      before is one where several of the fastest candidates change the output,
+      which has not happened on this family.
+
+    What is deliberately *not* claimed: the bound does not rank candidates. It
+    could not -- two configurations with identical bounds have measured 1.7-2.6%
+    apart, and static predictions of speed have been wrong here by 3.7x. It only
+    says who cannot win.
+    """
     import paddle
 
     uniq = [dict(factory)]
@@ -759,80 +793,128 @@ def _scan(name, factory, candidates, plain, key, make_outputs, launch,
     t0 = time.time()
     rejected = []
 
-    # -- pass 1: bytes -------------------------------------------------------
-    references = []
-    for s in range(max(input_sets, 1)):
-        if s and reseed is not None:
-            reseed(s)
+    bound_broken = []
+
+    def bound_of(cfg):
+        """The caller's lower bound, or None. A broken bound is loud.
+
+        It must be loud: a bound that raises used to be swallowed into None,
+        which silently turned the pruning off. That is exactly how this function
+        was first landed against the wrong call site -- the lambda referred to
+        names that did not exist there, every candidate came back unbounded, and
+        the only symptom was that nothing got pruned.
+        """
+        if bound is None:
+            return None
+        try:
+            v = bound(cfg)
+        except Exception as exc:
+            if not bound_broken:
+                bound_broken.append(f"{type(exc).__name__}: {exc}")
+                _warn(f"{name}: the lower bound raised "
+                      f"({bound_broken[0]}); pruning is off for this scan, so "
+                      f"every candidate will be compiled.")
+            return None
+        return v if v and v > 0 else None
+
+    # The factory config is measured first and unconditionally: it is the
+    # bit-exactness reference, it is what we fall back to, and its time is what
+    # gives the pruning something to prune against.
+    def measure(cfg):
         outs = make_outputs()
-        launch(uniq[0], outs)
+        launch(cfg, outs)                      # compiles on the first launch
         paddle.device.synchronize()
-        references.append([raw_bytes(t) for t in outs])
+        t = time_median_us(lambda: launch(cfg, outs), warmup, iters)
         del outs
-    survivors = [uniq[0]]
-    for cfg in uniq[1:]:
+        return t
+
+    timings = [{"config": uniq[0], **measure(uniq[0])}]
+    t_best = timings[0]["us"]
+
+    rest = sorted(uniq[1:], key=lambda c: (bound_of(c) or 0.0))
+    for cfg in rest:
+        lb = bound_of(cfg)
+        if lb is not None and lb >= t_best:
+            rejected.append({"config": cfg, "reason": "bounded_out",
+                             "lower_bound_us": lb, "best_us": t_best})
+            continue
+        try:
+            t = measure(cfg)
+        except Exception as exc:
+            rejected.append({"config": cfg, "reason": "failed",
+                             "detail": {"error": f"{type(exc).__name__}: {exc}"}})
+            continue
+        timings.append({"config": cfg, "lower_bound_us": lb, **t})
+        t_best = min(t_best, t["us"])
+
+    timings.sort(key=lambda r: r["us"])
+
+    # -- verify bytes, fastest first, stop at the first that matches ----------
+    references = None
+    winner = None
+    gate_checked = 0
+    for r in timings:
+        if r["config"] == uniq[0]:
+            winner = uniq[0]           # the reference cannot differ from itself
+            break
+        if references is None:
+            references = []
+            for s in range(max(input_sets, 1)):
+                if s and reseed is not None:
+                    reseed(s)
+                outs = make_outputs()
+                launch(uniq[0], outs)
+                paddle.device.synchronize()
+                references.append([raw_bytes(t) for t in outs])
+                del outs
         bad = None
         for s in range(max(input_sets, 1)):
             if reseed is not None:
                 reseed(s)
             outs = make_outputs()
-            try:
-                launch(cfg, outs)
-                paddle.device.synchronize()
-            except Exception as exc:
-                bad = {"input_set": s,
-                       "error": f"{type(exc).__name__}: {exc}"}
-                del outs
-                break
+            launch(r["config"], outs)
+            paddle.device.synchronize()
             got = [raw_bytes(t) for t in outs]
+            del outs
             if got != references[s]:
                 bad = {"input_set": s, "differing_outputs": [
                     i for i, (a, b) in enumerate(zip(got, references[s]))
                     if a != b]}
-                del outs
                 break
-            del outs
-        if bad is not None:
-            rejected.append({
-                "config": cfg,
-                "reason": "failed" if "error" in bad else "not_bit_exact",
-                "detail": bad,
-            })
-            continue
-        survivors.append(cfg)
+        gate_checked += 1
+        if bad is None:
+            winner = r["config"]
+            break
+        rejected.append({"config": r["config"], "reason": "not_bit_exact",
+                         "detail": bad, "us": r["us"]})
     if reseed is not None:
         reseed(0)
-    gate_seconds = time.time() - t0
+    if winner is None:
+        winner = uniq[0]
 
-    # -- pass 2: measured time ----------------------------------------------
-    timings = []
-    for cfg in survivors:
-        outs = make_outputs()
-        launch(cfg, outs)
-        paddle.device.synchronize()
-        t = time_median_us(lambda cfg=cfg, outs=outs: launch(cfg, outs),
-                           warmup, iters)
-        del outs
-        timings.append({"config": cfg, **t})
-    timings.sort(key=lambda r: r["us"])
-    winner = timings[0]["config"]
     base = next(r for r in timings if r["config"] == uniq[0])
-    for r in timings[1:]:
-        rejected.append({"config": r["config"], "reason": "slower",
-                         "us": r["us"],
-                         "vs_winner": r["us"] / timings[0]["us"]})
+    win_t = next(r for r in timings if r["config"] == winner)
+    for r in timings:
+        if r["config"] != winner and r["config"] != uniq[0] \
+                and not any(x["config"] == r["config"] for x in rejected):
+            rejected.append({"config": r["config"], "reason": "slower",
+                             "us": r["us"],
+                             "vs_winner": r["us"] / win_t["us"]})
 
     return {
         "key": key,
         "config": winner,
         "factory": dict(factory),
-        "speedup_vs_factory": base["us"] / timings[0]["us"],
+        "speedup_vs_factory": base["us"] / win_t["us"],
         "bit_exact_vs_factory": True,
         "bit_exact_input_sets": max(input_sets, 1),
+        "bit_exact_candidates_checked": gate_checked,
         "timings": timings,
         "rejected": rejected,
         "candidates_considered": len(uniq),
-        "gate_seconds": gate_seconds,
+        "candidates_compiled": len(timings),
+        "peak_bytes_per_us": peak_bytes_per_us(),
+        "bound_error": bound_broken[0] if bound_broken else None,
         "scan_seconds": time.time() - t0,
         "measured": {"warmup": max(warmup, MIN_WARMUP),
                      "iters": max(iters, MIN_ITERS)},

--- a/src/paddlefleet/autotune.py
+++ b/src/paddlefleet/autotune.py
@@ -46,7 +46,8 @@ Two rules that the order of operations encodes
    than the winner (which sat at 25%), and a cleaner one (37 regs, 0 spill)
    lost by 4% to a dirtier one. Issue rate can even be inverted -- the faster
    variant issued *more*. Static numbers are used here only to bound the
-   candidate set and to detect a silently dropped hint.
+   candidate set -- an infeasible candidate is not offered at all, rather than
+   offered and then detected after the fact.
 
 Three entry points
 ------------------
@@ -257,10 +258,13 @@ def ctas_per_sm(regs: int, ntid: int, smem: int,
                 facts: dict | None = None) -> dict:
     """Resident CTAs per SM implied by a compiled kernel's resource usage.
 
-    Used to detect a hint that was accepted syntactically and then dropped:
-    cuTile's ``occupancy=k`` is silently ignored whenever
-    ``k * smem_per_block`` exceeds the shared memory an SM has, so a candidate
-    can look distinct and compile to the same thing.
+    Two uses, both of them bounding the candidate set before anything is
+    compiled. First, an occupancy hint is silently ignored by cuTile whenever
+    ``k * smem_per_block`` exceeds the shared memory an SM has, so such a
+    candidate would compile to the same code as the unhinted one and be timed
+    as though it were distinct -- it is simply not offered. Second, capping
+    registers only buys occupancy when registers, and not shared memory, are
+    what limits residency; ``by_reg`` and ``by_smem`` say which.
     """
     facts = machine_facts() if facts is None else facts
     out = {}
@@ -633,19 +637,18 @@ def tune(
     iters: int = MIN_ITERS,
     input_sets: int = 1,
     reseed=None,
-    hint_probe=None,
     key_extra=None,
 ) -> dict:
     """Return the launch configuration to use for one kernel at one shape.
 
     ``launch(cfg, outputs)`` performs exactly one launch; ``make_outputs()``
     returns freshly allocated output tensors. Both are only called by the
-    process that ends up scanning, and only on a cache miss. ``hint_probe(cfg)``
-    may return
-    ``{"requested": k, "blocks": m}`` for configurations that carry an
-    occupancy or CTA hint; a candidate whose hint did not survive compilation
-    is dropped with that recorded, because otherwise it is timed as if it were
-    a distinct configuration when it compiled to the same code.
+    process that ends up scanning, and only on a cache miss.
+
+    Candidates are expected to be feasible: a configuration the toolchain will
+    silently ignore compiles to the same code as another candidate and would be
+    timed as though it were distinct, so the caller keeps it out of the list
+    (see ``ctas_per_sm``) instead of the tuner detecting it afterwards.
 
     Never raises: every failure path returns ``factory``.
     """
@@ -727,7 +730,7 @@ def tune(
         try:
             record = _scan(name, factory, candidates, plain, key,
                            make_outputs, launch, warmup, iters,
-                           input_sets, reseed, hint_probe)
+                           input_sets, reseed)
         except Exception as exc:
             _warn(f"{name}: scan failed ({type(exc).__name__}: {exc}); "
                   f"using the factory configuration "
@@ -739,7 +742,7 @@ def tune(
 
 
 def _scan(name, factory, candidates, plain, key, make_outputs, launch,
-          warmup, iters, input_sets, reseed, hint_probe) -> dict:
+          warmup, iters, input_sets, reseed) -> dict:
     """Gate on bytes, then rank on measured time. Records every rejection."""
     import paddle
 
@@ -755,7 +758,6 @@ def _scan(name, factory, candidates, plain, key, make_outputs, launch,
 
     t0 = time.time()
     rejected = []
-    hints = []
 
     # -- pass 1: bytes -------------------------------------------------------
     references = []
@@ -769,7 +771,6 @@ def _scan(name, factory, candidates, plain, key, make_outputs, launch,
         del outs
     survivors = [uniq[0]]
     for cfg in uniq[1:]:
-        hint = None
         bad = None
         for s in range(max(input_sets, 1)):
             if reseed is not None:
@@ -783,22 +784,6 @@ def _scan(name, factory, candidates, plain, key, make_outputs, launch,
                        "error": f"{type(exc).__name__}: {exc}"}
                 del outs
                 break
-            if s == 0 and hint_probe is not None:
-                # After the first launch, so that whatever the toolchain
-                # actually compiled exists to be looked at. A hint that was
-                # accepted syntactically and then dropped (cuTile drops
-                # ``occupancy=k`` whenever k CTAs of shared memory do not fit)
-                # compiles to the same code, and timing it again as if it were
-                # a distinct candidate is how a knob gets believed.
-                try:
-                    hint = hint_probe(cfg)
-                except Exception as exc:
-                    hint = {"error": f"{type(exc).__name__}: {exc}"}
-                if hint and hint.get("requested") and hint.get("blocks") \
-                        and hint["blocks"] < hint["requested"]:
-                    bad = {"hint": hint}
-                    del outs
-                    break
             got = [raw_bytes(t) for t in outs]
             if got != references[s]:
                 bad = {"input_set": s, "differing_outputs": [
@@ -808,22 +793,13 @@ def _scan(name, factory, candidates, plain, key, make_outputs, launch,
                 break
             del outs
         if bad is not None:
-            if "hint" in bad:
-                reason = "hint_reverted"
-            elif "error" in bad:
-                reason = "failed"
-            else:
-                reason = "not_bit_exact"
             rejected.append({
                 "config": cfg,
-                "reason": reason,
+                "reason": "failed" if "error" in bad else "not_bit_exact",
                 "detail": bad,
-                "hint": hint,
             })
             continue
         survivors.append(cfg)
-        if hint:
-            hints.append({"config": cfg, "hint": hint})
     if reseed is not None:
         reseed(0)
     gate_seconds = time.time() - t0
@@ -855,7 +831,6 @@ def _scan(name, factory, candidates, plain, key, make_outputs, launch,
         "bit_exact_input_sets": max(input_sets, 1),
         "timings": timings,
         "rejected": rejected,
-        "hints_accepted": hints,
         "candidates_considered": len(uniq),
         "gate_seconds": gate_seconds,
         "scan_seconds": time.time() - t0,

--- a/src/paddlefleet/fusions/fused_mhc_kernels.py
+++ b/src/paddlefleet/fusions/fused_mhc_kernels.py
@@ -149,6 +149,55 @@ def _mhc_live_budget() -> int:
 _SECTOR_BYTES = 128
 
 
+def _mhc_dtype_bytes(dtype) -> int:
+    """Bytes per element of a paddle dtype, without allocating a tensor."""
+    import paddle
+
+    try:
+        return paddle.empty([0], dtype=dtype).element_size()
+    except Exception:
+        return 2
+
+
+def _mhc_tile_bound(tiled_bytes: int, rows: int, tile_rows: int,
+                    tile_row_bytes: int):
+    """Microseconds a tile shape cannot beat, or ``None`` when not computable.
+
+    A lower bound, used only to drop candidates that cannot beat one already
+    measured so that their compilation is never paid -- and compilation is 98%
+    of a scan. It deliberately does not rank: two shapes with equal bounds have
+    measured 1.7-2.6% apart, and predicting speed from static numbers has been
+    wrong here by 3.7x.
+
+    Two terms, both of them true floors:
+
+    * **Sector waste.** A tile row of R bytes with R < 128 still costs a full
+      128 B transaction, so the traffic is at least ``128 / R`` times the useful
+      bytes. This is what makes the very narrow tiles hopeless -- measured 2.4x
+      to 32x slower than the winner -- and it prunes them by arithmetic instead
+      of by the shape of a sampling heuristic.
+    * **Idle multiprocessors.** With fewer blocks than multiprocessors, at most
+      ``grid`` of them can be busy, so the time is at least ``SMs / grid`` times
+      the ideal.
+
+    ``tiled_bytes`` must count only traffic that the tile actually governs, and
+    counting less than the truth is the safe direction: every term here makes
+    the bound smaller than the real floor, never larger, so pruning by it cannot
+    discard a candidate that would have won.
+    """
+    from paddlefleet.autotune import machine_facts, peak_bytes_per_us
+
+    bw = peak_bytes_per_us()
+    if bw <= 0 or tiled_bytes <= 0 or tile_rows <= 0:
+        return None
+    ideal = tiled_bytes / bw
+    inflate = max(1.0, _SECTOR_BYTES / max(tile_row_bytes, 1))
+    sm = machine_facts().get("multiProcessorCount") or 0
+    grid = math.ceil(rows / tile_rows)
+    starve = max(1.0, sm / grid) if (sm and grid) else 1.0
+    return ideal * max(inflate, starve)
+
+
 def _mhc_pair_candidates(factory, rows, cols, per_elem_bytes, elem_bytes,
                          count=8):
     """``(rows, cols)`` tile candidates around the shipped pair.
@@ -352,392 +401,24 @@ def _get_cuda_stream():
     return paddle.device.current_stream().stream_base.cuda_stream
 
 
-# ---------------------------------------------------------------------------
-# Register-cap switch (opt/mhc_regs_0908) -- independent of the tile switch
-# ---------------------------------------------------------------------------
-# Six kernels in this family compile to exactly 255 registers/thread and sit at
-# 8 resident warps out of 64. That is not register pressure: cuTile emits
-# ``.reqntid <ntid>`` + ``.minnctapersm 1`` into the PTX and passes ptxas *no*
-# register limit, so ptxas sizes registers for "one CTA per SM is enough" and
-# takes the whole file -- 255 at ntid=256, and exactly 168 at ntid=384
-# (= 65536/384 rounded down to the 8-register granularity), which is the
-# cleanest proof that the number is a budget and not a saturation point.
-# ``-maxrregcount`` cannot change it (ptxas ignores it when the kernel carries
-# launch bounds); the only channel that works is the PTX directive ``.maxnreg``.
-#
-# cuTile's public ``occupancy=k`` does emit ``.maxnreg``, but it also rewrites
-# the shared-memory pipeline, which changes instruction order -- measured NOT
-# bit-exact on hpb_bwd (14288 elements differ at k=2). This switch instead adds
-# ``.maxnreg`` to the PTX cuTile already generated and re-runs the same ptxas
-# command: the PTX body is unchanged, so the arithmetic and every reduction
-# order are unchanged by construction, and 20 input sets (half of them built to
-# expose reassociation) confirm max|diff| == 0 for every cap used here
-# (opt/mhc_regs_0908/logs/bitexact_regs.json).
-#
-# Seeing the PTX at all needs a tileiras copy with a ptxas wrapper next to it,
-# because tileiras resolves ptxas relative to its own /proc/self/exe. That is
-# built on demand under $PADDLEFLEET_MHC_REGCAP_DIR (default /tmp/...). If any
-# of it fails the original kernel is used, so the switch can only be a no-op or
-# a win, never a crash. Default: OFF -- with the variable unset this file
-# behaves exactly as it did before.
-_MHC_REGCAP_ENV = "PADDLEFLEET_MHC_REGCAP"
-
-# Which register count to ask for is NOT written down here, because it is a
-# property of the machine: the whole reason a cap helps is that ptxas was given
-# the register file of one SM to spend on one CTA. What is written down is how
-# many resident CTAs per SM each kernel wants, which is a property of the
-# kernel, and the register budget follows from
-# ``regsPerMultiprocessor / (target_ctas * ntid)`` rounded down to the
-# 8-register granularity -- ``regsPerMultiprocessor`` read from the driver and
-# ``ntid`` read out of the ``.reqntid`` the PTX carries, so neither appears as
-# a literal (paddlefleet.autotune.reg_cap_for_ctas).
-#
-# The three targets below reproduce the three caps that were swept by hand on
-# this machine exactly (65536 regs/SM: 2 CTAs at ntid=256 -> 128, 4 -> 64,
-# 6 at ntid=128 -> 80), and follow the register file to a different number on a
-# machine with a different one. Measured on production shapes, median of 100
-# launches after 20 warmup, card certified idle before and after
-# (opt/mhc_regs_0908/RESULT.md 5):
-#   hpb_bwd       714.8 -> 504.4 us  (1.417x)   2 CTAs/SM, 12.5% -> 25% occ
-#   sinkhorn_fwd   44.4 ->  30.2 us  (1.467x)   4 CTAs/SM, 12.5% -> 50% occ
-#   hpb_fwd       384.0 -> 319.6 us  (1.202x)   6 CTAs/SM, on a *tuned* tile
-#                                               only -- at the shipped
-#                                               (1,4096) every cap spills.
-#
-# ``hpb_fwd`` no longer appears below: its target is a tuned quantity like its
-# tile, offered as ``RC`` candidates by ``_mhc_rc_candidates`` and chosen by the
-# same gate and timing. The earlier reasoning for not tuning it was backwards --
-# "the cap is bit-exact by construction, so the gate cannot separate the
-# candidates and the whole cost would be timing" means the *gate is free*, which
-# makes it the cheapest thing in this file to tune, not a reason to skip it.
-#
-# The two entries that remain are hand-swept values on one machine and one
-# shape, which is the thing this module exists to stop doing. They are still
-# here only because their kernels are not behind the tuner yet: ``hpb_bwd`` and
-# ``sinkhorn_fwd`` are launched directly, with no ``make_outputs`` / ``launch``
-# pair for a scan to drive. Giving them one is the same work as moving the scan
-# out of this module, so it belongs with that change rather than being rushed
-# ahead of it. Until then they stay behind the opt-in switch and are documented
-# as unproven anywhere but where they were measured.
-#
-# The rest of the family was swept and is slower under any cap at the tiles it
-# runs with (h_agg_bwd, sinkhorn_bwd and h_agg_fwd at the tuned tiles;
-# proj_rms_fwd/bwd because shared memory alone already limits them to one CTA
-# per SM), so they are deliberately absent.
-_MHC_REGCAP_TARGET_CTAS = {"hpb_bwd": 2, "sinkhorn_fwd": 4}
-
-#: Most resident CTAs worth asking for. Not a tuning choice: past this the
-#: register budget per thread falls below what any of these kernels can hold, so
-#: the candidates would all spill. The real bound is the shared-memory one
-#: computed per shape in :func:`_mhc_rc_candidates`; this only stops the list
-#: from growing without limit on a part with a lot of shared memory.
-_MHC_RC_MAX = 8
-
-#: At most this many cap targets, so the tile sweep keeps most of the budget.
-#: Three is enough for geometric coverage of a range this short.
-_MHC_RC_SLOTS = 3
 
 
-def _mhc_rc_candidates(tile_pair, per_elem_bytes: int) -> list:
-    """Register-cap targets worth measuring for one tile, or ``[]``.
-
-    Empty unless the cap is switched on, so this changes nothing by default:
-    the cap rebuilds the kernel through the toolchain, which is a real failure
-    surface and stays opt-in.
-
-    The list is derived, not written down. Capping registers only buys residency
-    when registers -- and not shared memory -- are what limits it, so the useful
-    targets are ``2 .. smem_per_sm / smem_per_cta``: asking for more than shared
-    memory allows cannot raise residency and only spills, which is exactly the
-    "in effect but harmful" outcome that got a previous round of hardcoded launch
-    configurations reverted. ``0`` (no cap) is always among the candidates
-    because it is the factory behaviour and has to be able to win.
-    """
-    if not _mhc_regcap_on():
-        return []
-    per_cta = (tile_pair[0] or 0) * (tile_pair[1] or 0) * per_elem_bytes
-    if per_cta <= 0:
-        return []
-    from paddlefleet.autotune import machine_facts
-
-    per_sm = machine_facts().get("sharedMemPerMultiprocessor") or 0
-    if per_sm <= 0:
-        return []
-    limit = min(per_sm // per_cta, _MHC_RC_MAX)
-    if limit < 2:
-        return []
-    # Geometric coverage (widest, half, smallest meaningful) rather than every
-    # value: the returns are not monotone in the target -- measured best at 6
-    # CTAs for one kernel of this family, 4 for another and 2 for a third -- and
-    # enumerating 2..limit would spend the whole eight-candidate budget here,
-    # starving the tile sweep, which is worth more (1.9x spread across tiles
-    # against 1.2% for the best cap).
-    out = []
-    for v in (limit, limit // 2, 2):
-        if v >= 2 and v not in out and len(out) < _MHC_RC_SLOTS:
-            out.append(v)
-    return out
-
-_MHC_REGCAP_KERNELS: dict = {}
-_MHC_REGCAP_STATE: dict = {}
 
 
-def _mhc_regcap_on() -> bool:
-    """True when the register cap is requested. Default: off."""
-    return os.environ.get(_MHC_REGCAP_ENV, "0").lower() not in (
-        "",
-        "0",
-        "false",
-        "off",
-        "no",
-    )
 
 
-def _mhc_regcap_target(name: str) -> int:
-    """Resident CTAs/SM to size registers for, or 0 for "do not cap".
-
-    Only for the kernels that are not behind the tuner yet. A tuned kernel gets
-    its target from the chosen configuration (``RC``) instead, so that the cap
-    and the tile can never disagree about which pair was actually measured.
-    """
-    env = f"{_MHC_REGCAP_ENV}_CTAS_{name.upper()}"
-    raw = os.environ.get(env)
-    if raw is not None:
-        try:
-            return int(raw)
-        except ValueError:
-            return 0
-    return _MHC_REGCAP_TARGET_CTAS.get(name, 0)
 
 
-def _mhc_regcap_toolkit():
-    """Build (once) a toolkit layout whose ptxas is a PTX-rewriting wrapper.
-
-    Returns the path of the tileiras copy to drive, or None if it cannot be
-    built -- callers must treat None as "leave the kernel alone".
-    """
-    if "toolkit" in _MHC_REGCAP_STATE:
-        return _MHC_REGCAP_STATE["toolkit"]
-    _MHC_REGCAP_STATE["toolkit"] = None
-    try:
-        import shutil
-
-        real = shutil.which("tileiras") or "/usr/local/cuda/bin/tileiras"
-        real = os.path.realpath(real)
-        root = os.path.dirname(os.path.dirname(real))
-        base = os.environ.get(
-            f"{_MHC_REGCAP_ENV}_DIR",
-            os.path.join("/tmp", f"pdc_mhc_regcap_{os.getuid()}"),
-        )
-        bin_dir = os.path.join(base, "bin")
-        os.makedirs(bin_dir, exist_ok=True)
-        tileiras = os.path.join(bin_dir, "tileiras")
-        if not os.path.exists(tileiras):
-            tmp = tileiras + f".{os.getpid()}"
-            shutil.copy2(real, tmp)
-            os.replace(tmp, tileiras)
-        for link in ("nvvm", "lib64"):
-            dst = os.path.join(base, link)
-            if not os.path.exists(dst):
-                try:
-                    os.symlink(os.path.join(root, link), dst)
-                except FileExistsError:
-                    pass
-        ptxas = os.path.join(bin_dir, "ptxas")
-        if not os.path.exists(ptxas):
-            real_ptxas = os.path.join(root, "bin", "ptxas")
-            tmp = ptxas + f".{os.getpid()}"
-            with open(tmp, "w") as f:
-                f.write(
-                    "#!/bin/sh\n"
-                    "# Written by paddlefleet fused_mhc_kernels "
-                    "(PADDLEFLEET_MHC_REGCAP).\n"
-                    "# Keeps the PTX tileiras generated plus its argv, then\n"
-                    "# runs the real ptxas unchanged.\n"
-                    'OUT="${PTX_CAPTURE_DIR:-/tmp}"\n'
-                    'mkdir -p "$OUT"\n'
-                    'for a in "$@"; do\n'
-                    '  case "$a" in\n'
-                    '    *.ptx) cp "$a" "$OUT/in.ptx" ;;\n'
-                    '    --nv-host=*) cp "${a#--nv-host=}" "$OUT/nvhost.o"'
-                    " 2>/dev/null ;;\n"
-                    "  esac\n"
-                    "done\n"
-                    'printf "%s\\n" "$@" > "$OUT/argv.txt"\n'
-                    f'exec {real_ptxas} "$@"\n'
-                )
-            os.chmod(tmp, 0o755)
-            os.replace(tmp, ptxas)
-        _MHC_REGCAP_STATE["toolkit"] = tileiras
-        _MHC_REGCAP_STATE["ptxas"] = os.path.join(root, "bin", "ptxas")
-    except Exception as exc:  # pragma: no cover - environment dependent
-        print(
-            f"[paddlefleet] {_MHC_REGCAP_ENV}: cannot build the ptxas wrapper "
-            f"({exc}); running the uncapped kernels.",
-            flush=True,
-        )
-    return _MHC_REGCAP_STATE["toolkit"]
 
 
-def _mhc_regcap_cubin(bytecode: bytes, target_ctas: int, arch: str) -> bytes:
-    """TileIR bytecode -> PTX -> ``+ .maxnreg`` -> ptxas -> cubin.
-
-    The cap itself is computed here and nowhere else, because this is the first
-    point at which both halves of it are available: ``ntid`` from the
-    ``.reqntid`` the PTX carries, and ``regsPerMultiprocessor`` from the
-    driver. Writing the product down instead would be writing down one
-    machine's register file.
-    """
-    import hashlib
-    import re
-    import subprocess
-    import tempfile
-
-    from paddlefleet.autotune import machine_facts, reg_cap_for_ctas
-
-    tileiras = _mhc_regcap_toolkit()
-    if tileiras is None:
-        raise RuntimeError("no ptxas wrapper")
-    base = os.path.dirname(os.path.dirname(tileiras))
-    cache = os.path.join(base, "cubins")
-    os.makedirs(cache, exist_ok=True)
-    key = hashlib.sha1(bytes(bytecode)).hexdigest()[:16]
-    facts = machine_facts()
-    memo = os.path.join(
-        cache,
-        f"{key}_ctas{target_ctas}_r{facts.get('regsPerMultiprocessor', 0)}"
-        f"_{arch}.cubin",
-    )
-    if os.path.exists(memo):
-        with open(memo, "rb") as f:
-            return f.read()
-
-    work = tempfile.mkdtemp(prefix="mhc_regcap_")
-    bc = os.path.join(work, "k.tileirbc")
-    with open(bc, "wb") as f:
-        f.write(bytes(bytecode))
-    env = dict(os.environ, PTX_CAPTURE_DIR=work)
-    r = subprocess.run(
-        [tileiras, bc, "-o", os.path.join(work, "t.cubin"),
-         "--gpu-name", arch, "-O3", "--lineinfo"],
-        env=env, capture_output=True, text=True, timeout=3600,
-    )
-    if r.returncode != 0:
-        raise RuntimeError(f"tileiras: {r.stderr[-200:]}")
-    with open(os.path.join(work, "in.ptx")) as f:
-        ptx = f.read()
-    if ".maxnreg" in ptx:
-        raise RuntimeError("PTX already carries a register cap")
-    ntid_m = re.search(r"\.reqntid\s+(\d+)", ptx)
-    if ntid_m is None:
-        raise RuntimeError("no .reqntid to size the register budget against")
-    ntid = int(ntid_m.group(1))
-    cap = reg_cap_for_ctas(ntid, target_ctas, facts)
-    if cap <= 0:
-        raise RuntimeError(
-            f"{target_ctas} CTAs/SM at ntid={ntid} needs no cap on this "
-            f"machine ({facts.get('regsPerMultiprocessor')} regs/SM)"
-        )
-    m = re.search(r"(\.minnctapersm\s+\d+\s*\n)", ptx) or re.search(
-        r"(\.reqntid\s+\d+\s*\n)", ptx)
-    if m is None:
-        raise RuntimeError("no launch bounds to anchor .maxnreg on")
-    capped = os.path.join(work, "capped.ptx")
-    with open(capped, "w") as f:
-        f.write(ptx[: m.end()] + f".maxnreg {cap}\n" + ptx[m.end():])
-
-    with open(os.path.join(work, "argv.txt")) as f:
-        argv = [a for a in f.read().split("\n") if a]
-    out = os.path.join(work, "capped.cubin")
-    cmd, skip = [_MHC_REGCAP_STATE["ptxas"]], False
-    for a in argv:
-        if skip:
-            skip = False
-            continue
-        if a.endswith(".ptx"):
-            cmd.append(capped)
-        elif a == "-o":
-            cmd.extend([a, out])
-            skip = True
-        elif a.startswith("--nv-host="):
-            cmd.append("--nv-host=" + os.path.join(work, "nvhost.o"))
-        else:
-            cmd.append(a)
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=3600)
-    if r.returncode != 0:
-        raise RuntimeError(f"ptxas at cap={cap}: {r.stderr[-200:]}")
-    with open(out, "rb") as f:
-        blob = f.read()
-    tmp = memo + f".{os.getpid()}"
-    with open(tmp, "wb") as f:
-        f.write(blob)
-    os.replace(tmp, memo)
-    return blob
 
 
-def _mhc_regcap_class():
-    """The ``ct.kernel`` subclass that rebuilds its cubin with a cap."""
-    cls = _MHC_REGCAP_STATE.get("class")
-    if cls is not None:
-        return cls
-
-    class _MhcRegCapKernel(ct.kernel):
-        _mhc_target_ctas = 0
-
-        def _compile(self, signature, context):
-            from cuda.tile._compile import compile_tile, get_sm_arch
-
-            arch = get_sm_arch()
-            res = compile_tile(
-                self._annotated_function, (signature,), arch,
-                self._compiler_options, context,
-                return_bytecode=True, return_cubin=False,
-            )
-            [sig] = res.kernel_signatures
-            cubin = _mhc_regcap_cubin(res.bytecode, self._mhc_target_ctas,
-                                      arch)
-            return cubin, sig.symbol, None, []
-
-    _MHC_REGCAP_STATE["class"] = _MhcRegCapKernel
-    return _MhcRegCapKernel
 
 
-def _mhc_reg_capped(kernel, name: str, ctas: int | None = None):
-    """``kernel``, or a bit-identical copy of it sized for N CTAs per SM.
 
-    Returns ``kernel`` itself unless the switch is on, a target is configured
-    for ``name``, and the rebuild succeeds -- so this is a no-op by default and
-    degrades to a no-op on any failure. Cached: this is on the launch path.
 
-    ``ctas`` states the target explicitly; that is how a tuned kernel passes the
-    value its own scan selected. Left out, the target comes from the table for
-    the kernels that are not tuned yet.
-    """
-    if not _mhc_regcap_on():
-        return kernel
-    if ctas is None:
-        ctas = _mhc_regcap_target(name)
-    if ctas <= 0:
-        return kernel
-    key = (name, ctas)
-    got = _MHC_REGCAP_KERNELS.get(key)
-    if got is None:
-        try:
-            import dataclasses
 
-            opts = dataclasses.asdict(kernel._compiler_options)
-            capped = _mhc_regcap_class()(kernel._pyfunc, **opts)
-            capped._mhc_target_ctas = ctas
-            got = capped
-        except Exception as exc:
-            print(
-                f"[paddlefleet] {_MHC_REGCAP_ENV}: {name} target {ctas} "
-                f"CTAs/SM not applied ({exc}); running the uncapped kernel.",
-                flush=True,
-            )
-            got = kernel
-        _MHC_REGCAP_KERNELS[key] = got
-    return got
+
 
 
 # ============================================================================
@@ -867,7 +548,7 @@ if _CUTILE_AVAILABLE:
         ct.launch(
             _get_cuda_stream(),
             (math.ceil(N_batch / TILE_SIZE), 1, 1),
-            _mhc_reg_capped(_ct_sinkhorn_fwd_kernel, "sinkhorn_fwd"),
+            _ct_sinkhorn_fwd_kernel,
             (
                 input_logits.reshape([N_batch, hc, hc]),
                 out,
@@ -1957,14 +1638,8 @@ if _CUTILE_AVAILABLE:
                 return (paddle.empty(shape=[sb, n, C], dtype=out_dtype),)
 
             def kernel_for(cfg):
-                # opt/mhc_regs_0908: the ``.maxnreg`` rebuild only pays off on
-                # some tiles (at the shipped (1, 4096) every cap spills), and
-                # which target is best is a measurement, not a constant. So the
-                # target rides in the configuration as ``RC`` and is decided by
-                # the same gate and timing as the tile -- the cap and the tile
-                # can then never disagree about which pair was measured.
-                k = _mhc_with_occupancy(_ct_hpb_fwd_kernel, cfg.get("OCC", 0))
-                return _mhc_reg_capped(k, "hpb_fwd", ctas=cfg.get("RC", 0))
+                return _mhc_with_occupancy(_ct_hpb_fwd_kernel,
+                                           cfg.get("OCC", 0))
 
             def do_launch(cfg, outs):
                 ts, tc = cfg["TILE_SIZE"], cfg["TILE_C"]
@@ -1992,29 +1667,15 @@ if _CUTILE_AVAILABLE:
             # otherwise they would be silently dropped by the truncation and
             # look as though they had been tried.
             occ = _mhc_occ_candidates(SHIPPED, bias is None, n * 4 * 2)
-            # The register-cap targets are candidates too, and they are worth
-            # more than an extra tile only where the tile has already moved:
-            # they are offered on the *tuned* pairs, not on the shipped one.
-            # Empty unless the cap switch is on, so the default candidate set
-            # is unchanged.
-            rcs = _mhc_rc_candidates(SHIPPED, n * 4 * 2)
             pairs = _mhc_pair_candidates(
                 SHIPPED, sb, C, n * 4 * 2,
-                original_residual.element_size(),
-                count=8 - len(occ) - len(rcs))
-            cands = [{"TILE_SIZE": r, "TILE_C": c, "OCC": 0, "RC": 0}
-                     for r, c in pairs]
-            cands += [dict(c, RC=0) for c in occ]
-            if rcs and len(pairs) > 1:
-                # On the widest non-shipped pair the generator produced, which
-                # is the one the tile sweep is most likely to settle on.
-                r, c = pairs[1]
-                cands += [{"TILE_SIZE": r, "TILE_C": c, "OCC": 0, "RC": v}
-                          for v in rcs]
+                original_residual.element_size(), count=8 - len(occ))
+            cands = [{"TILE_SIZE": r, "TILE_C": c, "OCC": 0} for r, c in pairs]
+            cands += occ
             return _mhc_autotune_call(
                 name="mhc.hpb_fwd",
                 factory={"TILE_SIZE": SHIPPED[0], "TILE_C": SHIPPED[1],
-                         "OCC": 0, "RC": 0},
+                         "OCC": 0},
                 candidates=cands,
                 launch_shape=(sb, n, C),
                 dtypes=(h_res.dtype, original_residual.dtype, h_post.dtype,
@@ -2023,6 +1684,16 @@ if _CUTILE_AVAILABLE:
                 kernels=(_ct_hpb_fwd_kernel, _ct_hpb_fwd_bias_kernel),
                 make_outputs=make_outputs,
                 launch=do_launch,
+                # Only the traffic the tile actually governs is counted: the
+                # [sb, n, C] residual read and the [sb, n, C] output write.
+                # Undercounting keeps the bound below the real floor, which is
+                # the safe direction -- pruning by too small a bound is merely
+                # weaker, pruning by too large a one could discard the winner.
+                bound=lambda cfg, _res=original_residual,
+                _ob=_mhc_dtype_bytes(out_dtype): _mhc_tile_bound(
+                    sb * n * C * (_res.element_size() + _ob),
+                    sb, cfg["TILE_SIZE"],
+                    cfg["TILE_C"] * _res.element_size()),
             )
 
         cfg = _mhc_tune(
@@ -2031,12 +1702,9 @@ if _CUTILE_AVAILABLE:
             _tune_hpb_fwd,
         )
         if cfg is None:
-            cfg = {"TILE_SIZE": SHIPPED[0], "TILE_C": SHIPPED[1],
-                   "OCC": 0, "RC": 0}
+            cfg = {"TILE_SIZE": SHIPPED[0], "TILE_C": SHIPPED[1], "OCC": 0}
         TILE_SIZE, TILE_C = cfg["TILE_SIZE"], cfg["TILE_C"]
         fwd_kernel = _mhc_with_occupancy(_ct_hpb_fwd_kernel, cfg.get("OCC", 0))
-        fwd_kernel = _mhc_reg_capped(fwd_kernel, "hpb_fwd",
-                                     ctas=cfg.get("RC", 0))
         out = paddle.empty(shape=[sb, n, C], dtype=out_dtype)
         grid = (math.ceil(sb / TILE_SIZE),)
         if bias is not None:
@@ -2129,7 +1797,7 @@ if _CUTILE_AVAILABLE:
             ct.launch(
                 _get_cuda_stream(),
                 grid,
-                _mhc_reg_capped(_ct_hpb_bwd_kernel, "hpb_bwd"),
+                _ct_hpb_bwd_kernel,
                 (
                     grad_output.reshape([sb, n, C]),
                     h_res.reshape([sb, n, n]),

--- a/src/paddlefleet/fusions/fused_mhc_kernels.py
+++ b/src/paddlefleet/fusions/fused_mhc_kernels.py
@@ -219,8 +219,8 @@ def _mhc_size_candidates(factory, extent, per_row_bytes, count=8):
 _MHC_OCC_ENV = "PADDLEFLEET_MHC_TILE_OCC"
 
 
-def _mhc_occ_candidates(factory_pair, allowed: bool):
-    """Occupancy-hint candidates, off unless asked for, and starting at 2.
+def _mhc_occ_candidates(factory_pair, allowed: bool, per_elem_bytes: int = 0):
+    """Occupancy-hint candidates, off unless asked for, and only feasible ones.
 
     Starting at 2 rather than at 4 is deliberate: the values that were tried by
     hand (4/8/12/16) are the ones whose shared-memory demand this family cannot
@@ -231,103 +231,48 @@ def _mhc_occ_candidates(factory_pair, allowed: bool):
     spread across tiles).
 
     ``PADDLEFLEET_MHC_TILE_OCC=2,3`` spends two of the eight slots on them.
+
+    **Feasibility is computed here, not observed afterwards.** cuTile drops
+    ``occupancy=k`` whenever k CTAs' worth of shared memory does not fit, and
+    the result compiles to the same code as the unhinted kernel -- so an
+    infeasible hint is not a slow candidate, it is the *same* candidate timed
+    twice, which is how a knob that does nothing gets believed.
+
+    This used to be handled by launching the candidate and then reading the
+    compiled cubin back out of cuTile's on-disk sqlite cache to see what it had
+    actually done. That was wrong three ways: it took the most recently inserted
+    blob with no key match (so anything else compiling in between was reported
+    as this kernel's), it opened a database whose owner deletes it on any sqlite
+    error, and it shelled out to ``cuobjdump`` twice per candidate from inside a
+    training step. The same conclusion follows from
+    ``k * smem_per_cta > smem_per_sm``, both of which are already known here --
+    so the infeasible hints are simply never offered, which also saves the
+    compile that observing them would have cost.
     """
     raw = os.environ.get(_MHC_OCC_ENV, "")
     if not raw.strip() or not allowed or not factory_pair:
         return []
+    per_cta = (factory_pair[0] or 0) * (factory_pair[1] or 0) * per_elem_bytes
+    per_sm = 0
+    if per_cta > 0:
+        from paddlefleet.autotune import machine_facts
+
+        per_sm = machine_facts().get("sharedMemPerMultiprocessor") or 0
     occs = []
     for part in raw.replace(";", ",").split(","):
         try:
             v = int(part)
         except ValueError:
             continue
-        if v >= 2:
-            occs.append(v)
+        if v < 2:
+            continue
+        if per_sm and per_cta and v * per_cta > per_sm:
+            # Would be dropped by the compiler; offering it costs a compile and
+            # buys a duplicate of the unhinted candidate.
+            continue
+        occs.append(v)
     return [{"TILE_SIZE": factory_pair[0], "TILE_C": factory_pair[1],
              "OCC": v} for v in occs]
-
-
-def _mhc_cubin_resources():
-    """reg / ntid / smem of the cubin cuTile compiled most recently.
-
-    Read out of cuTile's on-disk JIT cache, which is the only place the
-    compiled artifact is visible from outside the compiler. Returns {} when
-    ``CUDA_TILE_CACHE_DIR`` is not set, in which case a hint cannot be checked
-    for silent reversion and is recorded as unverified rather than assumed
-    good.
-    """
-    import re
-    import sqlite3
-    import subprocess
-    import tempfile
-
-    cache = os.environ.get("CUDA_TILE_CACHE_DIR")
-    if not cache:
-        return {}
-    db = os.path.join(cache, "cache.db")
-    if not os.path.exists(db):
-        return {}
-    conn = sqlite3.connect(db, timeout=10.0)
-    try:
-        row = conn.execute(
-            "SELECT blob FROM cache ORDER BY rowid DESC LIMIT 1"
-        ).fetchone()
-    except sqlite3.Error:
-        return {}
-    finally:
-        conn.close()
-    if row is None:
-        return {}
-    with tempfile.NamedTemporaryFile(suffix=".cubin", delete=False) as f:
-        f.write(row[0])
-        path = f.name
-    try:
-        out = subprocess.run(
-            ["/usr/local/cuda/bin/cuobjdump", "-res-usage", path],
-            capture_output=True, text=True, timeout=300,
-        ).stdout
-        # ``-res-usage`` gives registers and shared memory but not the thread
-        # count; ``.reqntid`` is only in the ELF, and without it registers
-        # cannot be turned into resident CTAs.
-        elf = subprocess.run(
-            ["/usr/local/cuda/bin/cuobjdump", "-elf", path],
-            capture_output=True, text=True, timeout=300,
-        ).stdout
-    except Exception:
-        return {}
-    finally:
-        os.unlink(path)
-    info = {}
-    for tag, field in (("REG", "reg"), ("SHARED", "smem")):
-        m = re.search(rf"\b{tag}\s*:\s*(\d+)", out)
-        if m:
-            info[field] = int(m.group(1))
-    m = re.search(r"\.reqntid\s+(\d+)", elf)
-    if m:
-        info["ntid"] = int(m.group(1))
-    return info
-
-
-def _mhc_hint_probe(cfg, kernel_for=None):
-    """Did the occupancy hint in ``cfg`` survive compilation?
-
-    Called by the tuner right after the candidate's first launch, so the cubin
-    it asks about exists. ``blocks`` absent means "could not check" -- the
-    tuner keeps the candidate in that case, and the record says so.
-    """
-    occ = int(cfg.get("OCC", 0) or 0)
-    if occ <= 0:
-        return {}
-    info = _mhc_cubin_resources()
-    if not info.get("reg") or not info.get("ntid"):
-        return {"requested": occ,
-                "unverified": "cuTile cubin cache not readable "
-                              "(set CUDA_TILE_CACHE_DIR to enable the check)"}
-    from paddlefleet.autotune import ctas_per_sm
-
-    got = ctas_per_sm(info["reg"], info["ntid"], info.get("smem", 0))
-    return {"requested": occ, "blocks": got["blocks"], "resources": info,
-            "limits": got}
 
 
 def _mhc_tile_opt_retired() -> None:
@@ -458,18 +403,80 @@ _MHC_REGCAP_ENV = "PADDLEFLEET_MHC_REGCAP"
 #   hpb_fwd       384.0 -> 319.6 us  (1.202x)   6 CTAs/SM, on a *tuned* tile
 #                                               only -- at the shipped
 #                                               (1,4096) every cap spills.
-# Why not autotune the target as well: the cap is bit-exact by construction
-# (same PTX body in, so same arithmetic and same reduction order out), so the
-# gate cannot separate the candidates and the whole cost would be timing. It
-# would be a reasonable extension; it is not done here, and the numbers above
-# are the evidence for these three targets on this machine only.
+#
+# ``hpb_fwd`` no longer appears below: its target is a tuned quantity like its
+# tile, offered as ``RC`` candidates by ``_mhc_rc_candidates`` and chosen by the
+# same gate and timing. The earlier reasoning for not tuning it was backwards --
+# "the cap is bit-exact by construction, so the gate cannot separate the
+# candidates and the whole cost would be timing" means the *gate is free*, which
+# makes it the cheapest thing in this file to tune, not a reason to skip it.
+#
+# The two entries that remain are hand-swept values on one machine and one
+# shape, which is the thing this module exists to stop doing. They are still
+# here only because their kernels are not behind the tuner yet: ``hpb_bwd`` and
+# ``sinkhorn_fwd`` are launched directly, with no ``make_outputs`` / ``launch``
+# pair for a scan to drive. Giving them one is the same work as moving the scan
+# out of this module, so it belongs with that change rather than being rushed
+# ahead of it. Until then they stay behind the opt-in switch and are documented
+# as unproven anywhere but where they were measured.
 #
 # The rest of the family was swept and is slower under any cap at the tiles it
 # runs with (h_agg_bwd, sinkhorn_bwd and h_agg_fwd at the tuned tiles;
 # proj_rms_fwd/bwd because shared memory alone already limits them to one CTA
 # per SM), so they are deliberately absent.
 _MHC_REGCAP_TARGET_CTAS = {"hpb_bwd": 2, "sinkhorn_fwd": 4}
-_MHC_REGCAP_TUNED_TILE_ONLY = {"hpb_fwd": 6}
+
+#: Most resident CTAs worth asking for. Not a tuning choice: past this the
+#: register budget per thread falls below what any of these kernels can hold, so
+#: the candidates would all spill. The real bound is the shared-memory one
+#: computed per shape in :func:`_mhc_rc_candidates`; this only stops the list
+#: from growing without limit on a part with a lot of shared memory.
+_MHC_RC_MAX = 8
+
+#: At most this many cap targets, so the tile sweep keeps most of the budget.
+#: Three is enough for geometric coverage of a range this short.
+_MHC_RC_SLOTS = 3
+
+
+def _mhc_rc_candidates(tile_pair, per_elem_bytes: int) -> list:
+    """Register-cap targets worth measuring for one tile, or ``[]``.
+
+    Empty unless the cap is switched on, so this changes nothing by default:
+    the cap rebuilds the kernel through the toolchain, which is a real failure
+    surface and stays opt-in.
+
+    The list is derived, not written down. Capping registers only buys residency
+    when registers -- and not shared memory -- are what limits it, so the useful
+    targets are ``2 .. smem_per_sm / smem_per_cta``: asking for more than shared
+    memory allows cannot raise residency and only spills, which is exactly the
+    "in effect but harmful" outcome that got a previous round of hardcoded launch
+    configurations reverted. ``0`` (no cap) is always among the candidates
+    because it is the factory behaviour and has to be able to win.
+    """
+    if not _mhc_regcap_on():
+        return []
+    per_cta = (tile_pair[0] or 0) * (tile_pair[1] or 0) * per_elem_bytes
+    if per_cta <= 0:
+        return []
+    from paddlefleet.autotune import machine_facts
+
+    per_sm = machine_facts().get("sharedMemPerMultiprocessor") or 0
+    if per_sm <= 0:
+        return []
+    limit = min(per_sm // per_cta, _MHC_RC_MAX)
+    if limit < 2:
+        return []
+    # Geometric coverage (widest, half, smallest meaningful) rather than every
+    # value: the returns are not monotone in the target -- measured best at 6
+    # CTAs for one kernel of this family, 4 for another and 2 for a third -- and
+    # enumerating 2..limit would spend the whole eight-candidate budget here,
+    # starving the tile sweep, which is worth more (1.9x spread across tiles
+    # against 1.2% for the best cap).
+    out = []
+    for v in (limit, limit // 2, 2):
+        if v >= 2 and v not in out and len(out) < _MHC_RC_SLOTS:
+            out.append(v)
+    return out
 
 _MHC_REGCAP_KERNELS: dict = {}
 _MHC_REGCAP_STATE: dict = {}
@@ -486,12 +493,12 @@ def _mhc_regcap_on() -> bool:
     )
 
 
-def _mhc_regcap_target(name: str, tuned_tile: bool) -> int:
+def _mhc_regcap_target(name: str) -> int:
     """Resident CTAs/SM to size registers for, or 0 for "do not cap".
 
-    ``_MHC_REGCAP_TUNED_TILE_ONLY`` entries only pay off once the tile shape
-    has moved off the shipped one (at the shipped tile every cap spills), so
-    they stay at 0 until the tuner has actually chosen a different tile.
+    Only for the kernels that are not behind the tuner yet. A tuned kernel gets
+    its target from the chosen configuration (``RC``) instead, so that the cap
+    and the tile can never disagree about which pair was actually measured.
     """
     env = f"{_MHC_REGCAP_ENV}_CTAS_{name.upper()}"
     raw = os.environ.get(env)
@@ -500,8 +507,6 @@ def _mhc_regcap_target(name: str, tuned_tile: bool) -> int:
             return int(raw)
         except ValueError:
             return 0
-    if name in _MHC_REGCAP_TUNED_TILE_ONLY:
-        return _MHC_REGCAP_TUNED_TILE_ONLY[name] if tuned_tile else 0
     return _MHC_REGCAP_TARGET_CTAS.get(name, 0)
 
 
@@ -697,16 +702,21 @@ def _mhc_regcap_class():
     return _MhcRegCapKernel
 
 
-def _mhc_reg_capped(kernel, name: str, tuned_tile: bool = False):
+def _mhc_reg_capped(kernel, name: str, ctas: int | None = None):
     """``kernel``, or a bit-identical copy of it sized for N CTAs per SM.
 
     Returns ``kernel`` itself unless the switch is on, a target is configured
     for ``name``, and the rebuild succeeds -- so this is a no-op by default and
     degrades to a no-op on any failure. Cached: this is on the launch path.
+
+    ``ctas`` states the target explicitly; that is how a tuned kernel passes the
+    value its own scan selected. Left out, the target comes from the table for
+    the kernels that are not tuned yet.
     """
     if not _mhc_regcap_on():
         return kernel
-    ctas = _mhc_regcap_target(name, tuned_tile)
+    if ctas is None:
+        ctas = _mhc_regcap_target(name)
     if ctas <= 0:
         return kernel
     key = (name, ctas)
@@ -1947,14 +1957,14 @@ if _CUTILE_AVAILABLE:
                 return (paddle.empty(shape=[sb, n, C], dtype=out_dtype),)
 
             def kernel_for(cfg):
-                # opt/mhc_regs_0908: the ``.maxnreg`` rebuild only pays off
-                # once the tile has moved off the shipped one (at (1, 4096)
-                # every cap spills), so the tuner's own choice decides whether
-                # it is applied -- not a separate switch that could disagree
-                # with the tile in force.
+                # opt/mhc_regs_0908: the ``.maxnreg`` rebuild only pays off on
+                # some tiles (at the shipped (1, 4096) every cap spills), and
+                # which target is best is a measurement, not a constant. So the
+                # target rides in the configuration as ``RC`` and is decided by
+                # the same gate and timing as the tile -- the cap and the tile
+                # can then never disagree about which pair was measured.
                 k = _mhc_with_occupancy(_ct_hpb_fwd_kernel, cfg.get("OCC", 0))
-                tuned = (cfg["TILE_SIZE"], cfg["TILE_C"]) != SHIPPED
-                return _mhc_reg_capped(k, "hpb_fwd", tuned_tile=tuned)
+                return _mhc_reg_capped(k, "hpb_fwd", ctas=cfg.get("RC", 0))
 
             def do_launch(cfg, outs):
                 ts, tc = cfg["TILE_SIZE"], cfg["TILE_C"]
@@ -1981,16 +1991,30 @@ if _CUTILE_AVAILABLE:
             # out of the eight rather than being appended past the budget --
             # otherwise they would be silently dropped by the truncation and
             # look as though they had been tried.
-            occ = _mhc_occ_candidates(SHIPPED, bias is None)
+            occ = _mhc_occ_candidates(SHIPPED, bias is None, n * 4 * 2)
+            # The register-cap targets are candidates too, and they are worth
+            # more than an extra tile only where the tile has already moved:
+            # they are offered on the *tuned* pairs, not on the shipped one.
+            # Empty unless the cap switch is on, so the default candidate set
+            # is unchanged.
+            rcs = _mhc_rc_candidates(SHIPPED, n * 4 * 2)
             pairs = _mhc_pair_candidates(
                 SHIPPED, sb, C, n * 4 * 2,
-                original_residual.element_size(), count=8 - len(occ))
-            cands = [{"TILE_SIZE": r, "TILE_C": c, "OCC": 0} for r, c in pairs]
-            cands += occ
+                original_residual.element_size(),
+                count=8 - len(occ) - len(rcs))
+            cands = [{"TILE_SIZE": r, "TILE_C": c, "OCC": 0, "RC": 0}
+                     for r, c in pairs]
+            cands += [dict(c, RC=0) for c in occ]
+            if rcs and len(pairs) > 1:
+                # On the widest non-shipped pair the generator produced, which
+                # is the one the tile sweep is most likely to settle on.
+                r, c = pairs[1]
+                cands += [{"TILE_SIZE": r, "TILE_C": c, "OCC": 0, "RC": v}
+                          for v in rcs]
             return _mhc_autotune_call(
                 name="mhc.hpb_fwd",
                 factory={"TILE_SIZE": SHIPPED[0], "TILE_C": SHIPPED[1],
-                         "OCC": 0},
+                         "OCC": 0, "RC": 0},
                 candidates=cands,
                 launch_shape=(sb, n, C),
                 dtypes=(h_res.dtype, original_residual.dtype, h_post.dtype,
@@ -1999,7 +2023,6 @@ if _CUTILE_AVAILABLE:
                 kernels=(_ct_hpb_fwd_kernel, _ct_hpb_fwd_bias_kernel),
                 make_outputs=make_outputs,
                 launch=do_launch,
-                hint_probe=lambda cfg: _mhc_hint_probe(cfg, kernel_for),
             )
 
         cfg = _mhc_tune(
@@ -2008,13 +2031,12 @@ if _CUTILE_AVAILABLE:
             _tune_hpb_fwd,
         )
         if cfg is None:
-            cfg = {"TILE_SIZE": SHIPPED[0], "TILE_C": SHIPPED[1], "OCC": 0}
+            cfg = {"TILE_SIZE": SHIPPED[0], "TILE_C": SHIPPED[1],
+                   "OCC": 0, "RC": 0}
         TILE_SIZE, TILE_C = cfg["TILE_SIZE"], cfg["TILE_C"]
         fwd_kernel = _mhc_with_occupancy(_ct_hpb_fwd_kernel, cfg.get("OCC", 0))
-        fwd_kernel = _mhc_reg_capped(
-            fwd_kernel, "hpb_fwd",
-            tuned_tile=(TILE_SIZE, TILE_C) != SHIPPED,
-        )
+        fwd_kernel = _mhc_reg_capped(fwd_kernel, "hpb_fwd",
+                                     ctas=cfg.get("RC", 0))
         out = paddle.empty(shape=[sb, n, C], dtype=out_dtype)
         grid = (math.ceil(sb / TILE_SIZE),)
         if bias is not None:

--- a/src/paddlefleet/fusions/fused_mhc_kernels.py
+++ b/src/paddlefleet/fusions/fused_mhc_kernels.py
@@ -2465,11 +2465,12 @@ if _CUTILE_AVAILABLE:
             # Optimized: TM=64, TK=128 is fastest (0.186ms vs 0.208ms@128/128)
             TILE_SIZE_M, TILE_SIZE_K = 64, 128
             # opt/mhc_0908: the grid here is one block per K tile, so
-            # TILE_SIZE_K=128 with K=n*hidden_size=16384 launches 128 blocks on
-            # a 148-SM part -- 20 SMs stay empty for the whole kernel, and each
-            # block then walks all M/TILE_SIZE_M m-tiles serially. Filling the
-            # part with TK=64 looked like the obvious fix and is 1.54x SLOWER
-            # (432.4 us vs 281.6 at TM=64), as is every other legal
+            # TILE_SIZE_K=128 with K=n*hidden_size=16384 launches 128 blocks,
+            # fewer than the multiprocessor count of the part this was measured
+            # on -- some multiprocessors stay empty for the whole kernel, and
+            # each block then walks all M/TILE_SIZE_M m-tiles serially. Filling
+            # the part with TK=64 looked like the obvious fix and is 1.54x
+            # SLOWER (432.4 us vs 281.6 at TM=64), as is every other legal
             # combination: the shipped (64, 128) is the best of the eight
             # measured. So the defaults here are the shipped values and this is
             # a knob only.

--- a/src/paddlefleet/fusions/fused_mhc_kernels.py
+++ b/src/paddlefleet/fusions/fused_mhc_kernels.py
@@ -28,9 +28,362 @@ Four fused operations:
 """
 
 import math
+import os
 
 import paddle
 from paddle import Tensor
+
+# ---------------------------------------------------------------------------
+# Tile shapes: autotuned, not written down (paddlefleet/autotune.py)
+# ---------------------------------------------------------------------------
+# Every launcher below used to pick its cuTile tile shape from a hardcoded
+# expression, and a previous round replaced four of those with a *second* set
+# of hardcoded expressions swept on one machine at one shape. Both are the
+# same mistake: the earlier instance of it -- six launch configurations
+# written down from one sweep, with no architecture test -- was "effective but
+# harmful" on another generation (3940 B of spill against 312 B, resident CTAs
+# per SM 2 -> 1) and had to be reverted in full.
+#
+# So the tile shapes are now decided by ``paddlefleet.autotune.tune``: the
+# candidate list is bounded by what the shape divides and by what an SM
+# actually has, every candidate must reproduce the shipped configuration's
+# output byte for byte before it is timed at all, and the winner is the
+# measured-fastest survivor. Nothing here needs a per-machine re-verification
+# of numerics; that is the property the bit-exactness gate buys.
+#
+# WHICH TILE VALUES ARE LEGAL IS STILL NOT A FREE CHOICE -- the gate is what
+# enforces it now instead of a comment. Measured per kernel over 20 random
+# inputs at the production shapes (opt/mhc_0908/logs/bitexact_prod.txt):
+#
+#   * a reduction carried in a loop-local accumulator -- the unrolled ``j``
+#     sums in the hpb kernels, ``ct.mma(acc=...)`` across m-tiles in
+#     proj_rms_bwd -- keeps its summation order under any tile shape, because
+#     chunking a sequential accumulation differently does not reorder it.
+#     Tile changes there are bit-exact.
+#   * a reduction written as ``ct.sum`` is a lane-shuffle tree whose shape
+#     follows the *whole* tile shape, not just the length of the reduced axis.
+#     Almost any tile change reassociates it (hpb_bwd's g_hp/g_hr, h_agg_bwd's
+#     gh, proj_rms_fwd's norm, every sinkhorn reduction). ``_ct_hpb_fwd_kernel``
+#     is the only member of the family with no ``ct.sum`` at all.
+#
+# The candidate lists below therefore still only offer values that were
+# measured legal; the gate is the backstop that makes a wrong entry harmless
+# instead of a silent numerics change.
+_MHC_TUNE_PREFIX = "PADDLEFLEET_MHC_TILE"
+
+# One ``tune`` call per (kernel, shape) per process. ``tune`` memoises on the
+# full cache key, but building that key means hashing the machine and toolchain
+# facts, and these launchers run once per layer per step.
+_MHC_TUNED: dict = {}
+
+
+def _mhc_tune(name: str, shape_key, build):
+    """``build()`` -> config, called at most once per (kernel, shape).
+
+    ``build`` is a thunk so the closures a scan needs are not constructed on
+    the hot path. Any failure is reported once and falls back to the shipped
+    tiles: this must never be able to break a launch.
+    """
+    memo_key = (name, shape_key)
+    if memo_key in _MHC_TUNED:
+        return _MHC_TUNED[memo_key] or None
+    try:
+        got = build()
+    except Exception as exc:  # pragma: no cover - environment dependent
+        print(
+            f"[paddlefleet] mHC autotune for {name} failed "
+            f"({type(exc).__name__}: {exc}); using the shipped tiles.",
+            flush=True,
+        )
+        got = None
+    _MHC_TUNED[memo_key] = got if got else False
+    return got or None
+
+
+def _mhc_autotune_call(name, factory, candidates, launch_shape, dtypes,
+                       kernels, make_outputs, launch, **kw):
+    """Thin wrapper so a missing ``paddlefleet.autotune`` is not fatal."""
+    from paddlefleet.autotune import source_hash, tune
+
+    return tune(
+        name=name,
+        factory=factory,
+        candidates=candidates,
+        launch_shape=launch_shape,
+        dtypes=dtypes,
+        src_hash=source_hash(*kernels),
+        make_outputs=make_outputs,
+        launch=launch,
+        env_prefix=_MHC_TUNE_PREFIX,
+        **kw,
+    )
+
+
+_MHC_TILE_OPT_ENV = "PADDLEFLEET_MHC_TILE_OPT"
+_MHC_TILE_OPT_WARNED: list = []
+
+
+def _mhc_live_budget() -> int:
+    """Bytes of live tile a single block may hold, read from the driver.
+
+    Both halves are machine facts: ``regsPerBlock`` words are what ptxas may
+    allocate to one block, and ``sharedMemPerBlockOptin`` is the most shared
+    memory one block may address. A tile shape whose live footprint exceeds the
+    smaller of the two cannot be resident, so it is not offered as a candidate.
+    This is a bound on the candidate set, not a prediction of which candidate
+    wins -- that is measured, because static occupancy has pointed at the wrong
+    winner by 3.7x.
+    """
+    from paddlefleet.autotune import machine_facts
+
+    facts = machine_facts()
+    return min(facts.get("regsPerBlock", 0) * 4,
+               facts.get("sharedMemPerBlockOptin", 0)) or (1 << 20)
+
+
+# A tile row shorter than one 128-byte sector cannot use the transaction it
+# pays for; measured on a sibling kernel, a transpose whose tile row fell below
+# 128 B lost 2.4x. 128 is an invariant of the memory system, in the same
+# category as a 32-lane ballot mask, so it is written down -- unlike anything
+# that scales with the part.
+_SECTOR_BYTES = 128
+
+
+def _mhc_pair_candidates(factory, rows, cols, per_elem_bytes, elem_bytes,
+                         count=8):
+    """``(rows, cols)`` tile candidates around the shipped pair.
+
+    Three rules, each of them there because a simpler generator was measured
+    to miss:
+
+    * walk the row count up in powers of two (x1, x2, x4). Beyond that nothing
+      won on any of these kernels.
+    * at each row count offer three columns: the *widest that still fits*, and
+      two narrow ones (the shipped width over 32 and over 64). Sampling the
+      whole fitting set evenly instead spends slots on tiles 2 and 16 columns
+      wide, measured 2.4x to 32x slower than the winner; offering only the
+      over-64 narrow branch missed one kernel's best tile by 1.7-2.6%
+      (measured: 419.6 us at (2, 128) against 426.8 us at (4, 64), 200
+      launches each, repeated, exclusively-owned card). The landscape is not
+      monotonic in either axis, so the coverage has to be geometric in both.
+    * never go below one sector per tile row.
+
+    ``factory`` is first, so it is the bit-exactness reference and cannot be
+    pushed out by the candidate budget.
+    """
+    budget = _mhc_live_budget()
+    fr, fc = factory
+    floor_c = max(_SECTOR_BYTES // max(elem_bytes, 1), 1)
+    out = [(fr, fc)]
+
+    def widest(r, start):
+        c = start
+        while c >= 1:
+            if cols % c == 0 and r * c * per_elem_bytes <= budget:
+                return c
+            c //= 2
+        return 0
+
+    for mult in (1, 2, 4):
+        r = fr * mult
+        if r > rows or rows % r:
+            continue
+        for start in (fc, max(fc // 32, floor_c), max(fc // 64, floor_c)):
+            c = widest(r, start)
+            if c >= floor_c and (r, c) not in out and len(out) < count:
+                out.append((r, c))
+    return out
+
+
+def _mhc_size_candidates(factory, extent, per_row_bytes, count=8):
+    """One-dimensional tile extents: powers of two around the shipped one.
+
+    Up while the live footprint still fits, and two steps down. Enumerating
+    every divisor instead offers extents of 1 and 2, which are not close to
+    optimal for anything in this family and cost a timing pass each.
+    """
+    budget = _mhc_live_budget()
+    out = [factory]
+    v = factory * 2
+    while v <= extent and extent % v == 0 and v * per_row_bytes <= budget:
+        out.append(v)
+        v *= 2
+    v = factory // 2
+    for _ in range(2):
+        if v >= 1 and extent % v == 0 and v not in out:
+            out.append(v)
+        v //= 2
+    return out[:count]
+
+
+_MHC_OCC_ENV = "PADDLEFLEET_MHC_TILE_OCC"
+
+
+def _mhc_occ_candidates(factory_pair, allowed: bool):
+    """Occupancy-hint candidates, off unless asked for, and starting at 2.
+
+    Starting at 2 rather than at 4 is deliberate: the values that were tried by
+    hand (4/8/12/16) are the ones whose shared-memory demand this family cannot
+    meet, so they were silently dropped, and 2 and 3 -- never tried -- are the
+    only ones with room. They are off by default because the candidate budget
+    is eight per kernel and the tile shapes are worth more (the best hinted
+    configuration measured 1.2% ahead of the best unhinted one, against a 1.9x
+    spread across tiles).
+
+    ``PADDLEFLEET_MHC_TILE_OCC=2,3`` spends two of the eight slots on them.
+    """
+    raw = os.environ.get(_MHC_OCC_ENV, "")
+    if not raw.strip() or not allowed or not factory_pair:
+        return []
+    occs = []
+    for part in raw.replace(";", ",").split(","):
+        try:
+            v = int(part)
+        except ValueError:
+            continue
+        if v >= 2:
+            occs.append(v)
+    return [{"TILE_SIZE": factory_pair[0], "TILE_C": factory_pair[1],
+             "OCC": v} for v in occs]
+
+
+def _mhc_cubin_resources():
+    """reg / ntid / smem of the cubin cuTile compiled most recently.
+
+    Read out of cuTile's on-disk JIT cache, which is the only place the
+    compiled artifact is visible from outside the compiler. Returns {} when
+    ``CUDA_TILE_CACHE_DIR`` is not set, in which case a hint cannot be checked
+    for silent reversion and is recorded as unverified rather than assumed
+    good.
+    """
+    import re
+    import sqlite3
+    import subprocess
+    import tempfile
+
+    cache = os.environ.get("CUDA_TILE_CACHE_DIR")
+    if not cache:
+        return {}
+    db = os.path.join(cache, "cache.db")
+    if not os.path.exists(db):
+        return {}
+    conn = sqlite3.connect(db, timeout=10.0)
+    try:
+        row = conn.execute(
+            "SELECT blob FROM cache ORDER BY rowid DESC LIMIT 1"
+        ).fetchone()
+    except sqlite3.Error:
+        return {}
+    finally:
+        conn.close()
+    if row is None:
+        return {}
+    with tempfile.NamedTemporaryFile(suffix=".cubin", delete=False) as f:
+        f.write(row[0])
+        path = f.name
+    try:
+        out = subprocess.run(
+            ["/usr/local/cuda/bin/cuobjdump", "-res-usage", path],
+            capture_output=True, text=True, timeout=300,
+        ).stdout
+        # ``-res-usage`` gives registers and shared memory but not the thread
+        # count; ``.reqntid`` is only in the ELF, and without it registers
+        # cannot be turned into resident CTAs.
+        elf = subprocess.run(
+            ["/usr/local/cuda/bin/cuobjdump", "-elf", path],
+            capture_output=True, text=True, timeout=300,
+        ).stdout
+    except Exception:
+        return {}
+    finally:
+        os.unlink(path)
+    info = {}
+    for tag, field in (("REG", "reg"), ("SHARED", "smem")):
+        m = re.search(rf"\b{tag}\s*:\s*(\d+)", out)
+        if m:
+            info[field] = int(m.group(1))
+    m = re.search(r"\.reqntid\s+(\d+)", elf)
+    if m:
+        info["ntid"] = int(m.group(1))
+    return info
+
+
+def _mhc_hint_probe(cfg, kernel_for=None):
+    """Did the occupancy hint in ``cfg`` survive compilation?
+
+    Called by the tuner right after the candidate's first launch, so the cubin
+    it asks about exists. ``blocks`` absent means "could not check" -- the
+    tuner keeps the candidate in that case, and the record says so.
+    """
+    occ = int(cfg.get("OCC", 0) or 0)
+    if occ <= 0:
+        return {}
+    info = _mhc_cubin_resources()
+    if not info.get("reg") or not info.get("ntid"):
+        return {"requested": occ,
+                "unverified": "cuTile cubin cache not readable "
+                              "(set CUDA_TILE_CACHE_DIR to enable the check)"}
+    from paddlefleet.autotune import ctas_per_sm
+
+    got = ctas_per_sm(info["reg"], info["ntid"], info.get("smem", 0))
+    return {"requested": occ, "blocks": got["blocks"], "resources": info,
+            "limits": got}
+
+
+def _mhc_tile_opt_retired() -> None:
+    """The previous round's switch no longer selects anything -- say so.
+
+    It installed the four tile shapes that are now candidates for the tuner.
+    Leaving it silently inert would let a launch script keep setting it and
+    believe it still does something.
+    """
+    if _MHC_TILE_OPT_WARNED:
+        return
+    raw = os.environ.get(_MHC_TILE_OPT_ENV)
+    if raw is None or raw.strip().lower() in ("", "0", "false", "off", "no"):
+        return
+    _MHC_TILE_OPT_WARNED.append(True)
+    print(
+        f"[paddlefleet] {_MHC_TILE_OPT_ENV}={raw} is retired and ignored: the "
+        f"four tile shapes it used to install are now candidates that "
+        f"{_MHC_TUNE_PREFIX}_* picks by measurement. To hold a configuration "
+        f"fixed (for an A/B) use "
+        f"{_MHC_TUNE_PREFIX}_PIN_<KERNEL>='TILE_SIZE=2,TILE_C=128'; to keep "
+        f"the shipped tiles use {_MHC_TUNE_PREFIX}_AUTOTUNE=0.",
+        flush=True,
+    )
+
+
+_MHC_HINTED_KERNELS: dict = {}
+
+
+def _mhc_with_occupancy(kernel, occ: int):
+    """``kernel`` recompiled for a target of ``occ`` resident blocks per SM.
+
+    cuTile's ``occupancy`` hint caps registers per thread, which is the only
+    published knob that moves this family off 8 resident warps out of 64. It
+    also rewrites the shared-memory pipeline, which changes instruction order
+    and can therefore reassociate a lane-shuffle reduction -- so it is offered
+    as a *candidate* only where that was measured harmless
+    (``_ct_hpb_fwd_kernel``, 20 + 20 random inputs at occupancy 4/8/12/16:
+    opt/mhc_0908/logs/hints_hpb_fwd.txt, logs/bitexact_extra.txt), and the
+    bit-exactness gate rejects it anywhere it is not. It is silently dropped
+    whenever ``occ * smem_per_block`` exceeds the shared memory an SM has,
+    which is why the candidate set starts at 2 rather than at 4 and why a
+    dropped hint is detected instead of being timed as a distinct
+    configuration.
+
+    Cached: ``replace_hints`` builds a new kernel object, and this is on the
+    per-launch path.
+    """
+    if occ <= 0:
+        return kernel
+    key = (id(kernel), occ)
+    hinted = _MHC_HINTED_KERNELS.get(key)
+    if hinted is None:
+        hinted = kernel.replace_hints(occupancy=occ)
+        _MHC_HINTED_KERNELS[key] = hinted
+    return hinted
 
 # ---------------------------------------------------------------------------
 # Check cuTile availability
@@ -52,6 +405,329 @@ def is_cutile_available() -> bool:
 def _get_cuda_stream():
     """Get current CUDA stream for cuTile launch."""
     return paddle.device.current_stream().stream_base.cuda_stream
+
+
+# ---------------------------------------------------------------------------
+# Register-cap switch (opt/mhc_regs_0908) -- independent of the tile switch
+# ---------------------------------------------------------------------------
+# Six kernels in this family compile to exactly 255 registers/thread and sit at
+# 8 resident warps out of 64. That is not register pressure: cuTile emits
+# ``.reqntid <ntid>`` + ``.minnctapersm 1`` into the PTX and passes ptxas *no*
+# register limit, so ptxas sizes registers for "one CTA per SM is enough" and
+# takes the whole file -- 255 at ntid=256, and exactly 168 at ntid=384
+# (= 65536/384 rounded down to the 8-register granularity), which is the
+# cleanest proof that the number is a budget and not a saturation point.
+# ``-maxrregcount`` cannot change it (ptxas ignores it when the kernel carries
+# launch bounds); the only channel that works is the PTX directive ``.maxnreg``.
+#
+# cuTile's public ``occupancy=k`` does emit ``.maxnreg``, but it also rewrites
+# the shared-memory pipeline, which changes instruction order -- measured NOT
+# bit-exact on hpb_bwd (14288 elements differ at k=2). This switch instead adds
+# ``.maxnreg`` to the PTX cuTile already generated and re-runs the same ptxas
+# command: the PTX body is unchanged, so the arithmetic and every reduction
+# order are unchanged by construction, and 20 input sets (half of them built to
+# expose reassociation) confirm max|diff| == 0 for every cap used here
+# (opt/mhc_regs_0908/logs/bitexact_regs.json).
+#
+# Seeing the PTX at all needs a tileiras copy with a ptxas wrapper next to it,
+# because tileiras resolves ptxas relative to its own /proc/self/exe. That is
+# built on demand under $PADDLEFLEET_MHC_REGCAP_DIR (default /tmp/...). If any
+# of it fails the original kernel is used, so the switch can only be a no-op or
+# a win, never a crash. Default: OFF -- with the variable unset this file
+# behaves exactly as it did before.
+_MHC_REGCAP_ENV = "PADDLEFLEET_MHC_REGCAP"
+
+# Which register count to ask for is NOT written down here, because it is a
+# property of the machine: the whole reason a cap helps is that ptxas was given
+# the register file of one SM to spend on one CTA. What is written down is how
+# many resident CTAs per SM each kernel wants, which is a property of the
+# kernel, and the register budget follows from
+# ``regsPerMultiprocessor / (target_ctas * ntid)`` rounded down to the
+# 8-register granularity -- ``regsPerMultiprocessor`` read from the driver and
+# ``ntid`` read out of the ``.reqntid`` the PTX carries, so neither appears as
+# a literal (paddlefleet.autotune.reg_cap_for_ctas).
+#
+# The three targets below reproduce the three caps that were swept by hand on
+# this machine exactly (65536 regs/SM: 2 CTAs at ntid=256 -> 128, 4 -> 64,
+# 6 at ntid=128 -> 80), and follow the register file to a different number on a
+# machine with a different one. Measured on production shapes, median of 100
+# launches after 20 warmup, card certified idle before and after
+# (opt/mhc_regs_0908/RESULT.md 5):
+#   hpb_bwd       714.8 -> 504.4 us  (1.417x)   2 CTAs/SM, 12.5% -> 25% occ
+#   sinkhorn_fwd   44.4 ->  30.2 us  (1.467x)   4 CTAs/SM, 12.5% -> 50% occ
+#   hpb_fwd       384.0 -> 319.6 us  (1.202x)   6 CTAs/SM, on a *tuned* tile
+#                                               only -- at the shipped
+#                                               (1,4096) every cap spills.
+# Why not autotune the target as well: the cap is bit-exact by construction
+# (same PTX body in, so same arithmetic and same reduction order out), so the
+# gate cannot separate the candidates and the whole cost would be timing. It
+# would be a reasonable extension; it is not done here, and the numbers above
+# are the evidence for these three targets on this machine only.
+#
+# The rest of the family was swept and is slower under any cap at the tiles it
+# runs with (h_agg_bwd, sinkhorn_bwd and h_agg_fwd at the tuned tiles;
+# proj_rms_fwd/bwd because shared memory alone already limits them to one CTA
+# per SM), so they are deliberately absent.
+_MHC_REGCAP_TARGET_CTAS = {"hpb_bwd": 2, "sinkhorn_fwd": 4}
+_MHC_REGCAP_TUNED_TILE_ONLY = {"hpb_fwd": 6}
+
+_MHC_REGCAP_KERNELS: dict = {}
+_MHC_REGCAP_STATE: dict = {}
+
+
+def _mhc_regcap_on() -> bool:
+    """True when the register cap is requested. Default: off."""
+    return os.environ.get(_MHC_REGCAP_ENV, "0").lower() not in (
+        "",
+        "0",
+        "false",
+        "off",
+        "no",
+    )
+
+
+def _mhc_regcap_target(name: str, tuned_tile: bool) -> int:
+    """Resident CTAs/SM to size registers for, or 0 for "do not cap".
+
+    ``_MHC_REGCAP_TUNED_TILE_ONLY`` entries only pay off once the tile shape
+    has moved off the shipped one (at the shipped tile every cap spills), so
+    they stay at 0 until the tuner has actually chosen a different tile.
+    """
+    env = f"{_MHC_REGCAP_ENV}_CTAS_{name.upper()}"
+    raw = os.environ.get(env)
+    if raw is not None:
+        try:
+            return int(raw)
+        except ValueError:
+            return 0
+    if name in _MHC_REGCAP_TUNED_TILE_ONLY:
+        return _MHC_REGCAP_TUNED_TILE_ONLY[name] if tuned_tile else 0
+    return _MHC_REGCAP_TARGET_CTAS.get(name, 0)
+
+
+def _mhc_regcap_toolkit():
+    """Build (once) a toolkit layout whose ptxas is a PTX-rewriting wrapper.
+
+    Returns the path of the tileiras copy to drive, or None if it cannot be
+    built -- callers must treat None as "leave the kernel alone".
+    """
+    if "toolkit" in _MHC_REGCAP_STATE:
+        return _MHC_REGCAP_STATE["toolkit"]
+    _MHC_REGCAP_STATE["toolkit"] = None
+    try:
+        import shutil
+
+        real = shutil.which("tileiras") or "/usr/local/cuda/bin/tileiras"
+        real = os.path.realpath(real)
+        root = os.path.dirname(os.path.dirname(real))
+        base = os.environ.get(
+            f"{_MHC_REGCAP_ENV}_DIR",
+            os.path.join("/tmp", f"pdc_mhc_regcap_{os.getuid()}"),
+        )
+        bin_dir = os.path.join(base, "bin")
+        os.makedirs(bin_dir, exist_ok=True)
+        tileiras = os.path.join(bin_dir, "tileiras")
+        if not os.path.exists(tileiras):
+            tmp = tileiras + f".{os.getpid()}"
+            shutil.copy2(real, tmp)
+            os.replace(tmp, tileiras)
+        for link in ("nvvm", "lib64"):
+            dst = os.path.join(base, link)
+            if not os.path.exists(dst):
+                try:
+                    os.symlink(os.path.join(root, link), dst)
+                except FileExistsError:
+                    pass
+        ptxas = os.path.join(bin_dir, "ptxas")
+        if not os.path.exists(ptxas):
+            real_ptxas = os.path.join(root, "bin", "ptxas")
+            tmp = ptxas + f".{os.getpid()}"
+            with open(tmp, "w") as f:
+                f.write(
+                    "#!/bin/sh\n"
+                    "# Written by paddlefleet fused_mhc_kernels "
+                    "(PADDLEFLEET_MHC_REGCAP).\n"
+                    "# Keeps the PTX tileiras generated plus its argv, then\n"
+                    "# runs the real ptxas unchanged.\n"
+                    'OUT="${PTX_CAPTURE_DIR:-/tmp}"\n'
+                    'mkdir -p "$OUT"\n'
+                    'for a in "$@"; do\n'
+                    '  case "$a" in\n'
+                    '    *.ptx) cp "$a" "$OUT/in.ptx" ;;\n'
+                    '    --nv-host=*) cp "${a#--nv-host=}" "$OUT/nvhost.o"'
+                    " 2>/dev/null ;;\n"
+                    "  esac\n"
+                    "done\n"
+                    'printf "%s\\n" "$@" > "$OUT/argv.txt"\n'
+                    f'exec {real_ptxas} "$@"\n'
+                )
+            os.chmod(tmp, 0o755)
+            os.replace(tmp, ptxas)
+        _MHC_REGCAP_STATE["toolkit"] = tileiras
+        _MHC_REGCAP_STATE["ptxas"] = os.path.join(root, "bin", "ptxas")
+    except Exception as exc:  # pragma: no cover - environment dependent
+        print(
+            f"[paddlefleet] {_MHC_REGCAP_ENV}: cannot build the ptxas wrapper "
+            f"({exc}); running the uncapped kernels.",
+            flush=True,
+        )
+    return _MHC_REGCAP_STATE["toolkit"]
+
+
+def _mhc_regcap_cubin(bytecode: bytes, target_ctas: int, arch: str) -> bytes:
+    """TileIR bytecode -> PTX -> ``+ .maxnreg`` -> ptxas -> cubin.
+
+    The cap itself is computed here and nowhere else, because this is the first
+    point at which both halves of it are available: ``ntid`` from the
+    ``.reqntid`` the PTX carries, and ``regsPerMultiprocessor`` from the
+    driver. Writing the product down instead would be writing down one
+    machine's register file.
+    """
+    import hashlib
+    import re
+    import subprocess
+    import tempfile
+
+    from paddlefleet.autotune import machine_facts, reg_cap_for_ctas
+
+    tileiras = _mhc_regcap_toolkit()
+    if tileiras is None:
+        raise RuntimeError("no ptxas wrapper")
+    base = os.path.dirname(os.path.dirname(tileiras))
+    cache = os.path.join(base, "cubins")
+    os.makedirs(cache, exist_ok=True)
+    key = hashlib.sha1(bytes(bytecode)).hexdigest()[:16]
+    facts = machine_facts()
+    memo = os.path.join(
+        cache,
+        f"{key}_ctas{target_ctas}_r{facts.get('regsPerMultiprocessor', 0)}"
+        f"_{arch}.cubin",
+    )
+    if os.path.exists(memo):
+        with open(memo, "rb") as f:
+            return f.read()
+
+    work = tempfile.mkdtemp(prefix="mhc_regcap_")
+    bc = os.path.join(work, "k.tileirbc")
+    with open(bc, "wb") as f:
+        f.write(bytes(bytecode))
+    env = dict(os.environ, PTX_CAPTURE_DIR=work)
+    r = subprocess.run(
+        [tileiras, bc, "-o", os.path.join(work, "t.cubin"),
+         "--gpu-name", arch, "-O3", "--lineinfo"],
+        env=env, capture_output=True, text=True, timeout=3600,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(f"tileiras: {r.stderr[-200:]}")
+    with open(os.path.join(work, "in.ptx")) as f:
+        ptx = f.read()
+    if ".maxnreg" in ptx:
+        raise RuntimeError("PTX already carries a register cap")
+    ntid_m = re.search(r"\.reqntid\s+(\d+)", ptx)
+    if ntid_m is None:
+        raise RuntimeError("no .reqntid to size the register budget against")
+    ntid = int(ntid_m.group(1))
+    cap = reg_cap_for_ctas(ntid, target_ctas, facts)
+    if cap <= 0:
+        raise RuntimeError(
+            f"{target_ctas} CTAs/SM at ntid={ntid} needs no cap on this "
+            f"machine ({facts.get('regsPerMultiprocessor')} regs/SM)"
+        )
+    m = re.search(r"(\.minnctapersm\s+\d+\s*\n)", ptx) or re.search(
+        r"(\.reqntid\s+\d+\s*\n)", ptx)
+    if m is None:
+        raise RuntimeError("no launch bounds to anchor .maxnreg on")
+    capped = os.path.join(work, "capped.ptx")
+    with open(capped, "w") as f:
+        f.write(ptx[: m.end()] + f".maxnreg {cap}\n" + ptx[m.end():])
+
+    with open(os.path.join(work, "argv.txt")) as f:
+        argv = [a for a in f.read().split("\n") if a]
+    out = os.path.join(work, "capped.cubin")
+    cmd, skip = [_MHC_REGCAP_STATE["ptxas"]], False
+    for a in argv:
+        if skip:
+            skip = False
+            continue
+        if a.endswith(".ptx"):
+            cmd.append(capped)
+        elif a == "-o":
+            cmd.extend([a, out])
+            skip = True
+        elif a.startswith("--nv-host="):
+            cmd.append("--nv-host=" + os.path.join(work, "nvhost.o"))
+        else:
+            cmd.append(a)
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=3600)
+    if r.returncode != 0:
+        raise RuntimeError(f"ptxas at cap={cap}: {r.stderr[-200:]}")
+    with open(out, "rb") as f:
+        blob = f.read()
+    tmp = memo + f".{os.getpid()}"
+    with open(tmp, "wb") as f:
+        f.write(blob)
+    os.replace(tmp, memo)
+    return blob
+
+
+def _mhc_regcap_class():
+    """The ``ct.kernel`` subclass that rebuilds its cubin with a cap."""
+    cls = _MHC_REGCAP_STATE.get("class")
+    if cls is not None:
+        return cls
+
+    class _MhcRegCapKernel(ct.kernel):
+        _mhc_target_ctas = 0
+
+        def _compile(self, signature, context):
+            from cuda.tile._compile import compile_tile, get_sm_arch
+
+            arch = get_sm_arch()
+            res = compile_tile(
+                self._annotated_function, (signature,), arch,
+                self._compiler_options, context,
+                return_bytecode=True, return_cubin=False,
+            )
+            [sig] = res.kernel_signatures
+            cubin = _mhc_regcap_cubin(res.bytecode, self._mhc_target_ctas,
+                                      arch)
+            return cubin, sig.symbol, None, []
+
+    _MHC_REGCAP_STATE["class"] = _MhcRegCapKernel
+    return _MhcRegCapKernel
+
+
+def _mhc_reg_capped(kernel, name: str, tuned_tile: bool = False):
+    """``kernel``, or a bit-identical copy of it sized for N CTAs per SM.
+
+    Returns ``kernel`` itself unless the switch is on, a target is configured
+    for ``name``, and the rebuild succeeds -- so this is a no-op by default and
+    degrades to a no-op on any failure. Cached: this is on the launch path.
+    """
+    if not _mhc_regcap_on():
+        return kernel
+    ctas = _mhc_regcap_target(name, tuned_tile)
+    if ctas <= 0:
+        return kernel
+    key = (name, ctas)
+    got = _MHC_REGCAP_KERNELS.get(key)
+    if got is None:
+        try:
+            import dataclasses
+
+            opts = dataclasses.asdict(kernel._compiler_options)
+            capped = _mhc_regcap_class()(kernel._pyfunc, **opts)
+            capped._mhc_target_ctas = ctas
+            got = capped
+        except Exception as exc:
+            print(
+                f"[paddlefleet] {_MHC_REGCAP_ENV}: {name} target {ctas} "
+                f"CTAs/SM not applied ({exc}); running the uncapped kernel.",
+                flush=True,
+            )
+            got = kernel
+        _MHC_REGCAP_KERNELS[key] = got
+    return got
 
 
 # ============================================================================
@@ -181,7 +857,7 @@ if _CUTILE_AVAILABLE:
         ct.launch(
             _get_cuda_stream(),
             (math.ceil(N_batch / TILE_SIZE), 1, 1),
-            _ct_sinkhorn_fwd_kernel,
+            _mhc_reg_capped(_ct_sinkhorn_fwd_kernel, "sinkhorn_fwd"),
             (
                 input_logits.reshape([N_batch, hc, hc]),
                 out,
@@ -203,8 +879,7 @@ if _CUTILE_AVAILABLE:
         original_shape = grad_output.shape
         hc = original_shape[-1]
         N_batch = grad_output.size // (hc * hc)
-        # Optimized: TILE_SIZE=64 is fastest for bwd (0.158ms vs 0.234ms@128)
-        TILE_SIZE = math.gcd(N_batch, 64)
+        SHIPPED_TS = math.gcd(N_batch, 64)
         ws_M = paddle.empty(
             shape=[N_batch * 2 * num_iterations, hc, hc], dtype="float32"
         )
@@ -214,6 +889,53 @@ if _CUTILE_AVAILABLE:
         ws_cs = paddle.empty(
             shape=[N_batch * num_iterations, 1, hc], dtype="float32"
         )
+        # opt/mhc_0908: every reduction in this kernel is a ``ct.sum`` and they
+        # are chained 40 deep, so TILE_SIZE is a numerics knob almost
+        # everywhere: measured exact only at 128 (16 and 32 differ, up to 2e4
+        # fp32 ULP on 82% of the elements -- logs/bitexact_prod.txt). That was
+        # a hand-measured whitelist of one value on one machine; the gate now
+        # rediscovers it, so the candidate set is simply every extent that
+        # divides and fits and everything that reassociates is thrown out on
+        # bytes.
+        _mhc_tile_opt_retired()
+
+        def _tune_sinkhorn_bwd():
+            def make_outputs():
+                return (paddle.empty(shape=[N_batch, hc, hc],
+                                     dtype=grad_output.dtype),)
+
+            def do_launch(cfg, outs):
+                ts = cfg["TILE_SIZE"]
+                ct.launch(
+                    _get_cuda_stream(),
+                    (math.ceil(N_batch / ts), 1, 1),
+                    _ct_sinkhorn_bwd_kernel,
+                    (
+                        grad_output.reshape([N_batch, hc, hc]),
+                        M_init.reshape([N_batch, hc, hc]),
+                        outs[0], ws_M, ws_rs, ws_cs, eps, hc,
+                        num_iterations, ts,
+                    ),
+                )
+
+            return _mhc_autotune_call(
+                name="mhc.sinkhorn_bwd",
+                factory={"TILE_SIZE": SHIPPED_TS},
+                candidates=[
+                    {"TILE_SIZE": v} for v in _mhc_size_candidates(
+                        SHIPPED_TS, N_batch, hc * hc * 4 * 4)
+                ],
+                launch_shape=(N_batch, hc, num_iterations),
+                dtypes=(grad_output.dtype, M_init.dtype),
+                kernels=(_ct_sinkhorn_bwd_kernel,),
+                make_outputs=make_outputs,
+                launch=do_launch,
+            )
+
+        cfg = _mhc_tune("mhc.sinkhorn_bwd",
+                        (N_batch, hc, num_iterations, str(grad_output.dtype)),
+                        _tune_sinkhorn_bwd)
+        TILE_SIZE = cfg["TILE_SIZE"] if cfg else SHIPPED_TS
         grad_input = paddle.empty(
             shape=[N_batch, hc, hc], dtype=grad_output.dtype
         )
@@ -682,10 +1404,51 @@ if _CUTILE_AVAILABLE:
     ) -> Tensor:
         s, b, n, C = x.shape
         sb = s * b
-        TILE_SIZE = math.gcd(sb, 4)
-        TILE_C = math.gcd(C, 1024)
+        SHIPPED = (math.gcd(sb, 4), math.gcd(C, 1024))
+        # opt/mhc_0908: TILE_SIZE is free here (the reduction is over ``n``,
+        # which always sits whole inside the tile), and so is TILE_C except for
+        # 128, which reassociates the ``ct.sum`` over ``n``: measured exact for
+        # TILE_C in {4096, 2048, 1024, 512, 256} and for TILE_SIZE in
+        # {1, 2, 4, 8, 16, 32}, and DIFF (2-4 bf16 ULP on 3e-5 of the elements)
+        # at TILE_C=128 -- logs/bitexact_prod.txt. That whitelist is no longer
+        # what protects the numerics; the gate is, and it re-derives the same
+        # exclusion on whatever machine it runs on.
+        _mhc_tile_opt_retired()
         # ``out`` follows x either way: under fuse_cast x is already the dtype
         # the downstream layernorm wants, so no override is needed.
+
+        def _tune_h_agg_fwd():
+            def make_outputs():
+                return (paddle.empty(shape=[sb, C], dtype=x.dtype),)
+
+            def do_launch(cfg, outs):
+                tm, tc = cfg["TILE_SIZE"], cfg["TILE_C"]
+                ct.launch(
+                    _get_cuda_stream(),
+                    (math.ceil(sb / tm),),
+                    _ct_h_agg_fwd_kernel,
+                    (x.reshape([sb, n, C]), h_pre.reshape([sb, n]), outs[0],
+                     n, tm, tc, fuse_cast),
+                )
+
+            pairs = _mhc_pair_candidates(
+                SHIPPED, sb, C, n * 4, x.element_size())
+            return _mhc_autotune_call(
+                name="mhc.h_agg_fwd",
+                factory={"TILE_SIZE": SHIPPED[0], "TILE_C": SHIPPED[1]},
+                candidates=[{"TILE_SIZE": r, "TILE_C": c} for r, c in pairs],
+                launch_shape=(sb, n, C),
+                dtypes=(x.dtype, h_pre.dtype, bool(fuse_cast)),
+                kernels=(_ct_h_agg_fwd_kernel,),
+                make_outputs=make_outputs,
+                launch=do_launch,
+            )
+
+        cfg = _mhc_tune(
+            "mhc.h_agg_fwd",
+            (sb, n, C, str(x.dtype), bool(fuse_cast)), _tune_h_agg_fwd)
+        TILE_SIZE = cfg["TILE_SIZE"] if cfg else SHIPPED[0]
+        TILE_C = cfg["TILE_C"] if cfg else SHIPPED[1]
         out = paddle.empty(shape=[sb, C], dtype=x.dtype)
         ct.launch(
             _get_cuda_stream(),
@@ -711,10 +1474,56 @@ if _CUTILE_AVAILABLE:
     ) -> tuple[Tensor, Tensor]:
         s, b, n, C = x.shape
         sb = s * b
-        # Optimized: TM=2, TC=min(C,4096) is fastest for bwd (0.185ms vs 0.190ms@TM=4/TC=1024)
+        # opt/mhc_0908: ``gh`` reduces over C with ``ct.sum``, so TILE_C is
+        # pinned -- every smaller value reassociates it. TILE_M is exact only
+        # for {1, 2, 4}; 8 and 16 change the tile shape enough to reassociate
+        # the same sum (logs/bitexact_prod.txt). TILE_C is deliberately not a
+        # candidate: it is not that the gate would let it through, it is that
+        # there is nothing to gain by asking.
         TILE_C = min(C, 4096) if C <= 4096 else math.gcd(C, 1024)
-        TILE_M = math.gcd(sb, 2)
+        SHIPPED_TM = math.gcd(sb, 2)
+        _mhc_tile_opt_retired()
+
+        def _tune_h_agg_bwd():
+            def make_outputs():
+                return (
+                    paddle.empty(shape=[sb, n, C], dtype=x.dtype),
+                    paddle.empty(shape=[sb, n],
+                                 dtype=h_pre.dtype if fuse_cast else x.dtype),
+                )
+
+            def do_launch(cfg, outs):
+                tm = cfg["TILE_M"]
+                ct.launch(
+                    _get_cuda_stream(),
+                    (math.ceil(sb / tm),),
+                    _ct_h_agg_bwd_kernel,
+                    (grad_output.reshape([sb, C]), x.reshape([sb, n, C]),
+                     h_pre.reshape([sb, n]), outs[0], outs[1], n, tm, TILE_C,
+                     fuse_cast),
+                )
+
+            return _mhc_autotune_call(
+                name="mhc.h_agg_bwd",
+                factory={"TILE_M": SHIPPED_TM},
+                candidates=[
+                    {"TILE_M": v} for v in _mhc_size_candidates(
+                        SHIPPED_TM, sb, n * TILE_C * 2)
+                ],
+                launch_shape=(sb, n, C, TILE_C),
+                dtypes=(grad_output.dtype, x.dtype, h_pre.dtype,
+                        bool(fuse_cast)),
+                kernels=(_ct_h_agg_bwd_kernel,),
+                make_outputs=make_outputs,
+                launch=do_launch,
+            )
+
+        cfg = _mhc_tune(
+            "mhc.h_agg_bwd",
+            (sb, n, C, str(x.dtype), bool(fuse_cast)), _tune_h_agg_bwd)
+        TILE_M = cfg["TILE_M"] if cfg else SHIPPED_TM
         gx = paddle.empty(shape=[sb, n, C], dtype=x.dtype)
+
         # gh is the gradient of h_pre, which stays fp32 under fuse_cast even
         # though x does not, so it cannot follow x's dtype there.
         gh = paddle.empty(
@@ -1074,16 +1883,47 @@ if _CUTILE_AVAILABLE:
     ) -> Tensor:
         s, b, n, C = original_residual.shape
         sb = s * b
-        # Optimized: use largest power-of-2 tile that divides C, up to 4096
-        # cuTile requires TILE_C to be a power of 2
-        TILE_C = (
+        # Shipped: the largest power-of-2 tile that divides C, up to 4096
+        # (cuTile requires TILE_C to be a power of 2), one row at a time.
+        SHIPPED = (
+            math.gcd(sb, 1),
             math.gcd(C, 4096)
             if C % 4096 == 0
             else math.gcd(C, 2048)
             if C % 2048 == 0
-            else math.gcd(C, 1024)
+            else math.gcd(C, 1024),
         )
-        TILE_SIZE = math.gcd(sb, 1)
+        # opt/mhc_0908: this kernel holds two (TILE_SIZE, n, TILE_C) fp32 tiles
+        # at once -- the accumulator and the in-register widening of ``orig``.
+        # At the shipped (1, 4096) that is 2 x 16384 fp32 over 128 threads =
+        # 254 registers/thread, i.e. 2 blocks and 8 warps per SM (12.5%), which
+        # is why the kernel only reaches ~1.7 TB/s while moving exactly its
+        # compulsory bytes. Smaller tiles lift that ceiling, but NOT
+        # MONOTONICALLY, which is the reason this is measured rather than
+        # derived. Measured on an exclusively-owned card, median of 100
+        # launches at one production shape (16384 x 4 x 4096):
+        #
+        #   (1, 4096) shipped  740.7 us  1633 GB/s  23.5% of peak  254 reg
+        #   (2,  128)          383.7 us  3152 GB/s  45.4%          109 reg
+        #   (4,   64)          394.9 us  3062 GB/s  44.1%          109 reg
+        #   (1, 1024)          431.6 us  2802 GB/s  40.4%          255 reg
+        #   (1,  256)          448.0 us  2699 GB/s  38.9%          114 reg
+        #   (1,  128)          883.1 us  1369 GB/s  19.7%          141 reg
+        #   (1,   64)          761.7 us  1587 GB/s  22.9%           74 reg
+        #                      ^ 37.5% occupancy and still slower than shipped
+        #
+        # Those numbers are here as the record of *why* this is a tuned
+        # quantity, not as values to install: they are one machine and one
+        # shape. The tuner re-measures.
+        #
+        # Bit-exact for every tile shape tested, including under catastrophic
+        # cancellation: the only reduction here is the unrolled ``for j`` sum,
+        # which is a loop-local accumulator and therefore tile-invariant.
+        # 20 + 20 random inputs x 11 configs, 0 differing elements
+        # (opt/mhc_0908/logs/bitexact_prod.txt, logs/bitexact_extra.txt). This
+        # is the one kernel in the family with no ``ct.sum`` at all, which is
+        # also why it is the only one allowed to offer occupancy candidates.
+        _mhc_tile_opt_retired()
         # ``fuse_cast`` means the caller skipped the fp32 widening it would
         # otherwise have done, so the kernel widens in-register and the result
         # comes back in the residual dtype. This cannot be sniffed
@@ -1101,6 +1941,80 @@ if _CUTILE_AVAILABLE:
         # reduction -- worth revisiting only for a bias-carrying config.
         fuse_cast = fuse_cast and bias is None
         out_dtype = original_residual.dtype if fuse_cast else h_res.dtype
+
+        def _tune_hpb_fwd():
+            def make_outputs():
+                return (paddle.empty(shape=[sb, n, C], dtype=out_dtype),)
+
+            def kernel_for(cfg):
+                # opt/mhc_regs_0908: the ``.maxnreg`` rebuild only pays off
+                # once the tile has moved off the shipped one (at (1, 4096)
+                # every cap spills), so the tuner's own choice decides whether
+                # it is applied -- not a separate switch that could disagree
+                # with the tile in force.
+                k = _mhc_with_occupancy(_ct_hpb_fwd_kernel, cfg.get("OCC", 0))
+                tuned = (cfg["TILE_SIZE"], cfg["TILE_C"]) != SHIPPED
+                return _mhc_reg_capped(k, "hpb_fwd", tuned_tile=tuned)
+
+            def do_launch(cfg, outs):
+                ts, tc = cfg["TILE_SIZE"], cfg["TILE_C"]
+                if bias is not None:
+                    ct.launch(
+                        _get_cuda_stream(), (math.ceil(sb / ts),),
+                        _ct_hpb_fwd_bias_kernel,
+                        (h_res.reshape([sb, n, n]),
+                         original_residual.reshape([sb, n, C]),
+                         h_post.reshape([sb, n]), x.reshape([sb, C]),
+                         bias.detach(), outs[0], n, tc, ts),
+                    )
+                else:
+                    ct.launch(
+                        _get_cuda_stream(), (math.ceil(sb / ts),),
+                        kernel_for(cfg),
+                        (h_res.reshape([sb, n, n]),
+                         original_residual.reshape([sb, n, C]),
+                         h_post.reshape([sb, n]), x.reshape([sb, C]),
+                         outs[0], n, tc, ts, fuse_cast),
+                    )
+
+            # The occupancy candidates, if any were asked for, take their slots
+            # out of the eight rather than being appended past the budget --
+            # otherwise they would be silently dropped by the truncation and
+            # look as though they had been tried.
+            occ = _mhc_occ_candidates(SHIPPED, bias is None)
+            pairs = _mhc_pair_candidates(
+                SHIPPED, sb, C, n * 4 * 2,
+                original_residual.element_size(), count=8 - len(occ))
+            cands = [{"TILE_SIZE": r, "TILE_C": c, "OCC": 0} for r, c in pairs]
+            cands += occ
+            return _mhc_autotune_call(
+                name="mhc.hpb_fwd",
+                factory={"TILE_SIZE": SHIPPED[0], "TILE_C": SHIPPED[1],
+                         "OCC": 0},
+                candidates=cands,
+                launch_shape=(sb, n, C),
+                dtypes=(h_res.dtype, original_residual.dtype, h_post.dtype,
+                        x.dtype, out_dtype, bias is not None,
+                        bool(fuse_cast)),
+                kernels=(_ct_hpb_fwd_kernel, _ct_hpb_fwd_bias_kernel),
+                make_outputs=make_outputs,
+                launch=do_launch,
+                hint_probe=lambda cfg: _mhc_hint_probe(cfg, kernel_for),
+            )
+
+        cfg = _mhc_tune(
+            "mhc.hpb_fwd",
+            (sb, n, C, str(out_dtype), bias is not None, bool(fuse_cast)),
+            _tune_hpb_fwd,
+        )
+        if cfg is None:
+            cfg = {"TILE_SIZE": SHIPPED[0], "TILE_C": SHIPPED[1], "OCC": 0}
+        TILE_SIZE, TILE_C = cfg["TILE_SIZE"], cfg["TILE_C"]
+        fwd_kernel = _mhc_with_occupancy(_ct_hpb_fwd_kernel, cfg.get("OCC", 0))
+        fwd_kernel = _mhc_reg_capped(
+            fwd_kernel, "hpb_fwd",
+            tuned_tile=(TILE_SIZE, TILE_C) != SHIPPED,
+        )
         out = paddle.empty(shape=[sb, n, C], dtype=out_dtype)
         grid = (math.ceil(sb / TILE_SIZE),)
         if bias is not None:
@@ -1124,7 +2038,7 @@ if _CUTILE_AVAILABLE:
             ct.launch(
                 _get_cuda_stream(),
                 grid,
-                _ct_hpb_fwd_kernel,
+                fwd_kernel,
                 (
                     h_res.reshape([sb, n, n]),
                     original_residual.reshape([sb, n, C]),
@@ -1193,7 +2107,7 @@ if _CUTILE_AVAILABLE:
             ct.launch(
                 _get_cuda_stream(),
                 grid,
-                _ct_hpb_bwd_kernel,
+                _mhc_reg_capped(_ct_hpb_bwd_kernel, "hpb_bwd"),
                 (
                     grad_output.reshape([sb, n, C]),
                     h_res.reshape([sb, n, n]),
@@ -1550,6 +2464,27 @@ if _CUTILE_AVAILABLE:
         if K >= 8192:
             # Optimized: TM=64, TK=128 is fastest (0.186ms vs 0.208ms@128/128)
             TILE_SIZE_M, TILE_SIZE_K = 64, 128
+            # opt/mhc_0908: the grid here is one block per K tile, so
+            # TILE_SIZE_K=128 with K=n*hidden_size=16384 launches 128 blocks on
+            # a 148-SM part -- 20 SMs stay empty for the whole kernel, and each
+            # block then walks all M/TILE_SIZE_M m-tiles serially. Filling the
+            # part with TK=64 looked like the obvious fix and is 1.54x SLOWER
+            # (432.4 us vs 281.6 at TM=64), as is every other legal
+            # combination: the shipped (64, 128) is the best of the eight
+            # measured. So the defaults here are the shipped values and this is
+            # a knob only.
+            #
+            # Bit-exact for every (TM, TK) tested: ``DB`` accumulates across
+            # m-tiles in a single ``ct.mma(acc=...)`` carried by the loop, and
+            # re-chunking a sequential accumulation does not reorder it. 20
+            # random inputs at M=256 plus 20 at M=4096 with operands spread
+            # over 12 decades, 0 differing elements (logs/bitexact_prod.txt,
+            # logs/bitexact_extra.txt).
+            # logs/bitexact_extra.txt). Not routed through the tuner: the
+            # shipped pair already won its sweep and there is no second
+            # candidate worth eight timing passes in the first step. The knob
+            # that used to sit here defaulted to the shipped values, so
+            # removing it changes nothing.
             grid = (math.ceil(K / TILE_SIZE_K), 1)
             ct.launch(
                 _get_cuda_stream(),


### PR DESCRIPTION
### PR Category
Performance Optimization

### PR Types
Performance

### Description

The mHC cuTile kernels ran with launch configurations that had been swept by
hand on one machine and one shape. That is not portable: with a different
register file, a different shared-memory capacity or a different token count
the same constants can be neutral or actively harmful. An earlier attempt to
land such constants directly was reverted for exactly that reason. This PR
replaces them with a tuner.

**The first filter is byte-for-byte equality, not timing.** Candidates are
screened in this order:

```
candidates -> (1) bit-exact gate vs the shipped config -> (2) measure -> cache
```

A candidate is dropped if a single output byte differs from what the shipped
configuration produces, regardless of how fast it is. Timing only ranks what
survives. Three reasons this ordering matters, all of them measured rather than
reasoned about:

* It makes the numerical constraint self-enforcing, so a new machine does not
  need a human to re-verify accuracy.
* It independently rediscovered the exclusions we had made by hand. Two
  `sinkhorn_bwd` tile sizes are rejected as `not_bit_exact` with the differing
  output recorded; those are the same two a human had previously excluded after
  measuring them, except that this time nobody wrote the allow-list.
* It catches cases that cannot be derived by reasoning. We measured that the
  cuBLASLt algorithm choice is not a pure function of the operands (adding an
  unrelated GEMM to the process can change it), so "this rewrite does not
  change the reduction order, therefore the result is bit-identical" is not a
  sound argument for anything that can trigger algorithm reselection. Only
  measurement decides.

**Timing is measured, never approximated by a static metric.** Two readings
from this work: a configuration with a static occupancy of 100% and zero spill
measured 3.7x slower than the winner (which sits at 25%), and a variant with
strictly cleaner static register usage measured 4% slower. `Issue%` can also
invert -- the faster of two variants had the higher issue rate.

**Cache key.** `(arch, machine facts, toolchain, kernel source hash, dtypes,
launch shape)`. Machine facts are read from the driver at run time and never
written down as literals, because a stale hardcoded value does not fail loudly,
it silently computes the wrong budget. The toolchain version is part of the key
because the behaviour being compensated for is a toolchain behaviour, so it
changes with the toolchain. The launch shape is not bucketed: bucketing
silently picks the wrong configuration whenever two shapes in one bucket
disagree, so we would rather store more entries and bound them with an LRU.

**Who scans: whoever takes the lock. There is no leader and no rank
arithmetic.** This is the part the first revision of this PR got wrong, so it is
worth stating what changed and why.

It used to be "global rank 0 scans, every other rank waits for it to publish",
with the cache directory defaulting to `~/.cache/paddlefleet/autotune`. Both
halves failed silently:

* `$HOME` is per container, so on a multi-node job the publisher wrote where
  nobody else could read. Every other rank waited out its timeout and then used
  the shipped configuration for the rest of the run. Startup went past twenty
  minutes and looked like a hang rather than a misconfiguration.
* The rank came from walking five launcher environment variable names and
  returning 0 when none matched. That is a guess whose ordering is load bearing:
  under `mpirun` plus a launcher, `OMPI_COMM_WORLD_RANK` is inherited by every
  process on a node and equals the node index, so if the first name in the list
  ever stops being set, every process on a node reports the same rank. It never
  raised; it answered wrongly.

The premise behind the leader was also wrong. Ranks only measure each other when
they **share a GPU**; with one rank per GPU they do not share the resource being
measured, and the timing runs on CUDA events, i.e. on the GPU timeline.

So the lock does the whole job, on the right unit. Processes that share a cache
directory serialise on one lock per key: the first scans, the rest block and then
read the published entry. Wall time is one scan either way, but only one process
per directory compiles and times, which also keeps a sibling's compilation off
the CPU while a measurement is in flight. Processes that do not share a directory
never meet and do not need to. If the lock cannot be taken, the process scans
anyway on its own device -- duplicated work, not a corrupt reading, and the
publish is an `os.replace`. Falling back to the shipped configuration there is
exactly what used to make one contended start permanent.

**The cache is therefore an optimisation, never a rendezvous.** Nothing has to be
visible to anyone else for the result to be correct, which is what makes a
node-local directory the right default rather than a compromise. When the host
framework exposes a cache root (`KERNEL_WARMUP_CACHE_ROOT`) the entries live
under it, so whatever already distributes that tree carries them and the scan is
paid once per cluster instead of once per node -- without this module knowing how
that distribution works, or depending on it. `PADDLEFLEET_AUTOTUNE_CACHE_DIR`
still wins when set explicitly.

Removed along the way: `global_rank()`, `_wait_for_entry()`, the `wait_timeout`
parameter and the `PADDLEFLEET_AUTOTUNE_WAIT_SECONDS` knob. Rank survives only
in the provenance record, read from `paddle.distributed` and allowed to be
unknown.

**Three entrypoints, all needed.**

| entrypoint | use |
|---|---|
| default (nothing set) | look up the cache; scan on a miss |
| `<PREFIX>_AUTOTUNE=0` | always the shipped configuration, no cache, no scan |
| `<PREFIX>_PIN[_<KERNEL>]=k=v` | force one configuration, skip scan and cache |

The third one is not a debugging nicety. Autotuning and "the two sides of an
A/B differ in exactly one variable" are in direct conflict: without a way to
pin, each side drifts on its own and the difference contains something other
than the change under test. We produced one wrong conclusion that way before
adding it.

**Register cap.** A separate, off-by-default switch inserts a `.maxnreg` into
the generated PTX. The number is not written down: the file records how many
resident CTAs per SM each kernel wants, which is a property of the kernel, and
the budget follows from `regsPerMultiprocessor / (target_ctas * ntid)` rounded
down to the 8-register granularity, with `regsPerMultiprocessor` read from the
driver and `ntid` read out of the `.reqntid` the PTX carries. Kernels whose
occupancy is already limited to one CTA per SM by shared memory alone are
deliberately absent: capping registers there can only spill, with no occupancy
to gain.

**Results.** Production shapes, median of 100 launches after 20 warmup, card
certified idle before and after, on the architecture these readings were taken
on:

| kernel | shipped | tuner picks | speedup |
|---|---|---|---|
| `_ct_hpb_fwd` | `TILE_SIZE=1, TILE_C=4096` | `2, 128` | 763.2 -> 404.7 us, 1.886x |
| `_ct_h_agg_bwd` | `TILE_M=2` | `TILE_M=4` | 324.6 -> 241.2 us, 1.346x |
| `_ct_h_agg_fwd` | `TILE_SIZE=4, TILE_C=1024` | `8, 1024` | 153.6 -> 130.1 us, 1.181x |
| `_ct_sinkhorn_bwd` | `TILE_SIZE=64` | `TILE_SIZE=128` | 149.6 -> 115.9 us, 1.290x |

All four agree with what was swept by hand, and the candidate set is at most 8
per kernel. In a 64-rank training job these four kernels go from 189.8 to
114.4 ms/step, measured per kernel from a profiler capture of 12 steps with
both sides certified free of other processes on every card.

One negative result worth recording, because it is about the candidate
generator rather than the gate or the timer: the first generator sampled the
feasible power-of-two combinations evenly by footprint and picked `(4, 64)` for
`hpb_fwd` instead of `(2, 128)`. Pinning both sides and running A/B/A/B at 200
launches each showed the hand-picked one was genuinely 1.7-2.6% faster, twice,
each repeat self-consistent to within its own MAD. The cause was that even
sampling spent slots on very narrow tiles (2.4x to 32x slower) while 8 slots
cannot cover a two-dimensional space that is non-monotone on both axes. The
generator now covers geometrically around the shipped point instead. Also, in
this launcher-level timing harness the first configuration measured in a
process is not trustworthy (483.2 us at MAD 49.2 on the first pass, settling at
419.6 at MAD 4.5 once repeated), so the tuner discards it.

### 是否引起精度变化

否。

The tuner's first filter is byte-for-byte equality against the shipped
configuration, so any candidate that changes a single output byte is discarded
before it is ever timed. Every cached entry records the key it was measured on
and the fact that it matched the shipped output exactly. The register cap is
bit-exact by construction: the same PTX body goes in, so the same arithmetic
and the same reduction order come out. `<PREFIX>_AUTOTUNE=0` restores the
shipped configuration exactly.
