### PR TITLE
[alignment] mark MLA q_a/kv_a weights as sequence-parallel parameters

### DIFF
--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -61,6 +61,9 @@ from paddlefleet.train_infer_consistent_ops.slice_util import (
 from paddlefleet.transformer.attention import Attention
 from paddlefleet.transformer.dw_overlap import deferrable_linear
 from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.paddle_norm import (
+    mark_as_sequence_parallel_parameter,
+)
 from paddlefleet.transformer.transformer_config import TransformerConfig
 from paddlefleet.utils import get_pg_rank, get_pg_size
 
@@ -1426,6 +1429,13 @@ class MLASelfAttention(MultiLatentAttention):
                 skip_weight_param_allocation=False,
                 tp_group=pg_collection.tp,
             )
+            # Replicated (non-parallel) weight: under sequence parallelism each
+            # rank only sees a shard of the sequence, so its gradient is partial
+            # and must be all-reduced across the TP group.
+            if getattr(self.config, "sequence_parallel", False):
+                weight = getattr(self.q_a_proj, "weight", None)
+                if weight is not None:
+                    mark_as_sequence_parallel_parameter(weight)
 
             self.q_b_proj = build_spec_layer(
                 sublayers_spec.q_b_proj,
@@ -1454,6 +1464,10 @@ class MLASelfAttention(MultiLatentAttention):
             skip_weight_param_allocation=False,
             tp_group=pg_collection.tp,
         )
+        if getattr(self.config, "sequence_parallel", False):
+            weight = getattr(self.kv_a_proj_with_mqa, "weight", None)
+            if weight is not None:
+                mark_as_sequence_parallel_parameter(weight)
 
         # In split mode ``k_b_proj`` / ``v_b_proj`` below *replace* this
         # projection: together they hold exactly its elements, nothing in the


### PR DESCRIPTION
### PR Category

Distributed Strategy

### PR Types

Bug fixes

### Description

`q_a_proj` and `kv_a_proj_with_mqa` are replicated (non-parallel) weights in MLA. Under sequence parallelism each rank only computes gradients from its own sequence shard, so those gradients are partial. Without marking the weights as sequence-parallel parameters, `register_sequence_parallel_allreduce_hooks` does not all-reduce them across the TP group, leaving the weight gradients under-reduced and inconsistent with Megatron-LM.

This PR marks both weights via `mark_as_sequence_parallel_parameter`, following the same pattern already used for other replicated weights such as `gated_delta_net.out_norm`, gated on `config.sequence_parallel`.

#### Changes

`src/paddlefleet/transformer/multi_latent_attention.py` (+14):

- import `mark_as_sequence_parallel_parameter` from `paddlefleet.transformer.paddle_norm` (that module already provides an ImportError fallback, so no extra guard is needed)
- mark `q_a_proj.weight` after it is built, when `sequence_parallel` is enabled
- mark `kv_a_proj_with_mqa.weight` likewise

#### Motivation

Found while aligning Kimi-K2 (MLA architecture) against Megatron-Swift, where step-1 loss is required to be bit-exact under TP=8 / EP=8 / SP=true. The fix previously lived only in a local experiment branch; this PR upstreams it.

#### Impact

Only affects `MLASelfAttention` with `sequence_parallel=true`. Behaviour is unchanged when sequence parallelism is off, which includes the default configuration and the existing EP2 cases under `scripts/alignment_model_accuracy/`.

#### Verification

- Import path checked against upstream `paddle_norm`; the helper exists there with a fallback
- Logic is equivalent to the implementation already validated in the 8-GPU alignment experiment
- No end-to-end bit-exact reproduction has been run in this repository's CI yet. A 2-GPU EP2 environment is being brought up separately (with 384 experts, EP=2 trips the DeepEP kernel constraint `num_experts / num_ranks <= kNumThreads`, so the alltoall dispatcher is required); that validation is out of scope for this PR.
