### PR TITLE
[release/0.4] add mhc and expand probes

### DIFF
--- a/src/paddlefleet/transformer/hyper_connection.py
+++ b/src/paddlefleet/transformer/hyper_connection.py
@@ -32,6 +32,7 @@ import paddle.nn.functional as F
 from paddle import Tensor, nn
 
 from paddlefleet.tensor_parallel.random import get_cuda_rng_tracker
+from paddlefleet.train_infer_consistent_ops.inspect_util import inspect_tensor
 from paddlefleet.transformer.layer import FleetLayer
 
 if TYPE_CHECKING:
@@ -1027,8 +1028,14 @@ class HyperConnectionExpandLayer(FleetLayer):
         self.n = config.num_residual_streams
 
     def forward(self, dict_args: dict) -> dict:
+        dict_args["hidden_states"] = inspect_tensor(
+            "mhc_expand_input", -1, dict_args["hidden_states"]
+        )
         dict_args["hidden_states"] = HyperConnectionModule.input_expand(
             dict_args["hidden_states"], self.n
+        )
+        dict_args["hidden_states"] = inspect_tensor(
+            "mhc_expand_output", -1, dict_args["hidden_states"]
         )
         return dict_args
 

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -1534,12 +1534,22 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             )
         aggregated = aggregated.to(ori_dtype)
 
+        h_post = inspect_tensor("mhc_attn_post", self.layer_number, h_post)
+        h_res = inspect_tensor("mhc_attn_comb", self.layer_number, h_res)
+
         # LayerNorm on aggregated single stream
         if self.recompute_input_layernorm:
             input_layernorm_output = recompute(self.input_layernorm, aggregated)
         else:
             input_layernorm_output = self.input_layernorm(aggregated)
 
+        # Observation only: "Attn_input" below owns this tensor's injection.
+        inspect_tensor(
+            "mhc_attn_pre",
+            self.layer_number,
+            input_layernorm_output,
+            load=False,
+        )
         self._log_md5(
             input_layernorm_output, "input_layernorm_out", self.layer_number
         )
@@ -1628,6 +1638,9 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         hidden_states = self._cast_and_discard_fused_bda(
             hidden_states, ori_dtype, fused_span
         )
+        hidden_states = inspect_tensor(
+            "mhc_attn_residual_output", self.layer_number, hidden_states
+        )
 
         # Cross attention (unchanged)
         residual = hidden_states
@@ -1681,6 +1694,9 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             aggregated, h_res, h_post = self.mlp_hyper_connection(hidden_states)
         aggregated = aggregated.to(ori_dtype)
 
+        h_post = inspect_tensor("mhc_mlp_post", self.layer_number, h_post)
+        h_res = inspect_tensor("mhc_mlp_comb", self.layer_number, h_res)
+
         # LayerNorm on aggregated single stream
         if self.recompute_post_attention_layernorm:
             post_attention_layernorm_output = recompute(
@@ -1691,6 +1707,13 @@ class HyperConnectionTransformerLayer(TransformerLayer):
                 aggregated
             )
 
+        # Observation only: "moe_or_dense_input" below owns the injection.
+        inspect_tensor(
+            "mhc_mlp_pre",
+            self.layer_number,
+            post_attention_layernorm_output,
+            load=False,
+        )
         self._log_md5(
             post_attention_layernorm_output,
             "post_attn_layernorm_out",
@@ -1761,6 +1784,9 @@ class HyperConnectionTransformerLayer(TransformerLayer):
             self._mlp_mhc_recompute = None
         hidden_states = self._cast_and_discard_fused_bda(
             hidden_states, ori_dtype, fused_span
+        )
+        hidden_states = inspect_tensor(
+            "mhc_mlp_residual_output", self.layer_number, hidden_states
         )
 
         if is_first_fwd:


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
Improvements

### Description
为 mHC 和expand 算子加训推对拍探针（`inspect_tensor`）。

- `transformer_layer.py`：`HyperConnectionTransformerLayer.forward` 的 attn / mlp 两段各加
  4 个探针 —— `mhc_{attn,mlp}_pre`、`mhc_{attn,mlp}_post`、`mhc_{attn,mlp}_comb`、
  `mhc_{attn,mlp}_residual_output`。
- `hyper_connection.py`：`HyperConnectionExpandLayer.forward` 前后加 `mhc_expand_input` /
  `mhc_expand_output`。

本 PR 只包含探针，不含任何算子改动。

### 是否引起精度变化
否。


Cherry-pick of #1997 to `release/0.4`.

Merged in dev: #1997  <!-- For pass CI -->