### PR TITLE
[release/0.4][New features] Add a selectable sparse-attention forward backend (FlashMLA / cuDNN)

### DIFF
--- a/src/paddlefleet/cudnn_ops/attn/csa_sparse_attn_fwd_cudnn.py
+++ b/src/paddlefleet/cudnn_ops/attn/csa_sparse_attn_fwd_cudnn.py
@@ -12,17 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""FlashMLA sparse forward kernel for the "cudnn" CSA sparse-attn backend.
+"""Sparse-attention forward kernels for the "cudnn" CSA sparse-attn backend.
 
-This is the forward half of the "cudnn" backend (the backward half lives in
-``csa_sparse_attn_bwd_cudnn.py``). It wraps the FlashMLA sparse prefill kernel
-and the index/alignment helpers it needs.
+Two forward implementations live here; the backward half is in
+``csa_sparse_attn_bwd_cudnn.py``.
+
+* ``flash_mla_sparse_attn`` -- the FlashMLA sparse prefill kernel plus the
+  index/alignment helpers it needs. This is the historical default and the
+  only path that covers every shape.
+* ``cudnn_sparse_attn_fwd`` -- cuDNN Frontend's own DSA sparse prefill
+  (``cudnn.DSA.sparse_attention_forward_wrapper``, added upstream in
+  cudnn-frontend PR #569). Only the three ``(H, D_qk)`` variants in
+  ``_CUDNN_FWD_VARIANTS`` are supported, so it is opt-in and falls back.
+
+``sparse_attn_fwd`` dispatches between them. Both return the same
+``(out, lse, lse_indexer)`` triple in the same layouts, so call sites only
+need to thread the backend name through.
 """
+
+import logging
 
 import paddle
 import paddle.nn.functional as F
 
 from paddlefleet.fusions.csa_sparse_attn_utils import local_to_global_flat
+
+_logger = logging.getLogger(__name__)
+# One-time "cuDNN forward is really running" marker, see cudnn_sparse_attn_fwd.
+_logged_cudnn_fwd_active = False
+# Tri-state cache for _cudnn_fwd_module_available(): None = not probed yet.
+_cudnn_fwd_module_cached = None
 
 try:
     from paddlefleet_ops.flash_mla import (
@@ -30,6 +49,67 @@ try:
     )
 except (ImportError, RuntimeError):
     _flash_mla_sparse_fwd = None
+
+
+# ---------------------------------------------------------------------------
+# Paddle <-> cuDNN Frontend bridging for the DSA sparse **forward**
+#
+# ``csa_sparse_attn_bwd_cudnn`` already installs four such patches at import
+# (memory_format sentinels, cutlass nvgpu, nvtx range, Stream.cuda_stream).
+# The forward kernels need two more; both are no-ops once applied.
+# ---------------------------------------------------------------------------
+def _patch_paddle_record_stream():
+    """Give ``paddle.Tensor`` a torch-named ``record_stream``.
+
+    ``sparse_attention_forward``'s ``_interface_sm100._record_stream`` calls
+    ``tensor.record_stream(consumer)`` on every input so the caching allocator
+    knows the raw kernel pointers are still in flight on that stream. Paddle
+    only exposes the underscored ``_record_stream``, so the torch-proxied call
+    raises ``AttributeError``. Forward the name; prefer passing the stream
+    through and fall back to the no-arg form (which records on the current
+    stream -- the same stream cuDNN's ``resolve_stream()`` resolves to under
+    the bwd module's ``Stream.cuda_stream`` patch).
+    """
+    if hasattr(paddle.Tensor, "record_stream"):
+        return
+
+    def record_stream(self, stream=None):
+        try:
+            return self._record_stream(stream)
+        except Exception:
+            return self._record_stream()
+
+    paddle.Tensor.record_stream = record_stream
+
+
+def _alias_cudnn_modules():
+    """Re-register the loaded cuDNN modules under a top-level ``cudnn`` name.
+
+    ``paddlefleet_ops._safe_load_ecosystem_lib`` only puts the ops dir on
+    ``sys.path`` inside a ``ModuleContext`` window, then renames everything to
+    ``paddlefleet_ops.cudnn.*``. Existing DSA modules import their kernels
+    eagerly at module scope, i.e. inside that window, so their absolute
+    ``from cudnn.api_base import ...`` imports resolve.
+
+    ``sparse_attention_forward._interface_sm100._make_kernel`` instead imports
+    its kernel lazily at execute time, which lands outside the window and
+    fails with ``ModuleNotFoundError: No module named 'cudnn'``. Alias the
+    already-loaded module objects (``setdefault``, never re-import) so the lazy
+    import hits the same instances -- a second copy would create a second
+    ``APIBase`` and break identity checks.
+    """
+    import sys
+
+    import paddlefleet_ops
+
+    prefix = "paddlefleet_ops.cudnn"
+    cudnn_mod = getattr(paddlefleet_ops, "cudnn", None)
+    if cudnn_mod is None:
+        return
+    sys.modules.setdefault("cudnn", cudnn_mod)
+    for name, mod in list(sys.modules.items()):
+        if name == prefix or name.startswith(prefix + "."):
+            sys.modules.setdefault("cudnn" + name[len(prefix) :], mod)
 
 
 def _get_topk_alignment() -> int:
@@ -105,4 +185,258 @@ def flash_mla_sparse_attn(
         out_flat.reshape([b, sq, h, d_v]),
         lse.reshape([b, sq, h]),
         lse_indexer,
+    )
+
+
+# ---------------------------------------------------------------------------
+# cuDNN Frontend DSA sparse prefill forward (cudnn-frontend PR #569)
+# ---------------------------------------------------------------------------
+# ``api._SUPPORTED_VARIANTS``: (H, D_qk) -> allowed ``indexer_topk`` values.
+# Mirrored here so the dispatch can pre-filter without importing the kernel
+# (the import is what pulls in CuTe DSL). Widen together with upstream.
+_CUDNN_FWD_VARIANTS = {
+    (64, 512): (0, 512, 1024, 2048),
+    (64, 576): (0, 512, 1024, 2048),
+    (128, 512): (0, 512, 1024),
+}
+# The kernels fix the value width at 512 (``check_support`` sets head_dim_v).
+_CUDNN_FWD_D_V = 512
+_CUDNN_FWD_DTYPES = (paddle.bfloat16, paddle.float16)
+
+
+def _cudnn_fwd_module_available() -> bool:
+    """Whether the bundled cuDNN Frontend actually ships the forward kernels.
+
+    ``sparse_attention_forward`` landed upstream in cudnn-frontend PR #569 and
+    is absent from every release the vendored fork has picked up so far, so the
+    submodule bump lags this dispatch. Probe the module instead of assuming it,
+    otherwise ``sparse_attn_forward_backend="cudnn"`` would raise
+    ``ModuleNotFoundError`` mid-forward on an older frontend rather than falling
+    back. ``find_spec`` avoids importing CuTe DSL just to answer the question.
+
+    Cached because this runs per layer per step.
+    """
+    global _cudnn_fwd_module_cached
+    if _cudnn_fwd_module_cached is None:
+        from importlib.util import find_spec
+
+        _patch_paddle_record_stream()
+        _alias_cudnn_modules()
+        try:
+            _cudnn_fwd_module_cached = (
+                find_spec(
+                    "paddlefleet_ops.cudnn.deepseek_sparse_attention"
+                    ".sparse_attention_forward"
+                )
+                is not None
+            )
+        except (ImportError, AttributeError, ValueError):
+            _cudnn_fwd_module_cached = False
+    return _cudnn_fwd_module_cached
+
+
+def cudnn_sparse_attn_fwd_supported(h, d_qk, d_v, indexer_topk, dtype):
+    """Whether ``cudnn_sparse_attn_fwd`` can serve this shape.
+
+    Returns ``(ok, reason)``; ``reason`` is empty when ok, else a short string
+    for the caller to log before falling back to FlashMLA.
+    """
+    try:
+        from paddlefleet_ops import is_cudnn_frontend_available
+
+        if not is_cudnn_frontend_available():
+            return False, "cudnn frontend unavailable"
+    except ImportError:
+        return False, "paddlefleet_ops.is_cudnn_frontend_available missing"
+
+    if not _cudnn_fwd_module_available():
+        return False, (
+            "cudnn frontend has no deepseek_sparse_attention."
+            "sparse_attention_forward (needs the PR #569 kernels)"
+        )
+
+    # ``api.check_support`` gates on the major only, i.e. the whole SM100
+    # family (10.0 / 10.3 / 10.7) is admitted. Pre-filter identically.
+    if paddle.cuda.get_device_capability()[0] != 10:
+        return (
+            False,
+            f"needs SM100 family, got {paddle.cuda.get_device_capability()}",
+        )
+    if dtype not in _CUDNN_FWD_DTYPES:
+        return False, f"dtype {dtype} not in {_CUDNN_FWD_DTYPES}"
+    if int(d_v) != _CUDNN_FWD_D_V:
+        return False, f"d_v must be {_CUDNN_FWD_D_V}, got {d_v}"
+    allowed = _CUDNN_FWD_VARIANTS.get((int(h), int(d_qk)))
+    if allowed is None:
+        return False, (
+            f"(H, D_qk)=({h}, {d_qk}) not in {tuple(_CUDNN_FWD_VARIANTS)}"
+        )
+    if int(indexer_topk) not in allowed:
+        return False, (
+            f"indexer_topk={indexer_topk} not in {allowed} for (H, D_qk)="
+            f"({h}, {d_qk})"
+        )
+    return True, ""
+
+
+def cudnn_sparse_attn_fwd(
+    q,
+    kv,
+    attn_sink,
+    topk_idxs,
+    sm_scale=None,
+    indexer_topk: int = 0,
+    d_v=None,
+    topk_length=None,
+    global_kv_idx_remap_fusion: bool = False,
+):
+    """Drop-in replacement for ``flash_mla_sparse_attn`` on supported shapes.
+
+    Same arguments, same ``(out, lse, lse_indexer)`` return in the same
+    layouts. ``cudnn_sparse_attn_fwd_supported`` must pass first; this function
+    does not fall back on its own.
+
+    Two differences from the FlashMLA path:
+
+    * no ``topk`` width padding -- the kernel pads logical K to a multiple of
+      64 internally, so the ``_get_topk_alignment`` / ``F.pad`` step is skipped;
+    * ``out`` / ``lse`` / ``lse_indexer`` are freshly allocated per call rather
+      than reused. ``execute()`` accepts caller-owned buffers, but the caller's
+      autograd node saves ``out`` and ``lse`` for backward, so a reused buffer
+      would be overwritten by the next layer's forward.
+    """
+    _patch_paddle_record_stream()
+    _alias_cudnn_modules()
+    from paddlefleet_ops.cudnn.deepseek_sparse_attention.sparse_attention_forward.api import (
+        sparse_attention_forward_wrapper,
+    )
+
+    b, sq, h, d = q.shape
+    _, skv, _ = kv.shape
+    if d_v is None:
+        d_v = d
+
+    q_flat = q.reshape([b * sq, h, d])
+    kv_flat = kv.reshape([b * skv, d])
+    global_idxs = local_to_global_flat(
+        topk_idxs, skv, fused=global_kv_idx_remap_fusion
+    ).reshape([b * sq, topk_idxs.shape[-1]])
+    topk_length_flat = (
+        None
+        if topk_length is None
+        else topk_length.reshape([b * sq]).cast("int32")
+    )
+
+    res = sparse_attention_forward_wrapper(
+        q_flat,
+        kv_flat,
+        global_idxs,
+        attn_sink=attn_sink,
+        topk_length=topk_length_flat,
+        softmax_scale=sm_scale,
+        indexer_topk=int(indexer_topk),
+    )
+
+    # Logged **after** the kernel returned, so the line's presence means the
+    # cuDNN kernel really executed -- not merely that this wrapper was entered.
+    # Without it a silent fallback would make an A/B measurement compare the
+    # baseline against itself. Emitted once per process.
+    global _logged_cudnn_fwd_active
+    if not _logged_cudnn_fwd_active:
+        _logged_cudnn_fwd_active = True
+        _logger.info(
+            "sparse-attn forward: cuDNN Frontend DSA sparse prefill RAN "
+            "(H=%d, D_qk=%d, D_v=%d, K=%d, indexer_topk=%d) -> out%s lse%s",
+            h,
+            d,
+            d_v,
+            topk_idxs.shape[-1],
+            int(indexer_topk),
+            tuple(res["out"].shape),
+            tuple(res["lse"].shape),
+        )
+
+    lse_indexer = res["lse_indexer"]
+    return (
+        res["out"].reshape([b, sq, h, d_v]),
+        res["lse"].reshape([b, sq, h]),
+        None if lse_indexer is None else lse_indexer.reshape([b, sq, h]),
+    )
+
+
+def sparse_attn_fwd(
+    q,
+    kv,
+    attn_sink,
+    topk_idxs,
+    sm_scale=None,
+    indexer_topk: int = 0,
+    d_v=None,
+    topk_length=None,
+    global_kv_idx_remap_fusion: bool = False,
+    forward_backend: str = "flash_mla",
+):
+    """Pick the sparse-attention forward kernel.
+
+    ``forward_backend`` is ``"flash_mla"`` (default, every shape) or
+    ``"cudnn"`` (cudnn-frontend PR #569, only the ``_CUDNN_FWD_VARIANTS``
+    shapes -- unsupported shapes warn once and fall back rather than failing a
+    training run over a config typo).
+    """
+    if forward_backend not in ("flash_mla", "cudnn"):
+        raise ValueError(
+            f"sparse_attn_fwd forward_backend must be 'flash_mla' or 'cudnn', "
+            f"got {forward_backend!r}"
+        )
+
+    if forward_backend == "cudnn":
+        d_qk = q.shape[3]
+        ok, reason = cudnn_sparse_attn_fwd_supported(
+            q.shape[2],
+            d_qk,
+            d_qk if d_v is None else d_v,
+            indexer_topk,
+            q.dtype,
+        )
+        if ok:
+            return cudnn_sparse_attn_fwd(
+                q,
+                kv,
+                attn_sink,
+                topk_idxs,
+                sm_scale=sm_scale,
+                indexer_topk=indexer_topk,
+                d_v=d_v,
+                topk_length=topk_length,
+                global_kv_idx_remap_fusion=global_kv_idx_remap_fusion,
+            )
+        _warn_cudnn_fwd_fallback(reason)
+
+    return flash_mla_sparse_attn(
+        q,
+        kv,
+        attn_sink,
+        topk_idxs,
+        sm_scale=sm_scale,
+        indexer_topk=indexer_topk,
+        d_v=d_v,
+        topk_length=topk_length,
+        global_kv_idx_remap_fusion=global_kv_idx_remap_fusion,
+    )
+
+
+_warned_cudnn_fwd_fallback = set()
+
+
+def _warn_cudnn_fwd_fallback(reason: str) -> None:
+    """Warn once per distinct reason; this runs per layer per step."""
+    if reason in _warned_cudnn_fwd_fallback:
+        return
+    _warned_cudnn_fwd_fallback.add(reason)
+    import warnings
+
+    warnings.warn(
+        f"sparse_attn_forward_backend='cudnn' requested but unsupported "
+        f"({reason}); falling back to FlashMLA.",
+        stacklevel=3,
     )

--- a/src/paddlefleet/fusions/mqa_sparse_attn.py
+++ b/src/paddlefleet/fusions/mqa_sparse_attn.py
@@ -94,9 +94,10 @@ class _MQASparseAttention(paddle.autograd.PyLayer):
         sink_grad_fusion=False,
         global_kv_idx_remap_fusion=False,
         backward_backend="cudnn",
+        forward_backend="flash_mla",
     ):
         from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
-            flash_mla_sparse_attn,
+            sparse_attn_fwd,
         )
         from paddlefleet.fusions.csa_sparse_attn import _csa_compute_topk_length
 
@@ -168,7 +169,7 @@ class _MQASparseAttention(paddle.autograd.PyLayer):
             token_indices.reshape([b * s, -1])
         )
 
-        out, lse, lse_indexer = flash_mla_sparse_attn(
+        out, lse, lse_indexer = sparse_attn_fwd(
             q_pad,
             kv,
             sink,
@@ -178,6 +179,7 @@ class _MQASparseAttention(paddle.autograd.PyLayer):
             topk_length=topk_len_flat.reshape([b, s]),
             indexer_topk=int(indexer_topk),
             global_kv_idx_remap_fusion=global_kv_idx_remap_fusion,
+            forward_backend=forward_backend,
         )  # out [b, s, 64, d_v], lse [b, s, 64]
         _MQASparseAttention._lse_indexer = lse_indexer
 
@@ -419,8 +421,9 @@ def mqa_sparse_attn(
     sink_grad_fusion=False,
     global_kv_idx_remap_fusion=False,
     backward_backend="cudnn",
+    forward_backend="flash_mla",
 ):
-    """Absorbed-MQA sparse attention (FlashMLA sparse fwd + selectable bwd).
+    """Absorbed-MQA sparse attention (selectable sparse fwd + selectable bwd).
 
     Args:
         query:         ``[b, s, h, d_qk]``, ``h <= 64``.
@@ -453,6 +456,11 @@ def mqa_sparse_attn(
                        ``sparse_attn_global_kv_idx_remap_fusion`` config field.
         backward_backend: ``"cudnn"`` (default, fast, non-deterministic dkv) or
                        ``"tilelang"`` (deterministic, ~14x slower on SM100).
+        forward_backend: ``"flash_mla"`` (default, every shape) or ``"cudnn"``
+                       (cudnn-frontend PR #569 DSA sparse prefill; only the
+                       ``(H, D_qk)`` variants in ``_CUDNN_FWD_VARIANTS``, other
+                       shapes warn once and fall back). Wired from the
+                       ``sparse_attn_forward_backend`` config field.
 
     Returns:
         ``[b, s, h * d_v]``, or ``(output, lse_indexer [b, s, 64] fp32)`` when
@@ -469,6 +477,7 @@ def mqa_sparse_attn(
         sink_grad_fusion,
         global_kv_idx_remap_fusion,
         str(backward_backend),
+        str(forward_backend),
     )
     lse_indexer = _MQASparseAttention._lse_indexer
     _MQASparseAttention._lse_indexer = None

--- a/src/paddlefleet/transformer/mqa_latent_attention.py
+++ b/src/paddlefleet/transformer/mqa_latent_attention.py
@@ -777,11 +777,18 @@ class MQALatentAttention(FleetLayer):
         # ``test_block_sparse_dsa_gradcheck.py::TestDeterminism``); "tilelang"
         # (mqa_latent_sparse_bwd) is bitwise stable for identical inputs -- by
         # construction, not via ``FLAGS_cudnn_deterministic`` -- but ~14x slower
-        # on SM100. The forward is always FlashMLA regardless of this switch
-        # (the tilelang forward cannot accept d_qk=576, which is not a power of
-        # two). Default "cudnn" preserves the previous behaviour.
+        # on SM100. This switch only picks the *backward*; the tilelang forward
+        # cannot accept d_qk=576, which is not a power of two. Default "cudnn"
+        # preserves the previous behaviour.
         self.sparse_attn_backward_backend = str(
             getattr(config, "mqa_sparse_attn_backward_backend", "cudnn")
+        )
+        # Forward kernel: FlashMLA (default, every shape) or cuDNN Frontend's
+        # own DSA sparse prefill (cudnn-frontend PR #569). Unsupported shapes
+        # fall back to FlashMLA with a one-time warning, so this is safe to flip
+        # on for measurement.
+        self.sparse_attn_forward_backend = str(
+            getattr(config, "sparse_attn_forward_backend", "flash_mla")
         )
         # Learnable per-head attention-sink logit, from the model-wide
         # ``add_full_attention_sink_bias`` / ``softmax_type``. Built by the same
@@ -1855,8 +1862,8 @@ class MQALatentAttention(FleetLayer):
         off, which the backend turns into a sinkless softmax. Query-head padding
         to the DSA-fixed ``h_q == 64`` is the backend's job.
 
-        The forward is always FlashMLA sparse; the backward kernel is selected
-        by ``mqa_sparse_attn_backward_backend`` (see ``__init__``).
+        The forward kernel is selected by ``sparse_attn_forward_backend`` and the
+        backward kernel by ``mqa_sparse_attn_backward_backend`` (see ``__init__``).
 
         ``indexer_topk > 0`` additionally returns the LSE over the first
         ``indexer_topk`` columns, which is the indexer-loss target's normalizer.
@@ -1873,6 +1880,7 @@ class MQALatentAttention(FleetLayer):
             indexer_topk=indexer_topk,
             sink_grad_fusion=self.sink_grad_fusion,
             global_kv_idx_remap_fusion=self.global_kv_idx_remap_fusion,
+            forward_backend=self.sparse_attn_forward_backend,
             backward_backend=self.sparse_attn_backward_backend,
         )
 

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -1721,6 +1721,31 @@ class TransformerConfig(ModelParallelConfig):
     the switch otherwise rather than let it be a silent no-op.
     """
 
+    sparse_attn_forward_backend: str = "flash_mla"
+    """Which kernel runs the sparse-attention **forward**.
+
+    One of {"flash_mla", "cudnn"}:
+
+    * ``"flash_mla"`` (default): ``paddlefleet_ops.flash_mla.flash_mla_sparse_fwd``,
+      the historical path and the only one that covers every shape.
+    * ``"cudnn"``: cuDNN Frontend's own DSA sparse prefill, added upstream in
+      cudnn-frontend PR #569 (``cudnn.DSA.sparse_attention_forward_wrapper``).
+      Requires the SM100 family (10.0 / 10.3 / 10.7), bf16/fp16, ``d_v == 512``
+      and one of the ``(H, D_qk)`` variants ``(64, 512)`` / ``(64, 576)`` /
+      ``(128, 512)`` with a matching ``indexer_topk``. Unsupported shapes warn
+      once and fall back to FlashMLA rather than failing the run.
+
+    Measured numerically equivalent to FlashMLA at
+    ``S_q=16384, H=64, D_qk=576, K=2176, indexer_topk=2048`` on SM103: ``lse``
+    bitwise identical, ``lse_indexer`` within fp32 epsilon (1.2e-7 relative),
+    ``out`` within one bf16 ulp. Both backends return ``+inf`` ``lse_indexer``
+    on all-invalid (packing / CUDA-graph padding) rows, which the indexer loss
+    masks out either way.
+
+    Off by default: the swap is not a guaranteed win, so measure the shape in
+    question before enabling it.
+    """
+
     sparse_attn_global_kv_idx_remap_fusion: bool = False
     """Whether to fuse the per-batch-local -> flat-global KV column index remap
     (``idx + b * seqlen_kv``) consumed by the cuDNN / FlashMLA sparse-attention


### PR DESCRIPTION
### PR Category
Operator Mechanism

### PR Types
New features

### Description

Merged in dev: #2014

The DSA sparse-attention **forward** was hardcoded to FlashMLA
(`MQALatentAttention._sparse_attn` -> `mqa_sparse_attn` -> `flash_mla_sparse_attn`),
while the backward already had a `mqa_sparse_attn_backward_backend` switch. This PR
makes the forward selectable too and adds cuDNN Frontend's own DSA sparse prefill as
a second backend.

**What changed**

- `transformer_config.py`: new `sparse_attn_forward_backend: str = "flash_mla"`.
- `cudnn_ops/attn/csa_sparse_attn_fwd_cudnn.py`:
  - `cudnn_sparse_attn_fwd()` -- calls
    `cudnn.DSA.sparse_attention_forward_wrapper`, added upstream in
    NVIDIA/cudnn-frontend#569. Drop-in for `flash_mla_sparse_attn`: same
    arguments, same `(out, lse, lse_indexer)` return in the same layouts.
  - `cudnn_sparse_attn_fwd_supported()` -- envelope pre-filter mirroring the
    kernel's `check_support`: SM100 family (10.0 / 10.3 / 10.7, gated on the
    major like upstream does), bf16/fp16, `d_v == 512`, and `(H, D_qk)` in
    `{(64, 512), (64, 576), (128, 512)}` with a matching `indexer_topk`.
  - `sparse_attn_fwd()` -- the dispatcher.
  - Two Paddle/cuDNN bridging patches, alongside the four that
    `csa_sparse_attn_bwd_cudnn` already installs at import:
    `Tensor.record_stream` (the kernel's `_record_stream` calls the torch name;
    Paddle only exposes `_record_stream`) and a top-level `cudnn` module alias
    (the forward interface imports its kernel *lazily* at execute time, which
    lands outside `_safe_load_ecosystem_lib`'s `ModuleContext` window where the
    absolute `from cudnn.api_base import ...` still resolves).
- `fusions/mqa_sparse_attn.py`, `transformer/mqa_latent_attention.py`: thread
  `forward_backend` through; fix two comments that claimed the forward is always
  FlashMLA.

**Safe to merge ahead of the submodule bump**

The vendored cudnn-frontend fork is on `paddle/v1.28.0`, which predates #569, so
`sparse_attention_forward` is not present yet. `cudnn_sparse_attn_fwd_supported`
probes for the module with `importlib.util.find_spec` (no CuTe DSL import just to
answer the question) and reports it as unsupported when missing, so requesting
`"cudnn"` on an older frontend warns once and falls back instead of raising
`ModuleNotFoundError` mid-forward. Unsupported shapes behave the same way. With
the default `"flash_mla"` nothing on the existing path changes.

**Validation** (B300 / SM10.3, 43-layer DSA config, `S_q=16384, H=64, D_qk=576,
D_v=512, K=2176, indexer_topk=2048`, bf16)

Numerics vs FlashMLA on identical inputs:

| tensor | max abs | max rel |
|---|---|---|
| `lse` | 0 (bitwise identical) | 0 |
| `lse_indexer` | 4.77e-07 | 1.19e-07 |
| `out` | 1.22e-04 | 7.75e-03 (one bf16 ulp) |

Both backends return `+inf` `lse_indexer` on all-invalid (packing / CUDA-graph
padding) rows, which the indexer loss masks out either way. End-to-end 50-step
`train_loss` 12.283381 (FlashMLA) vs 12.283374 (cuDNN) -- the bf16 ulp above,
propagated.

Performance, median of steps 11-50 (excludes warmup and the one-time CuTe DSL JIT):

| timer | flash_mla | cudnn | delta |
|---|---|---|---|
| `attn` | 390.06 ms | 397.92 ms | **+2.02%** |
| `forward-backward` | 4100.27 ms | 4102.72 ms | +0.06% |
| TFLOPS/card | 1082.05 | 1082.78 | +0.07% |

Only 7 of 43 layers run this forward and `attn` is ~9.5% of the step, so the
end-to-end delta is inside run-to-run noise. The cuDNN kernel is
`derived from the FlashMLA head64 Prefill kernel` (its own
`THIRD_PARTY_LICENSES.txt`), ported to CuTe DSL so cuDNN Frontend no longer needs
an external FlashMLA -- it is not meant to be faster. Hence the default stays
`"flash_mla"`; the switch exists so the two can be compared on other shapes
(#569's own benchmark anchor is the much smaller `S_q=4096, K=640,
indexer_topk=512`).

Instrumenting `paddlefleet_ops`' `_interface_sm100.py` right after the
`compiled(...)` launch confirmed the CuTe kernel really runs
(`variant='head64_regular', total_s_q=16384, logical_topk=2176`) and never takes
the zero-size host-side epilogue that skips the kernel.

### 是否引起精度变化
否

Default `sparse_attn_forward_backend="flash_mla"` keeps the existing path
bit-for-bit unchanged. The opt-in `"cudnn"` path differs by one bf16 ulp on `out`
(`lse` is bitwise identical), as tabulated above.
