### PR TITLE
Add modular AOA context protocol, Linear leaves and GPTModel whole-model entries

### DIFF
--- a/src/paddlefleet/models/gpt/aoa_generator.py
+++ b/src/paddlefleet/models/gpt/aoa_generator.py
@@ -1,0 +1,278 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Whole-model modular AOA statement generation for boundary models.
+
+Pure functions backing the ``GPTModel`` boundary's modular AOA generation, plus
+the container entries a multi-tower model uses to drive several roots. The flow
+is:
+
+1. :func:`build_aoa_context` builds the read-only ``AOAContext`` once, using the
+   live model's ``_pp_to_single_mapping`` (same source as ``sharded_state_dict``,
+   so names come from the live module tree rather than a re-derived guess).
+2. :func:`collect_alias_plan` resolves tied / shared aliases and the pipeline
+   names to skip in one pass, **before** recursion (no post-hoc text dedup).
+   The skip set is pinned into ``ctx.excluded_names`` so every component
+   override honors it.
+3. :func:`gen_whole_model_aoa` / :func:`gen_whole_model_inv_aoa` hand each child
+   to the standard ``Layer.gen_aoa_statements`` / ``gen_inv_aoa_statements``
+   protocol -- that polymorphic call is the component dispatch point, so the
+   module walk is never re-implemented here. The two directions are generated
+   independently and never derived from one another.
+4. :func:`gen_multi_tower_aoa` / :func:`gen_multi_tower_inv_aoa` are the entry
+   points for a container that owns several roots (a vision tower beside a
+   language model). Every tower is dispatched on what its root is: a boundary
+   root goes through step 3, any other root through plain component recursion.
+   The container keeps globalization to itself so it runs once over the union
+   of all its towers.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    AOAContext,
+    validate_checkpoint_name_mapping,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# MTP checkpoint prefix protocol
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MTPCheckpointPrefixSpec:
+    """Checkpoint-side prefix protocol for MTP layers, resolved once per pass.
+
+    Producer-side state built at the whole-model entry from the model-declared
+    ``aoa_mtp_*`` attributes and threaded straight into
+    :func:`_resolve_mtp_scopes`. Deliberately *not* a field of the
+    component-facing :class:`AOAContext`: no component override reads it, so it
+    does not belong on the frozen recursion context forwarded to every
+    component.
+
+    Defaults cover the common case: MTP layers share the normal-layer
+    checkpoint numbering ``layers.$LAYER_ID`` and the inner transformer inherits
+    that same prefix. A boundary overrides via the three model attributes.
+    """
+
+    checkpoint_prefix: str = "layers.$LAYER_ID"
+    transformer_checkpoint_prefix: str = "layers.$LAYER_ID"
+    is_absolute: bool = False
+
+
+def resolve_mtp_checkpoint_prefix_spec(config) -> MTPCheckpointPrefixSpec:
+    """Normalizes the model-declared MTP checkpoint-prefix attributes.
+
+    Reads ``aoa_mtp_checkpoint_prefix`` /
+    ``aoa_mtp_transformer_checkpoint_prefix`` /
+    ``aoa_mtp_checkpoint_prefix_absolute`` off ``config`` with the defaulting an
+    unmigrated model relies on: the MTP-own prefix defaults to
+    ``layers.$LAYER_ID`` (same numbering as normal layers), the inner
+    transformer prefix inherits the MTP-own prefix, and no absolute-prefix
+    escape. Both prefixes route through :func:`_protocol_value`, so only an
+    absent / ``None`` attribute falls back; an explicitly declared value
+    (including an empty ``""`` for a top-level checkpoint) is taken verbatim.
+    """
+    checkpoint_prefix = _protocol_value(
+        config, "aoa_mtp_checkpoint_prefix", "layers.$LAYER_ID"
+    )
+    return MTPCheckpointPrefixSpec(
+        checkpoint_prefix=checkpoint_prefix,
+        transformer_checkpoint_prefix=_protocol_value(
+            config, "aoa_mtp_transformer_checkpoint_prefix", checkpoint_prefix
+        ),
+        is_absolute=bool(
+            getattr(config, "aoa_mtp_checkpoint_prefix_absolute", False)
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint protocol defaults and context construction
+# ---------------------------------------------------------------------------
+
+
+# Defaults for the model-declarable ``aoa_*`` checkpoint protocol. Each default
+# is named exactly once here and referenced by every consumer (the
+# :class:`FleetAOAContext` fields, :func:`build_aoa_context` and
+# :func:`_build_tower_ctx`), so no default literal is duplicated. The values
+# describe the ERNIE-series self-developed checkpoint; an external model
+# overrides only the attributes whose layout diverges.
+#
+# Only naming divergences belong in the mapping below: names the components
+# already emit identically (layernorms, ``model.norm``, the MTP layer's
+# ``enorm`` / ``hnorm`` / ``eh_proj``, and the CSA subtree) are deliberately
+# absent. The logical layer root also intentionally omits ``transformer_layer``
+# so the same entries cover ordinary layers and an MTP layer's inner
+# transformer.
+DEFAULT_CHECKPOINT_NAME_MAPPING = {
+    "embedding.embed_tokens.weight": "embed_tokens.weight",
+    "layers.$LAYER_ID.mlp.gate.weight": "layers.$LAYER_ID.block_sparse_moe.gate.weight",
+    "layers.$LAYER_ID.mlp.gate.weight_1": "layers.$LAYER_ID.block_sparse_moe.gate.weight_1",
+    "layers.$LAYER_ID.mlp.gate.routed_scaling_factor_param": "layers.$LAYER_ID.block_sparse_moe.gate.routed_scaling_factor_param",
+    "layers.$LAYER_ID.mlp.gate.e_score_correction_bias": "layers.$LAYER_ID.block_sparse_moe.e_score_correction_bias",
+    "layers.$LAYER_ID.mlp.fc1_latent_proj.weight": "layers.$LAYER_ID.block_sparse_moe.fc1_latent_proj.weight",
+    "layers.$LAYER_ID.mlp.fc2_latent_proj.weight": "layers.$LAYER_ID.block_sparse_moe.fc2_latent_proj.weight",
+    "layers.$LAYER_ID.mlp.experts.$EXPERT_ID.gate_proj.weight": "layers.$LAYER_ID.block_sparse_moe.experts.$EXPERT_ID.w1.weight",
+    "layers.$LAYER_ID.mlp.experts.$EXPERT_ID.up_proj.weight": "layers.$LAYER_ID.block_sparse_moe.experts.$EXPERT_ID.w3.weight",
+    "layers.$LAYER_ID.mlp.experts.$EXPERT_ID.down_proj.weight": "layers.$LAYER_ID.block_sparse_moe.experts.$EXPERT_ID.w2.weight",
+    "layers.$LAYER_ID.mlp.shared_experts.gate_proj.weight": "layers.$LAYER_ID.block_sparse_moe.shared_experts.w1.weight",
+    "layers.$LAYER_ID.mlp.shared_experts.up_proj.weight": "layers.$LAYER_ID.block_sparse_moe.shared_experts.w3.weight",
+    "layers.$LAYER_ID.mlp.shared_experts.down_proj.weight": "layers.$LAYER_ID.block_sparse_moe.shared_experts.w2.weight",
+    "layers.$LAYER_ID.norm.weight": "layers.$LAYER_ID.shared_head.norm.weight",
+}
+DEFAULT_CHECKPOINT_NAME_PREFIX = "model"
+DEFAULT_DTYPE_CAST_RULES = {}
+DEFAULT_GATE_CHECKPOINT_LAYOUT = "separate"
+DEFAULT_QKV_CHECKPOINT_PREFUSED = False
+DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT = "per_expert"
+DEFAULT_MLP_GATE_UP_FUSED = True
+DEFAULT_MAPPING_PROJ_CHECKPOINT_TRANSPOSED = False
+
+# Model-side single-name root, taken from the live model rather than declared on
+# the config; kept next to its checkpoint-side counterpart for readability.
+DEFAULT_MODEL_NAME_PREFIX = "model"
+
+
+@dataclass(frozen=True)
+class FleetAOAContext(AOAContext):
+    """Adds the checkpoint-layout declarations this library's components consume.
+
+    Paddle owns the recursion contract (names, dtype rules, exclusions); the
+    layouts below are paddlefleet's own protocol and grow with the models it
+    supports, so they live here rather than in the framework. Each is a
+    checkpoint-format fact that cannot be inferred from the live module, so the
+    model declares it; it only selects an emit branch and never overrides the
+    live structure.
+    """
+
+    gate_checkpoint_layout: str = DEFAULT_GATE_CHECKPOINT_LAYOUT
+    """Attention output gate placement for gated attention. ``"separate"``
+    (default) is the ERNIE-Lite layout with a standalone ``gate_proj`` tensor;
+    ``"interleaved"`` is a gate packed head-interleaved inside ``q_proj`` that
+    must be de-interleaved before fusing into ``qkv_proj``. Only consulted when
+    the live attention is gated."""
+
+    qkv_checkpoint_prefused: bool = DEFAULT_QKV_CHECKPOINT_PREFUSED
+    """``False`` (default) is the usual checkpoint with distinct ``q_proj`` /
+    ``k_proj`` / ``v_proj`` tensors; ``True`` is a single pre-fused ``qkv``
+    tensor that must be split before the ``fused_qkv`` re-fusion."""
+
+    moe_expert_checkpoint_layout: str = DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT
+    """``"per_expert"`` (default) for one projection tensor per expert,
+    ``"packed"`` for two 3D tensors packing every expert. Only consulted on the
+    grouped-GEMM branch, so one model may mix layouts across layers."""
+
+    mlp_gate_up_fused: bool = DEFAULT_MLP_GATE_UP_FUSED
+    """``True`` (default) is the gated MLP whose separate checkpoint
+    ``gate_proj`` / ``up_proj`` fuse into the model ``up_gate_proj``; ``False``
+    is a non-gated MLP handled by the generic Linear family."""
+
+    mapping_proj_checkpoint_transposed: bool = (
+        DEFAULT_MAPPING_PROJ_CHECKPOINT_TRANSPOSED
+    )
+    """Whether the checkpoint stores the mHC ``mapping_proj`` weight as
+    ``(out, in)`` (the torch layout, needing a ``^T``) instead of the live
+    ``(in, out)``. Orthogonal to the alpha layout; the accompanying leaf rename
+    is expressed by ``checkpoint_name_mapping``, which cannot carry a
+    transpose."""
+
+
+def _protocol_value(config, attr, default):
+    """Reads one model-declared ``aoa_*`` attribute with the single rule.
+
+    An attribute that is absent or explicitly ``None`` falls back to the
+    default; every other declared value is taken verbatim, including the falsy
+    ones a real model relies on (an empty ``""`` checkpoint prefix, a ``False``
+    ``mlp_gate_up_fused``). Keeping this the only reading path is what makes the
+    eight attributes behave uniformly.
+    """
+    value = getattr(config, attr, None)
+    return default if value is None else value
+
+
+def build_aoa_context(model, config) -> FleetAOAContext:
+    """Builds the read-only :class:`FleetAOAContext` for a whole-model pass.
+
+    Ensures ``_set_pipeline_name_mapping`` has run (idempotent; the same
+    side-effect ``state_dict`` / ``sharded_state_dict`` rely on), then resolves
+    every model-declared ``aoa_*`` attribute through :func:`_protocol_value`
+    against the module-level ``DEFAULT_*`` constants. The name mapping is the
+    one field with extra handling: it is copied so the context never aliases the
+    shared default, and validated as a name template.
+
+    Args:
+        model: The live ``GPTModel`` (or subclass) whose pipeline mapping backs
+            the single-name resolution and whose ``_model_name_prefix``
+            reports the authoritative model single-name root -- the same value
+            ``get_layer_desc_list`` uses to name its pipeline layers, so pipeline
+            naming and AOA name resolution never diverge.
+        config: The sub-structure config threaded into the context (whole-model
+            config for single-tower models, per-tower config for multi-tower).
+
+    Returns:
+        A frozen :class:`FleetAOAContext`.
+    """
+    if model._pipeline_name_mapping is None:
+        model._set_pipeline_name_mapping()
+    checkpoint_name_mapping = dict(
+        _protocol_value(
+            config,
+            "aoa_checkpoint_name_mapping",
+            DEFAULT_CHECKPOINT_NAME_MAPPING,
+        )
+    )
+    validate_checkpoint_name_mapping(checkpoint_name_mapping)
+    return FleetAOAContext(
+        config=config,
+        pp_to_single_mapping=model._pp_to_single_mapping or {},
+        model_name_prefix=model._model_name_prefix(),
+        checkpoint_name_mapping=checkpoint_name_mapping,
+        checkpoint_name_prefix=_protocol_value(
+            config,
+            "aoa_checkpoint_name_prefix",
+            DEFAULT_CHECKPOINT_NAME_PREFIX,
+        ),
+        dtype_cast_rules=_protocol_value(
+            config, "aoa_dtype_cast_rules", DEFAULT_DTYPE_CAST_RULES
+        ),
+        gate_checkpoint_layout=_protocol_value(
+            config,
+            "aoa_gate_checkpoint_layout",
+            DEFAULT_GATE_CHECKPOINT_LAYOUT,
+        ),
+        qkv_checkpoint_prefused=_protocol_value(
+            config,
+            "aoa_qkv_checkpoint_prefused",
+            DEFAULT_QKV_CHECKPOINT_PREFUSED,
+        ),
+        moe_expert_checkpoint_layout=_protocol_value(
+            config,
+            "aoa_moe_expert_checkpoint_layout",
+            DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT,
+        ),
+        mlp_gate_up_fused=_protocol_value(
+            config, "aoa_mlp_gate_up_fused", DEFAULT_MLP_GATE_UP_FUSED
+        ),
+        mapping_proj_checkpoint_transposed=_protocol_value(
+            config,
+            "aoa_mapping_proj_checkpoint_transposed",
+            DEFAULT_MAPPING_PROJ_CHECKPOINT_TRANSPOSED,
+        ),
+    )

--- a/src/paddlefleet/models/gpt/gpt_model.py
+++ b/src/paddlefleet/models/gpt/gpt_model.py
@@ -299,13 +299,23 @@ class GPTModel(PipelineLayer):
                 gpu_param = param.cuda()
                 gpu_param._share_buffer_to(param)
 
-    def get_layer_desc_list(self, spec, tie_word_embeddings):
-        layers = []
+    def _model_name_prefix(self) -> str:
+        """The model single-name root prefix (no trailing dot).
+
+        Authoritative for how this model roots its single-name space: used by
+        :meth:`get_layer_desc_list` to name pipeline layers and fed into
+        ``build_aoa_context``, so pipeline naming and AOA name resolution never
+        diverge (e.g. ``model.language_model`` for the qwen3_vl / qwen3_5
+        language tower instead of the ``model`` default).
+        """
         model_type = getattr(self.config, "model_type", "")
         if "qwen3_vl" in model_type or "qwen3_5" in model_type:
-            name_prefix = "model.language_model"
-        else:
-            name_prefix = "model"
+            return "model.language_model"
+        return "model"
+
+    def get_layer_desc_list(self, spec, tie_word_embeddings):
+        layers = []
+        name_prefix = self._model_name_prefix()
         if tie_word_embeddings:
             self.add_sequential_layer(
                 layers,
@@ -331,11 +341,32 @@ class GPTModel(PipelineLayer):
                 layers, LayerDesc(spec.embedding), name_prefix
             )
         i = 0
+        empty_index = 0
+        aoa_modular = getattr(
+            getattr(self, "config", None), "aoa_modular", False
+        )
+
+        def next_empty_layer_name():
+            """Name for the next EmptyLayer, advancing the right counter.
+
+            With ``aoa_modular`` empty layers live in their own
+            ``empty_layers.<i>`` namespace and do not consume a ``layers.<i>``
+            slot, so transformer layers start at ``layers.0``. Otherwise both
+            kinds share the ``i`` counter (the legacy ``+H`` offset).
+            """
+            nonlocal i, empty_index
+            if aoa_modular:
+                name = f"{name_prefix}.empty_layers.{empty_index}"
+                empty_index += 1
+            else:
+                name = f"{name_prefix}.layers.{i}"
+                i += 1
+            return name
+
         for head_empty_layer in spec.head_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(head_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(head_empty_layer), next_empty_layer_name()
             )
-            i += 1
 
         if spec.mhc_expand is not None:
             self.add_sequential_layer(
@@ -449,9 +480,8 @@ class GPTModel(PipelineLayer):
 
         for tail_empty_layer in spec.tail_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(tail_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(tail_empty_layer), next_empty_layer_name()
             )
-            i += 1
 
         if (
             self.config.gpt_model_use_experimental_version

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -26,6 +26,13 @@ import paddle
 import paddle.distributed as dist
 import paddle.nn.functional as F
 from paddle.distributed.communication.reduce_scatter import _reduce_scatter_base
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    format_dtype_cast_attr,
+    format_inv_dtype_cast_attr,
+    resolve_dtype_cast_rule,
+    resolve_names,
+    should_skip,
+)
 from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
     build_sharded_state_dict,
 )
@@ -1283,6 +1290,96 @@ def linear_with_grad_accumulation_and_async_allreduce(
 linear_with_grad_accumulation_and_async_allreduce.warned = False
 
 
+def gen_linear_aoa_statements(
+    layer, ctx, *, structured_name_prefix="", aoa_name_scope=None
+):
+    """Checkpoint->model generator for the Linear family.
+
+    Weight carries a ``^T`` transpose; bias and any persistable buffer use
+    identity. A dtype cast suffix is appended when the model rules match the
+    single name. This is a plain module-level helper (not a base class) so
+    ``Linear`` / ``ColumnParallelLinear`` / ``RowParallelLinear`` share one
+    implementation without introducing a common ``LinearBase``. The transpose is
+    unconditional, so an owner whose embedded ``paddle.nn.Linear`` leaf may or
+    may not be transposed in the checkpoint (e.g.
+    ``HyperConnectionModule.mapping_proj``) emits that leaf inline instead of
+    calling this helper. The inverse direction has an independent helper and is
+    never derived from this one.
+    """
+    statements = []
+    local_state_dict = layer.state_dict(
+        structured_name_prefix="", include_sublayers=False
+    )
+    for name in local_state_dict:
+        if structured_name_prefix + name in ctx.excluded_names:
+            continue
+        checkpoint_name, single_name = resolve_names(
+            name,
+            ctx.checkpoint_name_prefix,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        cast = format_dtype_cast_attr(
+            resolve_dtype_cast_rule(
+                single_name,
+                ctx.dtype_cast_rules,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+        )
+        if name == "weight":
+            statements.append(f"{checkpoint_name}^T -> {single_name}{cast}")
+        else:
+            if should_skip(checkpoint_name, single_name, cast):
+                continue
+            statements.append(f"{checkpoint_name} -> {single_name}{cast}")
+    return statements
+
+
+def gen_linear_inv_aoa_statements(
+    layer, ctx, *, structured_name_prefix="", aoa_name_scope=None
+):
+    """Inverse (model -> checkpoint) generator for the Linear family.
+
+    Mirror of :func:`gen_linear_aoa_statements` for the opposite direction:
+    weight is transposed back (``^T`` stays on the source side), bias / buffers
+    use identity, and the dtype cast endpoints are swapped. Fully independent of
+    the checkpoint->model helper, never derived from its output text.
+    """
+    statements = []
+    local_state_dict = layer.state_dict(
+        structured_name_prefix="", include_sublayers=False
+    )
+    for name in local_state_dict:
+        if structured_name_prefix + name in ctx.excluded_names:
+            continue
+        checkpoint_name, single_name = resolve_names(
+            name,
+            ctx.checkpoint_name_prefix,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        cast = format_inv_dtype_cast_attr(
+            resolve_dtype_cast_rule(
+                single_name,
+                ctx.dtype_cast_rules,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+        )
+        if name == "weight":
+            statements.append(f"{single_name}^T -> {checkpoint_name}{cast}")
+        else:
+            if should_skip(checkpoint_name, single_name, cast):
+                continue
+            statements.append(f"{single_name} -> {checkpoint_name}{cast}")
+    return statements
+
+
 class Linear(paddle.nn.Layer):
     """Linear layer with no tensor parallelism (weight duplicated across TP ranks).
 
@@ -1593,6 +1690,37 @@ class Linear(paddle.nn.Layer):
         state_dict = self.state_dict(structured_name_prefix="")
         return build_sharded_state_dict(
             state_dict, None, structured_name_prefix
+        )
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model AOA for this Linear.
+
+        Weight is transposed (``^T``); bias / persistable buffers use identity;
+        a dtype cast suffix is appended when the model rules match.
+        """
+        return gen_linear_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) AOA for this Linear.
+
+        Independently generated, not derived from the checkpoint->model text:
+        weight is transposed back, bias / buffers use identity, dtype cast
+        endpoints are swapped.
+        """
+        return gen_linear_inv_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
         )
 
     def set_extra_state(self, state):
@@ -2123,6 +2251,37 @@ class ColumnParallelLinear(paddle.nn.Layer):
             state_dict, shard_rules, structured_name_prefix
         )
 
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model AOA for this Linear.
+
+        Weight is transposed (``^T``); bias / persistable buffers use identity;
+        a dtype cast suffix is appended when the model rules match.
+        """
+        return gen_linear_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) AOA for this Linear.
+
+        Independently generated, not derived from the checkpoint->model text:
+        weight is transposed back, bias / buffers use identity, dtype cast
+        endpoints are swapped.
+        """
+        return gen_linear_inv_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
     def set_extra_state(self, state):
         """Extra state is ignored"""
 
@@ -2439,6 +2598,37 @@ class RowParallelLinear(paddle.nn.Layer):
         shard_rules = None if self.world_size == 1 else {"weight": 0}
         return build_sharded_state_dict(
             state_dict, shard_rules, structured_name_prefix
+        )
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model AOA for this Linear.
+
+        Weight is transposed (``^T``); bias / persistable buffers use identity;
+        a dtype cast suffix is appended when the model rules match.
+        """
+        return gen_linear_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) AOA for this Linear.
+
+        Independently generated, not derived from the checkpoint->model text:
+        weight is transposed back, bias / buffers use identity, dtype cast
+        endpoints are swapped.
+        """
+        return gen_linear_inv_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
         )
 
     def set_extra_state(self, state):

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -21,7 +21,7 @@ import functools
 import logging
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 import paddle.nn.functional as F
 
@@ -1950,6 +1950,40 @@ class TransformerConfig(ModelParallelConfig):
     deepep_buffer_configs: dict | None = None
     """DeepEP buffer configuration."""
 
+    ####################
+    # AOA generator migration marker (code-level, not a config item)
+    ####################
+
+    aoa_modular: ClassVar[bool] = False
+    """Whether this model has been migrated to modular AOA.
+
+    Deliberately a ``ClassVar``, so it is not a dataclass field -- it records a
+    property of the model's *code*, not a choice the user makes per run. A
+    provider subclass flips it to ``True`` once its components carry their own
+    AOA markers and its hand-written generator is gone (see
+    ``Ernie5V2Provider``). Because ``register_attributes`` would otherwise turn
+    an ``aoa_modular`` key in a yaml / ``config.json`` into an instance
+    attribute that shadows this ``ClassVar``, ``_process_attribute`` rejects
+    that key outright, so it can only ever be set in a class body.
+
+    One marker drives two coupled behaviours, which is why they cannot be
+    separate switches:
+
+    * whole-model AOA generation: ``True`` -> module-tree recursion
+      (``gen_whole_model_aoa``), ``False`` -> the per-model hand-written
+      generator attached on the model instance (``model._gen_aoa_config``).
+    * empty-layer naming: ``True`` -> ``EmptyLayer`` instances get their own
+      ``empty_layers.<i>`` namespace and transformer layers are numbered
+      ``layers.0 .. layers.{num_hidden_layers - 1}`` regardless of
+      ``num_empty_layers_add_in_head=H``; ``False`` -> both kinds share one
+      ``layers.<i>`` counter, so the first transformer layer is ``layers.H``.
+
+    The modular generator is written against decoupled numbering and every
+    legacy generator against the shared counter, so mixing the two would
+    silently corrupt checkpoint keys. Keeping a single marker makes that
+    mixed state inexpressible.
+    """
+
     # Field name mapping rules: HuggingFace config.json name -> TransformerConfig name
     transform_rules = {
         # DSA field mapping
@@ -2080,6 +2114,12 @@ class TransformerConfig(ModelParallelConfig):
                 f"{self.renamed_config_keys_when_set[key]} Update the config "
                 f"that still sets {key}={value!r}; it would otherwise be "
                 f"silently ignored."
+            )
+        elif key == "aoa_modular":
+            raise ValueError(
+                "aoa_modular is a code-level modular-AOA migration marker "
+                "(a ClassVar flipped in a provider class body), not a config "
+                "field; it must never be set from yaml / config.json."
             )
         else:
             setattr(self, key, value)

--- a/src/paddlefleet/transformer/transformer_encoder.py
+++ b/src/paddlefleet/transformer/transformer_encoder.py
@@ -167,11 +167,31 @@ class TransformerEncoder(PipelineLayer):
 
     def get_encoder_layer_desc_list(self, layers, spec, name_prefix):
         i = 0
+        empty_index = 0
+
+        def next_empty_layer_name():
+            """Name for the next EmptyLayer, advancing the right counter.
+
+            With ``aoa_modular`` empty layers live in their own
+            ``empty_layers.<i>`` namespace and do not consume a ``layers.<i>``
+            slot, so transformer layers start at ``layers.0``. Otherwise both
+            kinds share the ``i`` counter. Kept identical to the language
+            tower's rule in ``GPTModel.get_layer_desc_list`` so the two towers
+            never name layers differently.
+            """
+            nonlocal i, empty_index
+            if getattr(getattr(self, "config", None), "aoa_modular", False):
+                name = f"{name_prefix}.empty_layers.{empty_index}"
+            else:
+                name = f"{name_prefix}.layers.{i}"
+                i += 1
+            empty_index += 1
+            return name
+
         for head_empty_layer in spec.head_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(head_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(head_empty_layer), next_empty_layer_name()
             )
-            i += 1
         for transformer_layer_spec in spec.transformer_layers:
             self.add_sequential_layer(
                 layers,
@@ -181,9 +201,8 @@ class TransformerEncoder(PipelineLayer):
             i += 1
         for tail_empty_layer in spec.tail_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(tail_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(tail_empty_layer), next_empty_layer_name()
             )
-            i += 1
 
     def overlapped_forward_backward(
         self,

--- a/tests/single_card_tests/aoa/test_aoa_config_protocol.py
+++ b/tests/single_card_tests/aoa/test_aoa_config_protocol.py
@@ -1,0 +1,289 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: pins the whole-model config-field protocol normalization -- the single
+# place that resolves the model-declared AOA name / dtype / layout attributes
+# (``build_aoa_context`` via ``_protocol_value``) and the MTP checkpoint-prefix
+# attributes (``MTPCheckpointPrefixSpec`` via
+# ``resolve_mtp_checkpoint_prefix_spec``). An unmigrated model (without an
+# explicit mapping) inherits the shared ERNIE mapping; an external model
+# overrides it via that attribute. Also carries a source-level lint pinning
+# the direction-independence contract (no ``direction`` / ``reverse`` param, a
+# ``_fwd_`` / ``_inv_`` helper split with no cross-direction calls and no
+# ``aoa_config_reverse`` call).
+import dataclasses
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+from paddle.distributed.flex_checkpoint.aoa.generation import AOAContext
+
+from paddlefleet.models.gpt.aoa_generator import (
+    DEFAULT_CHECKPOINT_NAME_MAPPING,
+    DEFAULT_CHECKPOINT_NAME_PREFIX,
+    DEFAULT_GATE_CHECKPOINT_LAYOUT,
+    DEFAULT_MLP_GATE_UP_FUSED,
+    DEFAULT_MODEL_NAME_PREFIX,
+    DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT,
+    DEFAULT_QKV_CHECKPOINT_PREFUSED,
+    FleetAOAContext,
+    MTPCheckpointPrefixSpec,
+    build_aoa_context,
+    resolve_mtp_checkpoint_prefix_spec,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+class _Cfg:
+    """Bare config stand-in; only the attributes a test sets are present."""
+
+
+class _FakeModel:
+    """Duck-types the attributes ``build_aoa_context`` reads.
+
+    ``_pipeline_name_mapping`` is pre-populated (non-None) so the idempotent
+    ``_set_pipeline_name_mapping`` side effect is skipped in the happy path.
+    ``_model_name_prefix()`` stands in for the live model's single-name root,
+    which is where the context takes it from; the value is held in a separately
+    named attribute so it does not shadow the method.
+    """
+
+    def __init__(
+        self,
+        pp_to_single_mapping=None,
+        model_name_prefix=DEFAULT_MODEL_NAME_PREFIX,
+    ):
+        self._pipeline_name_mapping = {}
+        self._pp_to_single_mapping = pp_to_single_mapping or {}
+        self._model_name_prefix_value = model_name_prefix
+
+    def _set_pipeline_name_mapping(self):
+        self._pipeline_name_mapping = {}
+
+    def _model_name_prefix(self):
+        return self._model_name_prefix_value
+
+
+class TestBuildAOAContextDefaults(unittest.TestCase):
+    def test_unmigrated_config_uses_ernie_defaults(self):
+        model = _FakeModel(pp_to_single_mapping={"s": "s"})
+        ctx = build_aoa_context(model, _Cfg())
+        self.assertIsInstance(ctx, AOAContext)
+        self.assertIsInstance(ctx, FleetAOAContext)
+        self.assertEqual(
+            ctx.checkpoint_name_prefix, DEFAULT_CHECKPOINT_NAME_PREFIX
+        )
+        self.assertEqual(
+            dict(ctx.checkpoint_name_mapping), DEFAULT_CHECKPOINT_NAME_MAPPING
+        )
+        self.assertEqual(dict(ctx.dtype_cast_rules), {})
+        self.assertEqual(ctx.model_name_prefix, DEFAULT_MODEL_NAME_PREFIX)
+        self.assertEqual(dict(ctx.pp_to_single_mapping), {"s": "s"})
+
+    def test_layout_defaults(self):
+        ctx = build_aoa_context(_FakeModel(), _Cfg())
+        self.assertEqual(
+            ctx.gate_checkpoint_layout, DEFAULT_GATE_CHECKPOINT_LAYOUT
+        )
+        self.assertEqual(
+            ctx.qkv_checkpoint_prefused, DEFAULT_QKV_CHECKPOINT_PREFUSED
+        )
+        self.assertEqual(
+            ctx.moe_expert_checkpoint_layout,
+            DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT,
+        )
+        self.assertEqual(ctx.mlp_gate_up_fused, DEFAULT_MLP_GATE_UP_FUSED)
+        self.assertFalse(ctx.mapping_proj_checkpoint_transposed)
+
+    def test_mapping_is_copied_not_aliased(self):
+        ctx = build_aoa_context(_FakeModel(), _Cfg())
+        self.assertIsNot(
+            ctx.checkpoint_name_mapping, DEFAULT_CHECKPOINT_NAME_MAPPING
+        )
+
+    def test_explicit_empty_checkpoint_mapping_overrides_default(self):
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_mapping = {}
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(dict(ctx.checkpoint_name_mapping), {})
+
+    def test_explicit_empty_checkpoint_prefix_is_preserved(self):
+        # A checkpoint rooted at the top level (DeepSeek V4) declares "" and
+        # must not silently fall back to the Ernie-series default.
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_prefix = ""
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(ctx.checkpoint_name_prefix, "")
+
+    def test_explicit_none_falls_back_to_default(self):
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_prefix = None
+        cfg.aoa_dtype_cast_rules = None
+        cfg.aoa_qkv_checkpoint_prefused = None
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(
+            ctx.checkpoint_name_prefix, DEFAULT_CHECKPOINT_NAME_PREFIX
+        )
+        self.assertEqual(dict(ctx.dtype_cast_rules), {})
+        self.assertEqual(
+            ctx.qkv_checkpoint_prefused, DEFAULT_QKV_CHECKPOINT_PREFUSED
+        )
+
+
+class TestBuildAOAContextOverrides(unittest.TestCase):
+    def test_name_and_dtype_overrides_propagate(self):
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_prefix = "hf"
+        cfg.aoa_checkpoint_name_mapping = {"a.weight": "b.weight"}
+        cfg.aoa_dtype_cast_rules = {
+            "x": {"checkpoint_dtype": "bfloat16", "model_dtype": "float32"}
+        }
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(ctx.checkpoint_name_prefix, "hf")
+        self.assertEqual(
+            dict(ctx.checkpoint_name_mapping), {"a.weight": "b.weight"}
+        )
+        self.assertEqual(
+            dict(ctx.dtype_cast_rules),
+            {"x": {"checkpoint_dtype": "bfloat16", "model_dtype": "float32"}},
+        )
+
+    def test_layout_overrides_propagate(self):
+        cfg = _Cfg()
+        cfg.aoa_gate_checkpoint_layout = "interleaved"
+        cfg.aoa_qkv_checkpoint_prefused = True
+        cfg.aoa_moe_expert_checkpoint_layout = "packed"
+        cfg.aoa_mapping_proj_checkpoint_transposed = True
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(ctx.gate_checkpoint_layout, "interleaved")
+        self.assertTrue(ctx.qkv_checkpoint_prefused)
+        self.assertEqual(ctx.moe_expert_checkpoint_layout, "packed")
+        self.assertTrue(ctx.mapping_proj_checkpoint_transposed)
+
+    def test_falsy_mlp_gate_up_fused_is_preserved(self):
+        # Qwen3-VL declares False; a truthiness-based default would swallow it.
+        cfg = _Cfg()
+        cfg.aoa_mlp_gate_up_fused = False
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertFalse(ctx.mlp_gate_up_fused)
+
+    def test_model_name_prefix_comes_from_the_live_model(self):
+        # The model single-name root comes from the live model, not the config:
+        # it must stay the same value that names the pipeline layers.
+        ctx = build_aoa_context(_FakeModel(model_name_prefix="root"), _Cfg())
+        self.assertEqual(ctx.model_name_prefix, "root")
+
+    def test_context_is_frozen(self):
+        ctx = build_aoa_context(_FakeModel(), _Cfg())
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            ctx.checkpoint_name_prefix = "mut"
+
+    def test_none_pipeline_mapping_triggers_side_effect(self):
+        model = _FakeModel()
+        model._pipeline_name_mapping = None
+        ctx = build_aoa_context(model, _Cfg())
+        self.assertIsNotNone(model._pipeline_name_mapping)
+        self.assertIsInstance(ctx, AOAContext)
+
+
+class TestMTPCheckpointPrefixSpec(unittest.TestCase):
+    def test_defaults(self):
+        spec = resolve_mtp_checkpoint_prefix_spec(_Cfg())
+        self.assertEqual(spec.checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertFalse(spec.is_absolute)
+
+    def test_transformer_inherits_own_prefix(self):
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix = "mtp.$LAYER_ID"
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertEqual(spec.checkpoint_prefix, "mtp.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "mtp.$LAYER_ID")
+
+    def test_transformer_prefix_override_independent(self):
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix = "mtp.$LAYER_ID"
+        cfg.aoa_mtp_transformer_checkpoint_prefix = "mtp.$LAYER_ID.tf"
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertEqual(spec.checkpoint_prefix, "mtp.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "mtp.$LAYER_ID.tf")
+
+    def test_absolute_flag(self):
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix_absolute = True
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertTrue(spec.is_absolute)
+
+    def test_bare_spec_defaults(self):
+        spec = MTPCheckpointPrefixSpec()
+        self.assertEqual(spec.checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertFalse(spec.is_absolute)
+
+    def test_explicit_empty_mtp_prefix_is_preserved(self):
+        # A top-level MTP checkpoint declares "" and must not silently fall
+        # back to the layers.$LAYER_ID default; the inner transformer prefix
+        # then inherits that same "".
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix = ""
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertEqual(spec.checkpoint_prefix, "")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "")
+
+
+class TestAoaModularNotConfigInjectable(unittest.TestCase):
+    """Pins that ``aoa_modular`` is a code-level marker, not a config field.
+
+    The marker is a ``ClassVar`` a migrated provider flips in its class body;
+    it must never be reachable from a yaml / ``config.json``. Two independent
+    surfaces enforce this and this test pins both: the ``ClassVar`` keeps it
+    out of the dataclass fields (so it is neither constructor-settable nor
+    instance-shadowed), and ``_process_attribute`` rejects the key outright on
+    the ``from_config`` load path.
+    """
+
+    def test_classvar_default_is_false(self):
+        self.assertFalse(TransformerConfig.aoa_modular)
+
+    def test_aoa_modular_is_not_a_dataclass_field(self):
+        field_names = {f.name for f in dataclasses.fields(TransformerConfig)}
+        self.assertNotIn("aoa_modular", field_names)
+
+    def test_from_config_rejects_aoa_modular_key(self):
+        # Rejected by the key itself, independent of the value carried.
+        for value in (True, False):
+            with self.assertRaises(ValueError):
+                TransformerConfig.from_config(
+                    SimpleNamespace(aoa_modular=value)
+                )
+
+    def test_reject_is_narrow(self):
+        # An unrelated attribute still flows through the normal setattr path.
+        inst = object.__new__(TransformerConfig)
+        inst._process_attribute("some_unrelated_attr", 123)
+        self.assertEqual(inst.some_unrelated_attr, 123)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_linear_component.py
+++ b/tests/single_card_tests/aoa/test_aoa_linear_component.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: the Linear family (``Linear`` / ``ColumnParallelLinear`` /
+# ``RowParallelLinear``) share a single module-level helper
+# ``gen_linear_aoa_statements`` / ``gen_linear_inv_aoa_statements``. This test
+# pins the coverage contract: ``weight`` carries ``^T``; bias / buffers use
+# identity only when their resolved names differ or a dtype cast is required;
+# and excluded aliases are omitted in both directions.
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+
+import paddle
+
+from paddlefleet.models.gpt.aoa_generator import (
+    FleetAOAContext,
+)
+
+
+def _ctx(
+    dtype_cast_rules=None,
+    *,
+    checkpoint_name_prefix="hf",
+    model_name_prefix="model",
+    excluded_names=frozenset(),
+):
+    return FleetAOAContext(
+        config=None,
+        checkpoint_name_prefix=checkpoint_name_prefix,
+        pp_to_single_mapping={},
+        checkpoint_name_mapping={},
+        dtype_cast_rules=dtype_cast_rules or {},
+        model_name_prefix=model_name_prefix,
+        excluded_names=excluded_names,
+    )
+
+
+def _make_linear_leaf(bias=False, buffer=False):
+    """Binds the Linear family AOA helpers onto a controllable stand-in.
+
+    The real ``Linear`` needs a live TP process group to construct, so we bind
+    the two override methods (which just forward to the module-level helpers)
+    onto a lightweight ``paddle.nn.Layer`` carrying real params / buffers.
+    """
+    from paddlefleet.tensor_parallel.layers import Linear
+
+    class _LinearLeaf(paddle.nn.Layer):
+        gen_aoa_statements = Linear.gen_aoa_statements
+        gen_inv_aoa_statements = Linear.gen_inv_aoa_statements
+
+        def __init__(self):
+            super().__init__()
+            self.weight = self.create_parameter(shape=[2, 2])
+            if bias:
+                self.bias = self.create_parameter(shape=[2])
+            if buffer:
+                # A persistable buffer must appear in state_dict and therefore
+                # get an identity statement (no orphan target).
+                self.register_buffer(
+                    "some_buf", paddle.zeros([2]), persistable=True
+                )
+                # A non-persistable buffer must NOT appear (no statement).
+                self.register_buffer(
+                    "tmp_buf", paddle.zeros([2]), persistable=False
+                )
+
+    return _LinearLeaf
+
+
+_PFX = "model.layers.0.mlp.down_proj."
+_W_CK = "hf.layers.0.mlp.down_proj.weight"
+_W_MD = "model.layers.0.mlp.down_proj.weight"
+
+
+class TestLinearClassContract(unittest.TestCase):
+    def test_three_linear_classes_override(self):
+        from paddlefleet.tensor_parallel.layers import (
+            ColumnParallelLinear,
+            Linear,
+            RowParallelLinear,
+        )
+
+        for cls in (Linear, ColumnParallelLinear, RowParallelLinear):
+            self.assertIn("gen_aoa_statements", cls.__dict__)
+            self.assertIn("gen_inv_aoa_statements", cls.__dict__)
+
+
+class TestLinearForward(unittest.TestCase):
+    def test_weight_transposed_bias_and_buffer_identity(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        # weight is transposed
+        self.assertIn(f"{_W_CK}^T -> {_W_MD}", stmts)
+        # bias is identity (no ^T)
+        self.assertIn(
+            "hf.layers.0.mlp.down_proj.bias -> "
+            "model.layers.0.mlp.down_proj.bias",
+            stmts,
+        )
+        # persistable buffer is identity, non-persistable buffer is absent
+        self.assertIn(
+            "hf.layers.0.mlp.down_proj.some_buf -> "
+            "model.layers.0.mlp.down_proj.some_buf",
+            stmts,
+        )
+        self.assertFalse(any("tmp_buf" in s for s in stmts))
+
+    def test_no_orphan_targets(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        # Every own state_dict key (weight/bias/some_buf) has exactly one
+        # producing statement; tmp_buf (non-persistable) has none.
+        self.assertEqual(len(stmts), 3)
+
+    def test_bias_absent_when_not_present(self):
+        model = _make_linear_leaf(bias=False, buffer=False)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        self.assertEqual(stmts, [f"{_W_CK}^T -> {_W_MD}"])
+
+    def test_same_name_identity_is_omitted(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        ctx = _ctx(checkpoint_name_prefix="model", model_name_prefix="model")
+        stmts = model.gen_aoa_statements(ctx, structured_name_prefix=_PFX)
+        self.assertEqual(stmts, [f"{_W_MD}^T -> {_W_MD}"])
+
+    def test_excluded_weight_is_omitted_in_forward_and_inverse(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        ctx = _ctx(excluded_names=frozenset({_PFX + "weight"}))
+
+        forward = model.gen_aoa_statements(ctx, structured_name_prefix=_PFX)
+        inverse = model.gen_inv_aoa_statements(ctx, structured_name_prefix=_PFX)
+
+        self.assertNotIn(f"{_W_CK}^T -> {_W_MD}", forward)
+        self.assertNotIn(f"{_W_MD}^T -> {_W_CK}", inverse)
+
+
+class TestLinearInverse(unittest.TestCase):
+    def test_weight_transposed_back_endpoints_swapped(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        stmts = model.gen_inv_aoa_statements(
+            _ctx(), structured_name_prefix=_PFX
+        )
+        self.assertIn(f"{_W_MD}^T -> {_W_CK}", stmts)
+        self.assertIn(
+            "model.layers.0.mlp.down_proj.bias -> "
+            "hf.layers.0.mlp.down_proj.bias",
+            stmts,
+        )
+        self.assertIn(
+            "model.layers.0.mlp.down_proj.some_buf -> "
+            "hf.layers.0.mlp.down_proj.some_buf",
+            stmts,
+        )
+        self.assertEqual(len(stmts), 3)
+
+
+class TestLinearDtypeCast(unittest.TestCase):
+    def test_forward_and_inverse_cast_endpoints(self):
+        rules = {
+            "layers.0.mlp.down_proj.weight": {
+                "checkpoint_dtype": "bfloat16",
+                "model_dtype": "float32",
+            }
+        }
+        model = _make_linear_leaf(bias=False)()
+        fwd = model.gen_aoa_statements(_ctx(rules), structured_name_prefix=_PFX)
+        self.assertEqual(
+            fwd,
+            [
+                f"{_W_CK}^T -> {_W_MD}, "
+                "src_dtype='bfloat16', dst_dtype='float32'"
+            ],
+        )
+        inv = model.gen_inv_aoa_statements(
+            _ctx(rules), structured_name_prefix=_PFX
+        )
+        self.assertEqual(
+            inv,
+            [
+                f"{_W_MD}^T -> {_W_CK}, "
+                "src_dtype='float32', dst_dtype='bfloat16'"
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
+++ b/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
@@ -74,11 +74,13 @@ def _make_config(**overrides):
 def _layer_descs(num_mtp=1, **config_overrides):
     """Call get_layer_desc_list without building a real GPTModel.
 
-    The method only touches ``self.config`` and ``self.add_sequential_layer``,
-    so a stub carrying those two is enough and keeps this a single-card test.
+    The method only touches ``self.config``, ``self._model_name_prefix`` and
+    ``self.add_sequential_layer``, so a stub carrying those three is enough and
+    keeps this a single-card test.
     """
     fake_self = SimpleNamespace(
         config=_make_config(**config_overrides),
+        _model_name_prefix=lambda: "model",
         add_sequential_layer=lambda layers, desc, name_prefix="": layers.append(
             {"layer": desc, "name_prefix": name_prefix}
         ),


### PR DESCRIPTION
### PR Category

Distributed Strategy

### PR Types

New features

### Description

引入模块化 AOA 的 checkpoint 转换协议：不再为每个模型手写一份整模 AOA 生成器，而是让组件自己产出 AOA 语句，并沿真实的 `Layer` 模块树递归组装。本 PR 落地边界部分，其余组件叶子（MLP、MoE、Attention、MLA 等）在各自的 PR 中接入。

- **上下文协议**：`build_aoa_context` 把模型声明的 `aoa_*` 属性（checkpoint 根前缀、checkpoint 命名映射）按一套模块级默认值归一，冻结进 Paddle 的 `AOAContext`，递归过程中只原样向下转发。
- **整模入口**：`gen_whole_model_(inv_)aoa` 构造一次 context，遍历真实的 pipeline 单元，经递归收集语句；`GPTModel` override 这两个协议方法，模型边界除命名之外不承担任何规则。两个方向都在返回前全局化：pipeline 组会把层切分到各 rank，而 `save_full_param` 要求所有 rank 对同一份 config 达成一致，`_globalize_statements` 因此在 pipeline 子组内 all-gather 并按 rank 序拼接。
- **Linear 家族叶子**：`Linear` / `ColumnParallelLinear` / `RowParallelLinear` 共用一对模块级 helper。`weight` 带 `^T`；bias 与持久化 buffer 只在两侧解析出的名字不同时才发语句，因为同名张量本身就会按名透传。
- **命名收敛**：模型 single 名的根前缀统一由 `GPTModel._model_name_prefix()` 提供，`get_layer_desc_list` 给 pipeline 层命名用的值与 AOA 解析名字所依据的值从此不可能分叉。

**对现有训练与 checkpoint 存取零行为变化。** 所有在用模型继续走各自的手写 AOA 生成器，本 PR 新增的代码在真实运行路径上不可达。

### 是否引起精度变化

否。
