### PR TITLE
[docmask_meta] Opt MTP layers out of the shared document-mask metadata registry

### DIFF
--- a/src/paddlefleet/transformer/doc_mask_meta_registry.py
+++ b/src/paddlefleet/transformer/doc_mask_meta_registry.py
@@ -44,7 +44,11 @@ the same scheme ``ernie-core``'s ``MagicInstance`` uses:
 
 * one counter per consumer, keyed by ``(layer_number, is_mtp_layer)``;
 * advanced exactly once per micro-batch, from ``TransformerLayer.forward`` --
-  which always runs outside the recompute wrapper, unlike ``_forward_impl``;
+  which for a decoder layer always runs outside the recompute wrapper, unlike
+  ``_forward_impl``. MTP layers are not consumers: their mask group is never
+  prebuilt, and their ``forward`` *is* inside a recompute segment (the MTP
+  module recomputes one level above it), so they opt out in
+  ``_docmask_meta_kwargs`` and build their metadata privately;
 * ``mb_idx = counter % accumulate_steps`` picks the slot;
 * counters are reset and audited at the step boundary by the trainer.
 

--- a/src/paddlefleet/transformer/transformer_layer.py
+++ b/src/paddlefleet/transformer/transformer_layer.py
@@ -856,10 +856,11 @@ class TransformerLayer(nn.Layer):
             # receive unused tensors that cause backward errors.
             dict_args.pop("blocks", None)
         # Shared CSA document-mask metadata (see _docmask_meta_kwargs). Taken HERE,
-        # outside the recompute wrapper below: `forward` runs exactly once per
-        # (layer, micro-batch) whatever the recompute granularity is, while
-        # `_forward_impl` may be replayed. Empty dict for every layer class that
-        # does not opt in.
+        # outside the recompute wrapper below: for a decoder layer `forward` runs
+        # exactly once per (layer, micro-batch) whatever the recompute
+        # granularity is, while `_forward_impl` may be replayed. Empty dict for
+        # every layer class that does not opt in, and for MTP layers, whose
+        # `forward` is itself inside the MTP module's recompute segment.
         docmask_meta_kwargs = self._docmask_meta_kwargs()
 
         if self.full_recompute or (not has_recovered()):
@@ -1662,9 +1663,15 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         # Consumer identity for the shared CSA document-mask metadata
         # (config.csa_share_docmask_meta): one forward counter per consumer, so
         # virtual-pipeline interleaving across chunks cannot mix them up.
+        #
+        # MTP layers are not consumers at all -- see _docmask_meta_kwargs for
+        # why -- so they are not registered either; registering them would leave
+        # a permanently-unused counter in the step-boundary audit.
+        self._docmask_meta_is_consumer = not bool(is_mtp_layer)
         self._docmask_meta_key = (int(layer_number), bool(is_mtp_layer))
-        if getattr(config, "csa_share_docmask_meta", False) or getattr(
-            config, "mqa_share_docmask_meta", False
+        if self._docmask_meta_is_consumer and (
+            getattr(config, "csa_share_docmask_meta", False)
+            or getattr(config, "mqa_share_docmask_meta", False)
         ):
             from paddlefleet.transformer.doc_mask_meta_registry import (
                 doc_mask_meta_registry,
@@ -1809,7 +1816,25 @@ class HyperConnectionTransformerLayer(TransformerLayer):
         Called from ``TransformerLayer.forward``, i.e. outside the recompute
         wrapper: the counter must advance exactly once per (layer, micro-batch),
         whereas ``_forward_impl`` may be replayed by recompute.
+
+        MTP layers opt out. Two reasons, either of which is sufficient:
+
+        * they would gain nothing. The trainer prebuilds only the ``("main",)``
+          mask group, while an MTP layer's attention asks for its own
+          ``("mtp", layer_number)`` group -- it is fed a slice of
+          ``mtp_startend_row_indices_all``, a different mask -- so every lookup
+          misses by design and the layer builds its own metadata anyway.
+        * their ``forward`` is not outside the recompute wrapper.
+          ``MultiTokenPredictionLayer._checkpointed_forward`` recomputes
+          ``_proj_and_transformer_layer``, i.e. one level *above* this layer's
+          ``forward``, so under ``recompute_granularity="full"`` +
+          ``recompute_method="uniform"`` the call lands inside a recompute
+          segment and ``advance`` rejects it -- the counter cannot be made
+          correct there, since paddle runs the original forward under
+          ``no_grad`` and only the backward replay with grad enabled.
         """
+        if not self._docmask_meta_is_consumer:
+            return {}
         if not (
             getattr(self.config, "csa_share_docmask_meta", False)
             or getattr(self.config, "mqa_share_docmask_meta", False)

--- a/tests/single_card_tests/transformer/test_doc_mask_meta_registry.py
+++ b/tests/single_card_tests/transformer/test_doc_mask_meta_registry.py
@@ -596,14 +596,27 @@ class TestDocMaskLayerWiring(unittest.TestCase):
         self.assertNotIn((99, False), doc_mask_meta_registry._cnt)
         self.assertEqual(layer._docmask_meta_kwargs(), {})
 
-    def test_mtp_layer_uses_its_own_consumer_key(self):
+    def test_mtp_layer_opts_out_entirely(self):
+        # MTP layers are not consumers: the trainer never prebuilds their
+        # ("mtp", n) mask group, and their forward runs *inside* the MTP
+        # module's recompute segment, where advance() cannot be made correct.
         layer = _layer(is_mtp=True, layer_number=4)
         self.assertEqual(layer._docmask_meta_key, (4, True))
-        self.assertIn((4, True), doc_mask_meta_registry._cnt)
-        # separate counter from the main layer
+        self.assertNotIn((4, True), doc_mask_meta_registry._cnt)
+        self.assertEqual(layer._docmask_meta_kwargs(), {})
+        # and it does not disturb the main layer's counter
         main = _layer(is_mtp=False, layer_number=1)
         self.assertEqual(main._docmask_meta_kwargs(), {"docmask_mb_idx": 0})
-        self.assertEqual(layer._docmask_meta_kwargs(), {"docmask_mb_idx": 0})
+        self.assertEqual(layer._docmask_meta_kwargs(), {})
+
+    def test_mtp_layer_kwargs_ok_inside_nograd(self):
+        # The crash this opt-out fixes: under recompute_granularity="full" +
+        # recompute_method="uniform" the MTP module recomputes one level above
+        # TransformerLayer.forward, so this call happens under no_grad.
+        layer = _layer(is_mtp=True, layer_number=5)
+        layer.train()
+        with paddle.no_grad():
+            self.assertEqual(layer._docmask_meta_kwargs(), {})
 
     def test_advance_respects_accumulation_boundary(self):
         layer = _layer(share=True)


### PR DESCRIPTION
### PR Category

Performance Optimization

### PR Types

Bug fixes

### Description

`csa_share_docmask_meta` + MTP + `recompute_granularity="full"` crashes on the
first training step:

```
RuntimeError: doc-mask metadata: advance((0, True)) ran in a no-grad training
forward, i.e. nested inside a recompute segment. It must be called from
TransformerLayer.forward, outside the recompute wrapper -- otherwise the forward
reads the previous micro-batch's slot.
```

`DocMaskMetaRegistry.advance` requires its caller to sit outside any recompute
wrapper, and `HyperConnectionTransformerLayer._docmask_meta_kwargs` satisfies
that for decoder layers because `TransformerLayer.forward` is where the layer's
own `full_recompute` wrapper is opened, not something it sits inside.

That does not hold for MTP layers. `MultiTokenPredictionLayer` recomputes at a
coarser granularity: `_checkpointed_forward` wraps
`_proj_and_transformer_layer`, which is one level *above* the layer's `forward`.
So under `recompute_granularity="full"` + `recompute_method="uniform"` the call
lands inside a recompute segment, where the counter cannot be made correct in
the first place -- paddle's reentrant recompute runs the original forward under
`no_grad` and restores `_has_grad` only for the backward replay, so a counter
that skipped the no-grad pass would hand the forward whose output actually flows
onward the previous micro-batch's slot.

MTP layers are therefore opted out of the registry entirely, which costs nothing
because they were never getting anything from it: the trainer prebuilds only the
`("main",)` mask group, while an MTP layer's attention asks for its own
`("mtp", layer_number)` group -- it is fed a slice of
`mtp_startend_row_indices_all`, a different mask -- so every lookup missed by
design and the layer built its own metadata anyway.

Changes:

- `transformer_layer.py`: `HyperConnectionTransformerLayer` gains
  `_docmask_meta_is_consumer` (false for MTP layers); MTP layers no longer
  `register()` a forward counter and `_docmask_meta_kwargs()` returns `{}` for
  them, leaving `docmask_mb_idx == -1`.
- `doc_mask_meta_registry.py`: module docstring no longer claims
  `TransformerLayer.forward` always runs outside the recompute wrapper, and
  records why MTP layers are not consumers. No behavioural change.
- `test_doc_mask_meta_registry.py`: `test_mtp_layer_uses_its_own_consumer_key`
  asserted the behaviour being removed, so it is replaced by
  `test_mtp_layer_opts_out_entirely` plus
  `test_mtp_layer_kwargs_ok_inside_nograd`, which is the regression case (the
  call under `paddle.no_grad()` that used to raise).

Verified on an ERNIE-lite layer43 `mqa_dsa` pretraining job (43 layers,
`num_nextn_predict_layers=1`, `mtp_shared_last_layer=True`, cp=4, ep=8,
`csa_share_docmask_meta=True`): the step-1 crash is gone and 10 steps run with
`mtp_1_loss` in the expected range. Unit tests:
`test_doc_mask_meta_registry.py`, `test_doc_mask_meta_cache_equivalence.py`,
`test_dsv4_document_isolation.py`,
`test_ai_hyper_connection_transformer_layer.py` and
`test_ai_multi_token_prediction.py` all pass (233 cases).

### 是否引起精度变化

否

`docmask_mb_idx == -1` is exactly the state the switched-off path produces, and
it is read in only two places, both gated on it being non-negative
(`dsv4_hybrid_attention.py`'s `csa_share_docmask_meta and docmask_mb_idx >= 0`
and `mqa_latent_attention.py`'s `docmask_mb_idx >= 0 and
mqa_share_docmask_meta`). Both then fall through to the same
`CSADocMaskMetadata.build` / `_derive_csa_doc_boundaries` call the MTP layer
already reached via the guaranteed lookup miss, so the metadata is produced by
the same function from the same inputs. Decoder layers are untouched: they keep
registering, advancing and sharing, and `advance`'s guard still protects them.
