### PR TITLE
[release/0.4] Fix FA4 cutedsl-switch dispatch for small head dims

### DIFF
--- a/tests/single_card_tests/transformer/test_hybrid_mla_recompute_mtp_ckpt.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_recompute_mtp_ckpt.py
@@ -152,7 +152,12 @@ class TestRefinedRecomputeSinkGuard(unittest.TestCase):
         sink. (256, 128) is not in the cutedsl head-dim whitelist (256 requires
         ``head_dim_v == 256``), so it degrades to FA2 and the guard fires.
         Turning the hotfix switch off routes FA3 to Paddle's kernel, where the
-        sink does not exist at any head dim."""
+        sink does not exist at any head dim.
+
+        On SM100 production picks FA4, which is cutedsl-only: the switch is an
+        FA3 routing flag and does not touch FA4, so (192, 128) stays on cute
+        with the switch off as well; only (256, 128) degrades, via the
+        whitelist."""
         try:
             from paddlefleet_ops.flash_mask_facade import (
                 get_fa_version,
@@ -174,11 +179,23 @@ class TestRefinedRecomputeSinkGuard(unittest.TestCase):
             self.assertTrue(_cute(192), "(192, 128) should stay on cute")
             self.assertFalse(_cute(256), "(256, 128) should degrade to FA2")
             with cpp_flashmask_backend():
-                for qd in (192, 256):
-                    self.assertFalse(
-                        _cute(qd),
-                        f"({qd}, 128) must leave cute once the switch is off",
+                if production == 4:
+                    # FA4 is cutedsl-only and the hotfix switch routes FA3
+                    # only: flipping it must not move FA4 off cute.
+                    self.assertTrue(
+                        _cute(192),
+                        "(192, 128) should stay on cute: the switch "
+                        "does not route FA4",
                     )
+                    self.assertFalse(
+                        _cute(256), "(256, 128) should degrade to FA2"
+                    )
+                else:
+                    for qd in (192, 256):
+                        self.assertFalse(
+                            _cute(qd),
+                            f"({qd}, 128) must leave cute once the switch is off",
+                        )
 
 
 # ===========================================================================


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Operator Mechanism

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->
修复单测
修复前 sm90 能 pass，sm100 因为支持程度和 sm90 不一致单测挂。
修复后 sm90 sm100 卡上均能 pass。

d192/dv128 支持程度：

FA3 sm90
+ cpp，不支持 d192/dv128
+ cutedsl，支持 d192/dv128

FA4 sm100
+ 支持 d192/dv128

### 是否引起精度变化
<!-- one of the following [ 是 | 否 ]-->
否

Cherry-pick of #2025 to `release/0.4`.

Merged in dev: #2025  <!-- For pass CI -->