### PR TITLE
[FlexCheckpoint] Modular AOA: whole-model generator + entries

### DIFF
--- a/src/paddlefleet/models/gpt/aoa_generator.py
+++ b/src/paddlefleet/models/gpt/aoa_generator.py
@@ -1,0 +1,278 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Whole-model modular AOA statement generation for boundary models.
+
+Pure functions backing the ``GPTModel`` boundary's modular AOA generation, plus
+the container entries a multi-tower model uses to drive several roots. The flow
+is:
+
+1. :func:`build_aoa_context` builds the read-only ``AOAContext`` once, using the
+   live model's ``_pp_to_single_mapping`` (same source as ``sharded_state_dict``,
+   so names come from the live module tree rather than a re-derived guess).
+2. :func:`collect_alias_plan` resolves tied / shared aliases and the pipeline
+   names to skip in one pass, **before** recursion (no post-hoc text dedup).
+   The skip set is pinned into ``ctx.excluded_names`` so every component
+   override honors it.
+3. :func:`gen_whole_model_aoa` / :func:`gen_whole_model_inv_aoa` hand each child
+   to the standard ``Layer.gen_aoa_statements`` / ``gen_inv_aoa_statements``
+   protocol -- that polymorphic call is the component dispatch point, so the
+   module walk is never re-implemented here. The two directions are generated
+   independently and never derived from one another.
+4. :func:`gen_multi_tower_aoa` / :func:`gen_multi_tower_inv_aoa` are the entry
+   points for a container that owns several roots (a vision tower beside a
+   language model). Every tower is dispatched on what its root is: a boundary
+   root goes through step 3, any other root through plain component recursion.
+   The container keeps globalization to itself so it runs once over the union
+   of all its towers.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    AOAContext,
+    validate_checkpoint_name_mapping,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# MTP checkpoint prefix protocol
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MTPCheckpointPrefixSpec:
+    """Checkpoint-side prefix protocol for MTP layers, resolved once per pass.
+
+    Producer-side state built at the whole-model entry from the model-declared
+    ``aoa_mtp_*`` attributes and threaded straight into
+    :func:`_resolve_mtp_scopes`. Deliberately *not* a field of the
+    component-facing :class:`AOAContext`: no component override reads it, so it
+    does not belong on the frozen recursion context forwarded to every
+    component.
+
+    Defaults cover the common case: MTP layers share the normal-layer
+    checkpoint numbering ``layers.$LAYER_ID`` and the inner transformer inherits
+    that same prefix. A boundary overrides via the three model attributes.
+    """
+
+    checkpoint_prefix: str = "layers.$LAYER_ID"
+    transformer_checkpoint_prefix: str = "layers.$LAYER_ID"
+    is_absolute: bool = False
+
+
+def resolve_mtp_checkpoint_prefix_spec(config) -> MTPCheckpointPrefixSpec:
+    """Normalizes the model-declared MTP checkpoint-prefix attributes.
+
+    Reads ``aoa_mtp_checkpoint_prefix`` /
+    ``aoa_mtp_transformer_checkpoint_prefix`` /
+    ``aoa_mtp_checkpoint_prefix_absolute`` off ``config`` with the defaulting an
+    unmigrated model relies on: the MTP-own prefix defaults to
+    ``layers.$LAYER_ID`` (same numbering as normal layers), the inner
+    transformer prefix inherits the MTP-own prefix, and no absolute-prefix
+    escape. Both prefixes route through :func:`_protocol_value`, so only an
+    absent / ``None`` attribute falls back; an explicitly declared value
+    (including an empty ``""`` for a top-level checkpoint) is taken verbatim.
+    """
+    checkpoint_prefix = _protocol_value(
+        config, "aoa_mtp_checkpoint_prefix", "layers.$LAYER_ID"
+    )
+    return MTPCheckpointPrefixSpec(
+        checkpoint_prefix=checkpoint_prefix,
+        transformer_checkpoint_prefix=_protocol_value(
+            config, "aoa_mtp_transformer_checkpoint_prefix", checkpoint_prefix
+        ),
+        is_absolute=bool(
+            getattr(config, "aoa_mtp_checkpoint_prefix_absolute", False)
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint protocol defaults and context construction
+# ---------------------------------------------------------------------------
+
+
+# Defaults for the model-declarable ``aoa_*`` checkpoint protocol. Each default
+# is named exactly once here and referenced by every consumer (the
+# :class:`FleetAOAContext` fields, :func:`build_aoa_context` and
+# :func:`_build_tower_ctx`), so no default literal is duplicated. The values
+# describe the ERNIE-series self-developed checkpoint; an external model
+# overrides only the attributes whose layout diverges.
+#
+# Only naming divergences belong in the mapping below: names the components
+# already emit identically (layernorms, ``model.norm``, the MTP layer's
+# ``enorm`` / ``hnorm`` / ``eh_proj``, and the CSA subtree) are deliberately
+# absent. The logical layer root also intentionally omits ``transformer_layer``
+# so the same entries cover ordinary layers and an MTP layer's inner
+# transformer.
+DEFAULT_CHECKPOINT_NAME_MAPPING = {
+    "embedding.embed_tokens.weight": "embed_tokens.weight",
+    "layers.$LAYER_ID.mlp.gate.weight": "layers.$LAYER_ID.block_sparse_moe.gate.weight",
+    "layers.$LAYER_ID.mlp.gate.weight_1": "layers.$LAYER_ID.block_sparse_moe.gate.weight_1",
+    "layers.$LAYER_ID.mlp.gate.routed_scaling_factor_param": "layers.$LAYER_ID.block_sparse_moe.gate.routed_scaling_factor_param",
+    "layers.$LAYER_ID.mlp.gate.e_score_correction_bias": "layers.$LAYER_ID.block_sparse_moe.e_score_correction_bias",
+    "layers.$LAYER_ID.mlp.fc1_latent_proj.weight": "layers.$LAYER_ID.block_sparse_moe.fc1_latent_proj.weight",
+    "layers.$LAYER_ID.mlp.fc2_latent_proj.weight": "layers.$LAYER_ID.block_sparse_moe.fc2_latent_proj.weight",
+    "layers.$LAYER_ID.mlp.experts.$EXPERT_ID.gate_proj.weight": "layers.$LAYER_ID.block_sparse_moe.experts.$EXPERT_ID.w1.weight",
+    "layers.$LAYER_ID.mlp.experts.$EXPERT_ID.up_proj.weight": "layers.$LAYER_ID.block_sparse_moe.experts.$EXPERT_ID.w3.weight",
+    "layers.$LAYER_ID.mlp.experts.$EXPERT_ID.down_proj.weight": "layers.$LAYER_ID.block_sparse_moe.experts.$EXPERT_ID.w2.weight",
+    "layers.$LAYER_ID.mlp.shared_experts.gate_proj.weight": "layers.$LAYER_ID.block_sparse_moe.shared_experts.w1.weight",
+    "layers.$LAYER_ID.mlp.shared_experts.up_proj.weight": "layers.$LAYER_ID.block_sparse_moe.shared_experts.w3.weight",
+    "layers.$LAYER_ID.mlp.shared_experts.down_proj.weight": "layers.$LAYER_ID.block_sparse_moe.shared_experts.w2.weight",
+    "layers.$LAYER_ID.norm.weight": "layers.$LAYER_ID.shared_head.norm.weight",
+}
+DEFAULT_CHECKPOINT_NAME_PREFIX = "model"
+DEFAULT_DTYPE_CAST_RULES = {}
+DEFAULT_GATE_CHECKPOINT_LAYOUT = "separate"
+DEFAULT_QKV_CHECKPOINT_PREFUSED = False
+DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT = "per_expert"
+DEFAULT_MLP_GATE_UP_FUSED = True
+DEFAULT_MAPPING_PROJ_CHECKPOINT_TRANSPOSED = False
+
+# Model-side single-name root, taken from the live model rather than declared on
+# the config; kept next to its checkpoint-side counterpart for readability.
+DEFAULT_MODEL_NAME_PREFIX = "model"
+
+
+@dataclass(frozen=True)
+class FleetAOAContext(AOAContext):
+    """Adds the checkpoint-layout declarations this library's components consume.
+
+    Paddle owns the recursion contract (names, dtype rules, exclusions); the
+    layouts below are paddlefleet's own protocol and grow with the models it
+    supports, so they live here rather than in the framework. Each is a
+    checkpoint-format fact that cannot be inferred from the live module, so the
+    model declares it; it only selects an emit branch and never overrides the
+    live structure.
+    """
+
+    gate_checkpoint_layout: str = DEFAULT_GATE_CHECKPOINT_LAYOUT
+    """Attention output gate placement for gated attention. ``"separate"``
+    (default) is the ERNIE-Lite layout with a standalone ``gate_proj`` tensor;
+    ``"interleaved"`` is a gate packed head-interleaved inside ``q_proj`` that
+    must be de-interleaved before fusing into ``qkv_proj``. Only consulted when
+    the live attention is gated."""
+
+    qkv_checkpoint_prefused: bool = DEFAULT_QKV_CHECKPOINT_PREFUSED
+    """``False`` (default) is the usual checkpoint with distinct ``q_proj`` /
+    ``k_proj`` / ``v_proj`` tensors; ``True`` is a single pre-fused ``qkv``
+    tensor that must be split before the ``fused_qkv`` re-fusion."""
+
+    moe_expert_checkpoint_layout: str = DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT
+    """``"per_expert"`` (default) for one projection tensor per expert,
+    ``"packed"`` for two 3D tensors packing every expert. Only consulted on the
+    grouped-GEMM branch, so one model may mix layouts across layers."""
+
+    mlp_gate_up_fused: bool = DEFAULT_MLP_GATE_UP_FUSED
+    """``True`` (default) is the gated MLP whose separate checkpoint
+    ``gate_proj`` / ``up_proj`` fuse into the model ``up_gate_proj``; ``False``
+    is a non-gated MLP handled by the generic Linear family."""
+
+    mapping_proj_checkpoint_transposed: bool = (
+        DEFAULT_MAPPING_PROJ_CHECKPOINT_TRANSPOSED
+    )
+    """Whether the checkpoint stores the mHC ``mapping_proj`` weight as
+    ``(out, in)`` (the torch layout, needing a ``^T``) instead of the live
+    ``(in, out)``. Orthogonal to the alpha layout; the accompanying leaf rename
+    is expressed by ``checkpoint_name_mapping``, which cannot carry a
+    transpose."""
+
+
+def _protocol_value(config, attr, default):
+    """Reads one model-declared ``aoa_*`` attribute with the single rule.
+
+    An attribute that is absent or explicitly ``None`` falls back to the
+    default; every other declared value is taken verbatim, including the falsy
+    ones a real model relies on (an empty ``""`` checkpoint prefix, a ``False``
+    ``mlp_gate_up_fused``). Keeping this the only reading path is what makes the
+    eight attributes behave uniformly.
+    """
+    value = getattr(config, attr, None)
+    return default if value is None else value
+
+
+def build_aoa_context(model, config) -> FleetAOAContext:
+    """Builds the read-only :class:`FleetAOAContext` for a whole-model pass.
+
+    Ensures ``_set_pipeline_name_mapping`` has run (idempotent; the same
+    side-effect ``state_dict`` / ``sharded_state_dict`` rely on), then resolves
+    every model-declared ``aoa_*`` attribute through :func:`_protocol_value`
+    against the module-level ``DEFAULT_*`` constants. The name mapping is the
+    one field with extra handling: it is copied so the context never aliases the
+    shared default, and validated as a name template.
+
+    Args:
+        model: The live ``GPTModel`` (or subclass) whose pipeline mapping backs
+            the single-name resolution and whose ``_model_name_prefix``
+            reports the authoritative model single-name root -- the same value
+            ``get_layer_desc_list`` uses to name its pipeline layers, so pipeline
+            naming and AOA name resolution never diverge.
+        config: The sub-structure config threaded into the context (whole-model
+            config for single-tower models, per-tower config for multi-tower).
+
+    Returns:
+        A frozen :class:`FleetAOAContext`.
+    """
+    if model._pipeline_name_mapping is None:
+        model._set_pipeline_name_mapping()
+    checkpoint_name_mapping = dict(
+        _protocol_value(
+            config,
+            "aoa_checkpoint_name_mapping",
+            DEFAULT_CHECKPOINT_NAME_MAPPING,
+        )
+    )
+    validate_checkpoint_name_mapping(checkpoint_name_mapping)
+    return FleetAOAContext(
+        config=config,
+        pp_to_single_mapping=model._pp_to_single_mapping or {},
+        model_name_prefix=model._model_name_prefix(),
+        checkpoint_name_mapping=checkpoint_name_mapping,
+        checkpoint_name_prefix=_protocol_value(
+            config,
+            "aoa_checkpoint_name_prefix",
+            DEFAULT_CHECKPOINT_NAME_PREFIX,
+        ),
+        dtype_cast_rules=_protocol_value(
+            config, "aoa_dtype_cast_rules", DEFAULT_DTYPE_CAST_RULES
+        ),
+        gate_checkpoint_layout=_protocol_value(
+            config,
+            "aoa_gate_checkpoint_layout",
+            DEFAULT_GATE_CHECKPOINT_LAYOUT,
+        ),
+        qkv_checkpoint_prefused=_protocol_value(
+            config,
+            "aoa_qkv_checkpoint_prefused",
+            DEFAULT_QKV_CHECKPOINT_PREFUSED,
+        ),
+        moe_expert_checkpoint_layout=_protocol_value(
+            config,
+            "aoa_moe_expert_checkpoint_layout",
+            DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT,
+        ),
+        mlp_gate_up_fused=_protocol_value(
+            config, "aoa_mlp_gate_up_fused", DEFAULT_MLP_GATE_UP_FUSED
+        ),
+        mapping_proj_checkpoint_transposed=_protocol_value(
+            config,
+            "aoa_mapping_proj_checkpoint_transposed",
+            DEFAULT_MAPPING_PROJ_CHECKPOINT_TRANSPOSED,
+        ),
+    )

--- a/src/paddlefleet/models/gpt/aoa_generator.py
+++ b/src/paddlefleet/models/gpt/aoa_generator.py
@@ -40,14 +40,107 @@ is:
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING
 
+import paddle.distributed
+from paddle.distributed.fleet.meta_parallel.parallel_layers.pp_layers import (
+    PipelineLayerChunk,
+)
 from paddle.distributed.flex_checkpoint.aoa.generation import (
     AOAContext,
+    AOANameScope,
+    format_dtype_cast_attr,
+    join_name,
+    resolve_dtype_cast_rule,
     validate_checkpoint_name_mapping,
 )
+from paddle.distributed.flex_checkpoint.aoa.macros import (
+    GLOBAL_ATTRIBUTE_KEYWORDS,
+)
+
+from paddlefleet.models.gpt.lm_head import (
+    GPTLMHead,
+    GPTMTPLMHead,
+)
+from paddlefleet.transformer.multi_token_prediction import (
+    MultiTokenPredictionLayer,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Whole-world gather availability
+# ---------------------------------------------------------------------------
+
+
+def _world_can_gather() -> bool:
+    """Whether a whole-world ``all_gather_object`` is actually available.
+
+    ``get_world_size()`` alone is not a usable guard: with no process group
+    initialized it falls back to ``PADDLE_TRAINERS_NUM``, so a
+    launched-but-not-initialized process reports the launcher's rank count while
+    the gather raises "The global group is not initialized." Both gather sites
+    (:func:`_shared_layer_members` and :func:`_globalize_statements`) degrade to
+    their rank-local answer when this returns ``False``.
+
+    A world size >1 with no live group is logged rather than silently accepted:
+    it is correct for a single-process run on a cluster node (the env vars are
+    still set), but under real multi-rank it means AOA generation ran before
+    distributed init, and staying rank-local then drops another stage's
+    contribution.
+    """
+    if paddle.distributed.get_world_size() <= 1:
+        return False
+    if paddle.distributed.is_initialized():
+        return True
+    logger.warning(
+        "AOA generation stayed rank-local: world_size=%d but no process group "
+        "is initialized. Expected for a single-process run; under real "
+        "multi-rank it means AOA ran before distributed init, and another PP "
+        "stage's keys would be missing.",
+        paddle.distributed.get_world_size(),
+    )
+    return False
+
+
+def _assert_world_gather_available(config) -> None:
+    """Fails loudly when a rank holds a model fragment but cannot gather.
+
+    :func:`_world_can_gather` degrades to the rank-local answer, which is the
+    correct degenerate result only when this rank's live module tree is the
+    whole model. Under pipeline parallelism it never is: each stage owns
+    different layers, so a rank-local config is missing another stage's keys,
+    while the full-parameter save path requires every rank to pass the same
+    config. Staying rank-local there is exactly the failure this globalization
+    exists to prevent, so a declared pipeline with no group to gather over is
+    an error rather than a degradation.
+
+    Expert parallelism fragments the config as well, but only under the
+    per-expert live layout -- a per-MoE-layer property rather than something
+    this entry-level check can read off the config -- so it is not covered
+    here.
+    """
+    if paddle.distributed.is_initialized():
+        return
+    if paddle.distributed.get_world_size() <= 1:
+        return
+    # Only a declared integer stage count establishes that the live module tree
+    # is a fragment.
+    stages = getattr(config, "pipeline_model_parallel_size", 1)
+    if not isinstance(stages, int) or stages <= 1:
+        return
+    raise RuntimeError(
+        f"AOA generation needs a whole-world gather: "
+        f"pipeline_model_parallel_size={stages} means this rank's live module "
+        f"tree is one stage of the model, but no process group is "
+        f"initialized, so the generated config would stay rank-local and miss "
+        f"the other stages' keys."
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -276,3 +369,982 @@ def build_aoa_context(model, config) -> FleetAOAContext:
             DEFAULT_MAPPING_PROJ_CHECKPOINT_TRANSPOSED,
         ),
     )
+
+
+# ---------------------------------------------------------------------------
+# Tied / shared alias planning
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AliasCandidate:
+    """One shared-layer alias candidate collected from the live model."""
+
+    layer_name: str | None
+    owned: list[tuple[str, str]]
+    distinct: list[str]
+    checkpoint_of: dict[str, str]
+    collapses: bool
+
+
+@dataclass(frozen=True)
+class AliasGroup:
+    """A set of model single-names backed by one logically shared tensor.
+
+    Produced by tied weights -- a pp==1 embedding / lm_head sharing one tensor
+    object, or a ``SharedLayerDesc`` group whose halves live on different PP
+    stages. ``canonical_single`` is the producer kept in normal recursion;
+    ``alias_singles`` are fanned out from ``canonical_checkpoint`` in the
+    checkpoint->model direction and deleted (``-> _``) in the model->checkpoint
+    direction.
+
+    ``canonical_checkpoint`` is the already-resolved checkpoint name, not a
+    structured name: for a group split across PP stages the canonical member is
+    owned by another rank, and re-resolving its structured name here would run it
+    through THIS rank's ``_pp_to_single_mapping`` and silently yield this rank's
+    own single. Resolution therefore happens on the owning rank and only the
+    finished name travels.
+
+    ``emit_canonical`` is used when the canonical member is excluded from normal
+    recursion because its checkpoint route differs from its model name. Ordinary
+    alias groups leave it false because recursion already emits the canonical
+    statement.
+    """
+
+    canonical_single: str
+    alias_singles: tuple[str, ...]
+    canonical_checkpoint: str
+    emit_canonical: bool = False
+
+
+_SHARED_LAYERS_ROOT = "shared_layers"
+
+# Single-names whose role marks them as the ALIAS side of a tie, never the
+# canonical producer. pp>1 registers the head under the shared prefixes
+# ``shared_head`` / ``shared_mtp_lm_head`` (``get_layer_desc_list``) rather than
+# ``lm_head``, and the magic-send re-embedding under ``mtp_embedding``, so all of
+# them belong here -- choosing the right canonical must not depend on ``embed``
+# happening to sort before ``shared`` / ``mtp``.
+_ALIAS_SEGMENTS = frozenset(
+    {
+        "lm_head",
+        "output_layer",
+        "shared_head",
+        "shared_mtp_lm_head",
+        "mtp_embedding",
+    }
+)
+
+
+def _grouped_shared_tensors(model):
+    """Groups structured pipeline names by shared tensor identity.
+
+    Uses the raw pipeline ``state_dict`` (with duplicate keys for shared
+    tensors), so keys match ``_pp_to_single_mapping`` and object identity
+    exposes VPP / shared duplicates and tied aliases. Only tensors registered
+    under more than one structured name are returned.
+
+    Returns:
+        A list of ``(structured_names, single_names)`` pairs, positionally
+        aligned, one per shared tensor.
+    """
+    if model._pipeline_name_mapping is None:
+        model._set_pipeline_name_mapping()
+    mapping = model._pp_to_single_mapping or {}
+    raw = model._raw_structured_state_dict()
+    id_to_structs: dict[int, list[str]] = {}
+    for structured, tensor in raw.items():
+        id_to_structs.setdefault(id(tensor), []).append(structured)
+    groups = []
+    for structs in id_to_structs.values():
+        if len(structs) <= 1:
+            continue
+        singles = [mapping.get(s, s) for s in structs]
+        groups.append((structs, singles))
+    return groups
+
+
+def _select_canonical(single_names: Iterable[str]) -> str:
+    """Picks the canonical producer among tied single-names.
+
+    Heuristic honoring the tie rule (the embedding is the canonical producer; the
+    head / re-embedding is the alias): prefer a name carrying no
+    ``_ALIAS_SEGMENTS`` segment, breaking ties lexicographically. Per-model
+    migration may refine this.
+    """
+    ordered = sorted(dict.fromkeys(single_names))
+    for name in ordered:
+        segments = set(name.lower().split("."))
+        if not segments & _ALIAS_SEGMENTS:
+            return name
+    return ordered[0]
+
+
+def _shared_layer_group_key(structs) -> str | None:
+    """Returns the ``SharedLayerDesc.layer_name`` a shared-tensor group belongs to.
+
+    ``None`` for a group with no ``shared_layers.*`` member -- a purely
+    intra-process share, i.e. the pp==1 tie (``skip_weight_param_allocation``
+    makes the head reuse the embedding tensor outright) or VPP re-registration.
+
+    A group may MIX a ``shared_layers.*`` registration with a plain path when the
+    same tensor object is reachable both ways: with ``tie_word_embeddings=True``,
+    ``pipeline_model_parallel_size == 1`` and ``spec.mtp_lm_head`` set, the
+    embedding stays on a plain ``LayerDesc`` (``get_layer_desc_list`` gates its
+    tie branch on pp>1) while the head becomes ``SharedLayerDesc("embed")``, and
+    ``skip_weight_param_allocation`` ties them by object. Such a group must be
+    planned as ONE unit under the shared layer_name -- otherwise the plain name
+    escapes exclusion and two producers write the same checkpoint key.
+    """
+    layer_names = {
+        s.split(".")[1]
+        for s in structs
+        if s.split(".")[0] == _SHARED_LAYERS_ROOT
+    }
+    if not layer_names:
+        return None
+    if len(layer_names) > 1:
+        raise ValueError(
+            f"one tensor is registered under several SharedLayerDesc names "
+            f"{sorted(layer_names)}; their checkpoint-layout policies may "
+            f"disagree, so the group cannot be planned as one unit"
+        )
+    return next(iter(layer_names))
+
+
+def _shared_layer_members(model, ctx):
+    """Resolves this rank's ``shared_layers.*`` members, then all-gathers them.
+
+    Object identity cannot group these. Under PP every stage that declares a
+    ``SharedLayerDesc`` builds its OWN instance (``pp_layers.py`` walks only
+    ``_layers_desc[start:end]``, then ``self.shared_layers[layer_name] =
+    layer.build_layer()``), kept in step by ``_synchronize_shared_weights`` and
+    ``allreduce_shared_weight_gradients``. The two halves of a tie are different
+    objects in different processes, so no ``id()`` relates them.
+    ``SharedLayerDesc.layer_name`` is the key Paddle itself shares on and is
+    globally identical, so it is the grouping key instead.
+
+    Names must be resolved by their OWNING rank, which is why the gather carries
+    resolved names rather than structured ones -- see :class:`AliasGroup`. An
+    alias member's checkpoint name is resolved too but unused; only the
+    canonical's is read.
+
+    Returns:
+        ``(owned, merged)``. ``owned`` maps layer_name -> this rank's
+        ``(structured_name, single_name)`` pairs, which is all that steering this
+        rank's own recursion needs. ``merged`` maps layer_name -> whole-world
+        ``(single_name, checkpoint_name)`` pairs.
+    """
+    # Identity groups first, so a plain path aliased onto a shared_layers
+    # registration is attributed to the same layer_name (the mixed group above).
+    planned_under: dict[str, str] = {}
+    for structs, _singles in _grouped_shared_tensors(model):
+        layer_name = _shared_layer_group_key(structs)
+        if layer_name is None:
+            continue
+        for structured in structs:
+            planned_under[structured] = layer_name
+    # Then the shared_layers registrations that are alone in their identity group
+    # -- the ordinary PP case, where the peer half lives in another process.
+    for structured in model._raw_structured_state_dict():
+        segments = structured.split(".")
+        if segments[0] == _SHARED_LAYERS_ROOT:
+            planned_under.setdefault(structured, segments[1])
+
+    owned: dict[str, list[tuple[str, str]]] = {}
+    resolved: dict[str, list[tuple[str, str]]] = {}
+    for structured, layer_name in planned_under.items():
+        checkpoint_name, single_name = model._resolve_leaf_names(
+            structured, ctx
+        )
+        owned.setdefault(layer_name, []).append((structured, single_name))
+        resolved.setdefault(layer_name, []).append(
+            (single_name, checkpoint_name)
+        )
+
+    # The gather needs a live process group, which `get_world_size()` does NOT
+    # imply -- see `_world_can_gather`. Rank-local members are the correct
+    # degenerate answer whenever there is no group to gather over.
+    if not _world_can_gather():
+        return owned, resolved
+    gathered: list[dict[str, list[tuple[str, str]]]] = []
+    paddle.distributed.all_gather_object(gathered, resolved)
+    merged: dict[str, list[tuple[str, str]]] = {}
+    for rank_members in gathered:
+        for layer_name, members in rank_members.items():
+            bucket = merged.setdefault(layer_name, [])
+            for member in members:
+                if member not in bucket:
+                    bucket.append(member)
+    return owned, merged
+
+
+def _iter_alias_candidates(model, ctx):
+    """Yields an :class:`AliasCandidate` per shared group.
+
+    Two sources, normalized to one shape:
+
+    - ``shared_layers.*`` groups, keyed on ``SharedLayerDesc.layer_name`` and
+      merged whole-world, so a PP-split tie is visible on every rank. Policy
+      comes from the model's declared checkpoint layout.
+    - Intra-process object-identity groups with no ``shared_layers.*`` member:
+      the pp==1 tie and pure VPP re-registration. Identity is the right
+      judgement here because the duplication is intra-process by construction,
+      and such a group always backs a single checkpoint tensor, hence
+      ``collapses=True``.
+    """
+    owned_by_layer, merged_by_layer = _shared_layer_members(model, ctx)
+    for layer_name, members in merged_by_layer.items():
+        owned = owned_by_layer.get(layer_name, [])
+        distinct = list(
+            dict.fromkeys(single for single, _checkpoint in members)
+        )
+        collapses = model._aoa_shared_layer_collapses(layer_name)
+        yield AliasCandidate(
+            layer_name=layer_name,
+            owned=owned,
+            distinct=distinct,
+            checkpoint_of=dict(members),
+            collapses=collapses,
+        )
+    for structs, singles in _grouped_shared_tensors(model):
+        if _shared_layer_group_key(structs) is not None:
+            continue
+        yield AliasCandidate(
+            layer_name=None,
+            owned=list(zip(structs, singles)),
+            distinct=list(dict.fromkeys(singles)),
+            checkpoint_of={
+                single: model._resolve_leaf_names(structured, ctx)[0]
+                for structured, single in zip(structs, singles)
+            },
+            collapses=True,
+        )
+
+
+def collect_alias_plan(model, ctx) -> tuple[frozenset[str], list[AliasGroup]]:
+    """Resolves, in one pass, what recursion must skip and what to re-emit.
+
+    Both halves derive from the same grouping and the same canonical selection,
+    so they are produced together:
+
+    - ``excluded``: the structured pipeline names recursion must skip. Stays
+      RANK-LOCAL -- it only steers this rank's recursion, and each rank knows its
+      own structured names. Two sources: pure VPP / shared dedup (a tensor under
+      several structured names all mapping to the *same* single-name: keep the
+      first, skip the rest), and tied aliases (keep one structured name for the
+      canonical single, skip every alias member and any duplicate canonical
+      registration).
+    - ``alias_groups``: the tied groups whose members are re-emitted by
+      :func:`emit_alias_aoa` / :func:`emit_alias_inv_aoa`. GLOBAL -- every rank
+      emits a group's alias statements even when it owns no member, and
+      :func:`_globalize_statements` dedups the identical strings. That is not
+      merely harmless but required, since the load path validates against the
+      whole-world union of model keys. Groups with one distinct single-name carry
+      no fan-out and are handled purely by exclusion, so they produce no group.
+
+    Returns:
+        ``(excluded, alias_groups)``.
+    """
+    excluded: set[str] = set()
+    alias_groups: list[AliasGroup] = []
+    for candidate in _iter_alias_candidates(model, ctx):
+        owned = candidate.owned
+        distinct = candidate.distinct
+        checkpoint_of = candidate.checkpoint_of
+        if not candidate.collapses:
+            # A non-collapsing group needs one producer per single name. For
+            # MTP reuse, prefer the registration that carries transformer scope
+            # when duplicate registrations resolve to the same single name.
+            by_single: dict[str, list[str]] = {}
+            for structured, single in owned:
+                by_single.setdefault(single, []).append(structured)
+            for structured_names in by_single.values():
+                if candidate.layer_name == "mtp_reuse_transformer":
+                    structured_names.sort(
+                        key=lambda name: (
+                            ".transformer_layer." not in name,
+                            name.startswith("shared_layers."),
+                            name,
+                        )
+                    )
+                excluded.update(structured_names[1:])
+            continue
+
+        if candidate.layer_name == "embed" and getattr(
+            ctx.config, "separate_mtp_headloss", False
+        ):
+            # The runtime embed group contains the embedding and two head
+            # registrations, but the HF layout has one checkpoint route per
+            # head attribute. Keep embedding recursion intact and materialize
+            # the MTP head routes explicitly below.
+            head_routes = (
+                ("weight", "lm_head.weight"),
+                ("multimax_ranges", "model.lm_head.multimax_ranges"),
+                ("multimax_ts", "model.lm_head.multimax_ts"),
+            )
+            for suffix, checkpoint_name in head_routes:
+                canonical = join_name(
+                    ctx.model_name_prefix, f"shared_mtp_lm_head.{suffix}"
+                )
+                alias = join_name(
+                    ctx.model_name_prefix, f"shared_head.{suffix}"
+                )
+                route_owned = [
+                    (structured, single)
+                    for structured, single in owned
+                    if single in (canonical, alias)
+                ]
+                if not route_owned:
+                    continue
+                excluded.update(
+                    structured for structured, _single in route_owned
+                )
+                if canonical not in distinct:
+                    continue
+                alias_groups.append(
+                    AliasGroup(
+                        canonical,
+                        (alias,) if alias in distinct else (),
+                        checkpoint_name,
+                        emit_canonical=True,
+                    )
+                )
+            continue
+
+        if len(distinct) <= 1:
+            excluded.update(structured for structured, _single in owned[1:])
+            continue
+        canonical = _select_canonical(distinct)
+        canonical_kept = False
+        for structured, single in owned:
+            if single == canonical and not canonical_kept:
+                canonical_kept = True
+            else:
+                excluded.add(structured)
+        alias_groups.append(
+            AliasGroup(
+                canonical,
+                tuple(single for single in distinct if single != canonical),
+                checkpoint_of[canonical],
+            )
+        )
+    return frozenset(excluded), alias_groups
+
+
+def emit_alias_aoa(ctx, alias_groups) -> list[str]:
+    """Checkpoint->model alias fan-out.
+
+    The canonical single is already produced by the normal recursion; here the
+    canonical checkpoint name additionally fans out to every alias model key.
+    Each alias single resolves its own dtype-cast rule (keyed on the single
+    name), so a fanned-out tensor lands in the alias's declared dtype even when
+    it differs from the canonical single.
+
+    ``canonical_checkpoint`` is taken as-is instead of being resolved here: for a
+    group split across PP stages the canonical member is owned by another rank, so
+    resolution must happen there -- see :class:`AliasGroup`.
+    """
+    statements = []
+    for group in alias_groups:
+        targets = group.alias_singles
+        if group.emit_canonical:
+            targets = (group.canonical_single, *targets)
+        for target in targets:
+            cast = format_dtype_cast_attr(
+                resolve_dtype_cast_rule(
+                    target, ctx.dtype_cast_rules, ctx.model_name_prefix
+                )
+            )
+            statements.append(f"{group.canonical_checkpoint} -> {target}{cast}")
+    return statements
+
+
+def emit_alias_inv_aoa(alias_groups) -> list[str]:
+    """Inverse (model -> checkpoint) alias handling.
+
+    The canonical single -> checkpoint statement comes from the normal
+    recursion; each alias model key is deleted (``-> _``) so only the canonical
+    producer writes the checkpoint tensor.
+    """
+    statements = []
+    for group in alias_groups:
+        if group.emit_canonical:
+            statements.append(
+                f"{group.canonical_single} -> {group.canonical_checkpoint}"
+            )
+        for alias_single in group.alias_singles:
+            statements.append(f"{alias_single} -> _")
+    return statements
+
+
+# ---------------------------------------------------------------------------
+# Single-tower guard and model-side name resolution
+# ---------------------------------------------------------------------------
+
+
+def _assert_single_tower(model):
+    """Fails loudly if a boundary declaring ``aoa_towers`` reaches this path.
+
+    Multi-tower containers (e.g. Qwen3-VL) are not ``GPTModel`` subclasses; they
+    own their own entry and loop over their towers. A ``GPTModel`` that declares
+    ``aoa_towers`` is therefore a misconfiguration, not a supported case.
+    """
+    if getattr(model, "aoa_towers", None):
+        raise NotImplementedError(
+            f"{type(model).__name__} declares aoa_towers but the whole-model "
+            f"generator only handles single-tower boundaries; a multi-tower "
+            f"container must own its AOA entry"
+        )
+
+
+def resolve_actual_model_prefix(structured_prefix, pp_to_single_mapping) -> str:
+    """Resolves a live structured subtree prefix to its single-name prefix.
+
+    Live-tree source of truth: rather than assume the pipeline key, this finds
+    any real leaf registered under ``structured_prefix`` in the authoritative
+    ``pp_to_single_mapping`` and strips the shared suffix off its single name.
+    ``_set_pipeline_name_mapping`` only remaps the root/index segment and
+    preserves the suffix exactly, so the recovered root is identical regardless
+    of which leaf under the prefix is picked.
+
+    Args:
+        structured_prefix: Live module path ending in ``.`` (e.g. ``"16."`` or
+            the VPP two-segment ``"0.1."``).
+        pp_to_single_mapping: Structured name -> single name mapping.
+
+    Returns:
+        The single-name subtree root (e.g. ``"model.layers.16"``).
+
+    Raises:
+        KeyError: If no mapping entry sits under ``structured_prefix``.
+        ValueError: If the single name does not end with the shared suffix.
+    """
+    for structured_name, single_name in pp_to_single_mapping.items():
+        if structured_name.startswith(structured_prefix):
+            suffix = structured_name[len(structured_prefix) :]
+            if not suffix:
+                return single_name
+            if single_name == suffix:
+                return ""
+            if single_name.endswith("." + suffix):
+                return single_name[: -len(suffix) - 1]
+            raise ValueError(
+                f"single name {single_name!r} does not end with suffix "
+                f"{suffix!r} for structured prefix {structured_prefix!r}"
+            )
+    raise KeyError(
+        f"no pp_to_single_mapping entry under structured prefix "
+        f"{structured_prefix!r}"
+    )
+
+
+def _parse_layers_index(root: str) -> int:
+    """Extracts the integer following a ``layers`` segment in a single root.
+
+    Args:
+        root: Single-name subtree root (e.g. ``"model.layers.16"`` or
+            ``"model.layers.16.transformer_layer"``).
+
+    Returns:
+        The int after the ``layers`` segment (the model layer id).
+
+    Raises:
+        ValueError: If no ``layers.<int>`` segment is present.
+    """
+    parts = root.split(".")
+    for i, part in enumerate(parts):
+        if part == "layers" and i + 1 < len(parts) and parts[i + 1].isdigit():
+            return int(parts[i + 1])
+    raise ValueError(f"no 'layers.<int>' segment in root {root!r}")
+
+
+def build_layer_name_scope(
+    ctx,
+    *,
+    layer_id: int,
+    checkpoint_prefix_template: str,
+    structured_prefix: str,
+    absolute: bool = False,
+) -> AOANameScope:
+    """Builds the per-layer :class:`AOANameScope`.
+
+    Prefix injection, not template arithmetic: the ``layer_id`` (and the
+    derived MTP-internal ``mtp_id``) are rendered into the checkpoint prefix
+    template up front via ``str.replace``. ``$LAYER_ID`` is the transformer
+    layer number; ``$MTP_LAYER_ID`` is the MTP-internal id from 0. Any residual
+    ``$`` means the template referenced a placeholder we do not inject, which
+    is a config error.
+
+    Args:
+        ctx: The read-only recursion context.
+        layer_id: Transformer layer number, as it appears in the model's own
+            ``layers.<i>`` naming.
+        checkpoint_prefix_template: Prefix template, possibly with ``$LAYER_ID``
+            / ``$MTP_LAYER_ID``.
+        structured_prefix: Live module path for this subtree, ending in ``.``.
+        absolute: When True, the resolved prefix is a full checkpoint prefix and
+            the shared checkpoint prefix is not prepended.
+
+    Returns:
+        The frozen scope for this subtree.
+    """
+    mtp_id = layer_id - ctx.config.num_hidden_layers
+    checkpoint_prefix = checkpoint_prefix_template.replace(
+        "$LAYER_ID", str(layer_id)
+    ).replace("$MTP_LAYER_ID", str(mtp_id))
+    if "$" in checkpoint_prefix:
+        raise ValueError(
+            f"unresolved placeholder in checkpoint prefix "
+            f"{checkpoint_prefix!r} (template={checkpoint_prefix_template!r}, "
+            f"layer_id={layer_id}, mtp_id={mtp_id})"
+        )
+    return AOANameScope(
+        checkpoint_prefix=checkpoint_prefix,
+        logical_model_prefix=join_name(
+            ctx.model_name_prefix, f"layers.{layer_id}"
+        ),
+        actual_model_prefix=resolve_actual_model_prefix(
+            structured_prefix, ctx.pp_to_single_mapping
+        ),
+        is_checkpoint_prefix_absolute=absolute,
+    )
+
+
+def _resolve_lm_head_scope(ctx, structured_prefix: str) -> AOANameScope:
+    """Builds the scope that emits the output head unprefixed at the ckpt root.
+
+    The HF ``ForCausalLM`` layout keeps the output ``lm_head`` a top-level
+    sibling of the backbone, so its checkpoint name carries no shared prefix
+    (bare ``lm_head.weight``). The shared checkpoint prefix is always prepended
+    by ``join_name`` and cannot be stripped by the mapping, so an
+    absolute-prefix scope is the only way to emit it. The checkpoint root
+    mirrors the head's model-relative root; no mapping leaf touches the head, so
+    the logical and actual model roots coincide and mapping resolution is
+    identity. Non-tied head only -- a tied head is an embedding alias handled by
+    the alias plan and is never dispatched here.
+    """
+    actual_prefix = resolve_actual_model_prefix(
+        structured_prefix, ctx.pp_to_single_mapping
+    )
+    prefix = ctx.model_name_prefix
+    if actual_prefix == prefix:
+        checkpoint_prefix = ""
+    elif prefix and actual_prefix.startswith(prefix + "."):
+        checkpoint_prefix = actual_prefix[len(prefix) + 1 :]
+    else:
+        checkpoint_prefix = actual_prefix
+    return AOANameScope(
+        checkpoint_prefix=checkpoint_prefix,
+        logical_model_prefix=actual_prefix,
+        actual_model_prefix=actual_prefix,
+        is_checkpoint_prefix_absolute=True,
+    )
+
+
+def _iter_pipeline_units(model) -> Iterator[tuple[str, object]]:
+    """Yields ``(structured_prefix, unit)`` for every live top-level layer.
+
+    Live enumeration (not ``range()``): walks ``model._sub_layers`` in
+    registration order and descends one level into VPP
+    :class:`PipelineLayerChunk` containers so a chunk's inner layers surface
+    with their real two-segment structured prefix (``f"{chunk}.{local}."``).
+    Non-chunk top-level entries (embedding, transformer layers, MTP, lm_head,
+    norm, shared_layers) surface directly.
+
+    This mirrors the ``fp8_quant_weight`` live-layer idiom's coverage and, like
+    it, does not special-case cudagraph / PipelineSublayers wrapping.
+    """
+    for name, unit in model._sub_layers.items():
+        if unit is None:
+            continue
+        if isinstance(unit, PipelineLayerChunk):
+            for local_name, sub in unit._sub_layers.items():
+                if sub is not None:
+                    yield f"{name}.{local_name}.", sub
+        else:
+            yield f"{name}.", unit
+
+
+def _resolve_mtp_scopes(
+    ctx, structured_prefix: str, unit, mtp_spec
+) -> tuple[AOANameScope, AOANameScope, str]:
+    """Resolves the MTP-own and inner-transformer scopes for one MTP layer.
+
+    Returns ``(mtp_scope, transformer_scope, transformer_structured_prefix)``.
+    The ``layer_id`` comes from the authoritative single root; the live
+    ``layer_number`` (the MTP-internal id) is cross-checked against the derived
+    ``mtp_id``. ``mtp_spec`` is the per-pass
+    :class:`MTPCheckpointPrefixSpec` carrying the model-declared checkpoint
+    prefixes; it is passed in directly rather than read off ``ctx`` because no
+    component override consumes it.
+
+    NOTE (unverified assumption): a boundary declaring
+    ``aoa_mtp_checkpoint_prefix_absolute`` (currently only assumed for Qwen3.5's
+    ``mtp`` prefix) routes BOTH the MTP-own and the inner-transformer checkpoint
+    names at the checkpoint model root, skipping the shared prefix. Qwen3.5's
+    ``mtp.*`` naming has not been verified against a real checkpoint; revisit
+    when confirmed.
+    """
+    actual_prefix = resolve_actual_model_prefix(
+        structured_prefix, ctx.pp_to_single_mapping
+    )
+    layer_id = _parse_layers_index(actual_prefix)
+    mtp_id = layer_id - ctx.config.num_hidden_layers
+    assert unit.layer_number == mtp_id, (
+        f"MultiTokenPredictionLayer.layer_number={unit.layer_number} "
+        f"disagrees with mtp_id={mtp_id} (layer_id={layer_id}, "
+        f"structured_prefix={structured_prefix!r})"
+    )
+    absolute = mtp_spec.is_absolute
+    mtp_scope = build_layer_name_scope(
+        ctx,
+        layer_id=layer_id,
+        checkpoint_prefix_template=mtp_spec.checkpoint_prefix,
+        structured_prefix=structured_prefix,
+        absolute=absolute,
+    )
+    transformer_structured_prefix = f"{structured_prefix}transformer_layer."
+    transformer_scope = build_layer_name_scope(
+        ctx,
+        layer_id=layer_id,
+        checkpoint_prefix_template=mtp_spec.transformer_checkpoint_prefix,
+        structured_prefix=transformer_structured_prefix,
+        absolute=absolute,
+    )
+    return mtp_scope, transformer_scope, transformer_structured_prefix
+
+
+# ---------------------------------------------------------------------------
+# AOA statement text: parsing and invariants
+# ---------------------------------------------------------------------------
+
+
+def _split_top_level(text: str) -> list[str]:
+    """Splits on top-level commas, respecting ``()``/``[]``/``{}`` nesting."""
+    parts: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for ch in text:
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        if ch == "," and depth == 0:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    parts.append("".join(current))
+    return parts
+
+
+def _statement_targets(statement: str) -> list[str]:
+    """Extracts the target names on the RHS of one AOA statement.
+
+    The RHS is everything after ``->``; targets are the comma-separated tokens
+    that are not attributes. Attributes are either ``key=value`` forms
+    (``axis=``, ``permute=``, ``dtype=``, ...) or bareword fusion macros
+    (``fused_ffn``, ``fused_qkv``, ...); both are identified by their keyword
+    living in ``GLOBAL_ATTRIBUTE_KEYWORDS`` -- the lexer's single source of
+    truth for what is an attribute rather than a tensor name. Bracketed
+    attribute values (e.g. ``permute=[1,0]``) are kept intact by top-level
+    splitting.
+    """
+    _, sep, rhs = statement.partition("->")
+    if not sep:
+        return []
+    attr_keywords = set(GLOBAL_ATTRIBUTE_KEYWORDS)
+    targets = []
+    for seg in _split_top_level(rhs):
+        seg = seg.strip()
+        if not seg:
+            continue
+        keyword = seg.split("=", 1)[0].strip()
+        if keyword in attr_keywords:
+            continue
+        targets.append(seg)
+    return targets
+
+
+def _statement_sources(statement: str) -> list[str]:
+    """Extracts the source names on the left side of one AOA statement.
+
+    Mirrors :func:`_statement_targets` for the left side: the source side is
+    everything before ``->``; sources are the comma-separated tokens with any
+    trailing ``^T`` transpose marker stripped, excluding attribute keywords.
+    Used by :func:`_assert_unique_inverse_targets` to recognize a statement that
+    rewrites a name it also reads, so an in-place rewrite is not mistaken for a
+    second producer.
+    """
+    source_side, sep, _ = statement.partition("->")
+    if not sep:
+        return []
+    attr_keywords = set(GLOBAL_ATTRIBUTE_KEYWORDS)
+    sources = []
+    for seg in _split_top_level(source_side):
+        seg = seg.strip()
+        if seg.endswith("^T"):
+            seg = seg[:-2].strip()
+        if not seg:
+            continue
+        keyword = seg.split("=", 1)[0].strip()
+        if keyword in attr_keywords:
+            continue
+        sources.append(seg)
+    return sources
+
+
+def _assert_unique_inverse_targets(statements, origins=None) -> None:
+    """Fails loudly on a duplicate inverse (model -> checkpoint) target.
+
+    A many-to-one model -> checkpoint mapping (e.g. Qwen3.5's per-MTP-layer
+    ``enorm`` copies all naming the single ``mtp.enorm.weight``) is not
+    expressible: AOAEngine's inverse export has no target validation and would
+    silently overwrite. This is an assert-only guard, never a text dedup: the
+    ``-> _`` deletions the alias handler emits are skipped.
+
+    A statement that reads back the name it writes is a rewrite in place, not a
+    second producer, and takes over that name's ownership. The fused gate/up
+    inverse split writes the model-side halves under their gate/up names
+    (``up_gate_proj -> gate_proj, up_proj, fused_ffn``) and a following
+    statement transposes each in place onto the checkpoint name
+    (``gate_proj^T -> gate_proj``); in the Ernie layout the half-name and the
+    checkpoint name render to the same string, so without this the second
+    statement would look like a duplicate. A genuine many-to-one collision
+    writes a name it does not itself read, so it stays caught even when some
+    unrelated statement elsewhere happens to read that same name.
+
+    ``origins``, when given, is a list parallel to ``statements`` naming the
+    tower that emitted each one, so a cross-tower collision can say which towers
+    disagree.
+    """
+    claimed_by: dict[str, int] = {}
+    for index, statement in enumerate(statements):
+        sources = frozenset(_statement_sources(statement))
+        for target in _statement_targets(statement):
+            if target == "_":
+                continue
+            previous = claimed_by.get(target)
+            if previous is not None and target not in sources:
+                origin_note = _duplicate_origin_note(origins, previous, index)
+                raise ValueError(
+                    f"inverse AOA emits duplicate checkpoint target "
+                    f"{target!r}{origin_note}"
+                    f"; a model->checkpoint many-to-one mapping "
+                    f"cannot be expressed and would silently overwrite "
+                    f"(statement: {statement!r})"
+                )
+            claimed_by[target] = index
+
+
+def _duplicate_origin_note(origins, first: int, second: int) -> str:
+    """Names the tower(s) behind a duplicate target, when origins are known.
+
+    Empty for a single-tower caller, which passes no origins: the flat statement
+    list is its own context there, so there is nothing to attribute.
+    """
+    if origins is None:
+        return ""
+    if origins[first] == origins[second]:
+        return f" (both emitted by tower {origins[first]!r})"
+    return f" (emitted by towers {origins[first]!r} and {origins[second]!r})"
+
+
+# ---------------------------------------------------------------------------
+# Whole-model entries and statement globalization
+# ---------------------------------------------------------------------------
+
+
+def gen_whole_model_aoa(model, ctx, *, globalize=True) -> dict[str, list[str]]:
+    """Whole-model checkpoint->model generation.
+
+    Resolves the alias plan, pins the excluded names into ``ctx`` so the whole
+    recursion honors them, then hands each child to the standard
+    ``Layer.gen_aoa_statements`` protocol -- that polymorphic call is what lets
+    component overrides (Linear, SelfAttention, MoE, ...) emit their own rules,
+    so this function must never re-implement the walk itself.
+
+    ``globalize=False`` returns the rank-local set, for a caller that unions
+    several of these and globalizes the result itself
+    (:func:`gen_multi_tower_aoa`). A rank-local set is not a usable config on
+    its own -- see :func:`_globalize_tagged_statements`.
+
+    Returns a ``{"aoa_statements": list[str]}`` dict; the list is mutable to
+    match the consumer contract.
+    """
+    _assert_world_gather_available(ctx.config)
+    _assert_single_tower(model)
+    excluded, alias_groups = collect_alias_plan(model, ctx)
+    ctx = replace(ctx, excluded_names=excluded)
+    mtp_spec = resolve_mtp_checkpoint_prefix_spec(ctx.config)
+    statements = []
+    # The boundary emits no own parameters, so recursion starts one level down.
+    # Single-enumeration classify-and-dispatch: each live unit is
+    # isinstance-classified once and dispatched exactly once. Two unit kinds
+    # need a scope: MTP, whose checkpoint prefix is model-declared and whose
+    # inner transformer sits one level deeper than the checkpoint layout; and
+    # the output head, whose checkpoint name sits unprefixed at the model root
+    # (HF ``ForCausalLM`` keeps ``lm_head`` a top-level sibling). The output
+    # head is matched on the base ``GPTLMHead`` so the non-separate variant
+    # (``separate_mtp_headloss=False``, a plain ``GPTLMHead`` instance) is
+    # covered as well as the ``GPTMainLMHead`` subclass; the MTP head
+    # ``GPTMTPLMHead`` is a ``GPTLMHead`` subclass too but is explicitly
+    # excluded so it keeps flowing through the plain scope-less else path.
+    # Every other unit (including normal transformer layers) resolves correctly
+    # on the plain scope-less path.
+    for structured_prefix, unit in _iter_pipeline_units(model):
+        if isinstance(unit, MultiTokenPredictionLayer):
+            mtp_scope, transformer_scope, transformer_prefix = (
+                _resolve_mtp_scopes(ctx, structured_prefix, unit, mtp_spec)
+            )
+            # Checkpoint->model order: MTP-own params first, then the inner
+            # transformer. GPTModel drives the inner transformer here because
+            # the MTP layer's own recursion deliberately does not.
+            statements += unit.gen_aoa_statements(
+                ctx,
+                structured_name_prefix=structured_prefix,
+                aoa_name_scope=mtp_scope,
+            )
+            statements += unit.transformer_layer.gen_aoa_statements(
+                ctx,
+                structured_name_prefix=transformer_prefix,
+                aoa_name_scope=transformer_scope,
+            )
+        elif isinstance(unit, GPTLMHead) and not isinstance(unit, GPTMTPLMHead):
+            statements += unit.gen_aoa_statements(
+                ctx,
+                structured_name_prefix=structured_prefix,
+                aoa_name_scope=_resolve_lm_head_scope(ctx, structured_prefix),
+            )
+        else:
+            statements += unit.gen_aoa_statements(
+                ctx, structured_name_prefix=structured_prefix
+            )
+    statements += emit_alias_aoa(ctx, alias_groups)
+    if globalize:
+        statements = _globalize_statements(statements)
+    return {"aoa_statements": statements}
+
+
+def _globalize_statements(local_statements: list[str]) -> list[str]:
+    """Untagged form of :func:`_globalize_tagged_statements`.
+
+    Used by every single-tower caller, which has no tower to attribute a
+    statement to.
+    """
+    tagged = _globalize_tagged_statements(
+        [(None, statement) for statement in local_statements]
+    )
+    return [statement for _origin, statement in tagged]
+
+
+def _globalize_tagged_statements(local_tagged):
+    """All-gathers per-PP/EP-rank-local AOA statements and dedups them.
+
+    Applies to both passes: modular generation walks the LOCAL live module tree
+    (:func:`_iter_pipeline_units`), so either statement set varies across PP
+    (each stage owns different layers, so it always varies) and across EP under
+    the per-expert live layout -- the MoE layer stores non-local experts as
+    ``None`` (``moe_layer.py`` build) and generation skips them, so each EP rank
+    emits only its local experts.
+
+    Both consumers require a globally complete set, for mirrored reasons:
+
+    - Inverse (model -> checkpoint): DCP ``save_full_param`` (``num_splits=1``)
+      requires every rank's config to be globally identical so that each rank's
+      ``destination_sharded_weight_desc`` contains all targets that appear in
+      the globally all-gathered read plan.
+    - Forward (checkpoint -> model): ``dist.load_state_dict`` builds its
+      ``destination_state_shard_info`` with ``build_global_state_shard_info``,
+      a whole-world ``all_gather_object``, so AOAEngine validates against the
+      union of every rank's model keys. Its ``shape_propagation`` destination
+      sweep demands a source for each one, and only same-name pass-through is
+      implicit; a rank-local set therefore fails on the first key that needs
+      renaming and is owned by another PP stage.
+
+    TP / DP / sharding / grouped-EP replicas emit byte-identical statements, so
+    an exact-string, order-preserving dedup collapses the whole-world gather
+    back to the complete config without loss. Chained statements (an
+    intermediate name emitted then consumed) stay contiguous because a chain
+    never straddles ranks, and rank-ordered gathering plus order-preserving
+    dedup leaves every rank with the same list in the same order -- AOA
+    statements are order-sensitive, so that determinism matters. The gather
+    spans the whole world (a superset of the assembler's h*v mesh) so the result
+    is layout-agnostic and does not depend on which expert layout each MoE layer
+    happens to use.
+
+    Each element is an ``(origin, statement)`` pair. Dedup keys on the statement
+    alone, so the first origin claiming a statement wins: replicas across ranks
+    carry the same origin anyway, and collapsing an identical statement is the
+    whole point of the dedup.
+    """
+    if not _world_can_gather():
+        return local_tagged
+    gathered: list[list[tuple[str | None, str]]] = []
+    paddle.distributed.all_gather_object(gathered, local_tagged)
+    seen: set[str] = set()
+    merged: list[tuple[str | None, str]] = []
+    for rank_tagged in gathered:
+        for origin, statement in rank_tagged:
+            if statement not in seen:
+                seen.add(statement)
+                merged.append((origin, statement))
+    return merged
+
+
+def gen_whole_model_inv_aoa(
+    model, ctx, *, globalize=True
+) -> dict[str, list[str]]:
+    """Whole-model inverse (model -> checkpoint) generation.
+
+    Independently recurses and emits through ``Layer.gen_inv_aoa_statements``;
+    never derived from the checkpoint->model pass. Returns a
+    ``{"aoa_statements": list[str]}`` dict.
+
+    ``globalize=False`` returns the rank-local set for a caller that unions
+    several of these (:func:`gen_multi_tower_inv_aoa`). The duplicate-target
+    guard still runs on the rank-local set so a within-tower collision fails at
+    its source; the union is re-checked by that caller.
+    """
+    _assert_world_gather_available(ctx.config)
+    _assert_single_tower(model)
+    excluded, alias_groups = collect_alias_plan(model, ctx)
+    ctx = replace(ctx, excluded_names=excluded)
+    mtp_spec = resolve_mtp_checkpoint_prefix_spec(ctx.config)
+    statements = []
+    # Independently recurses and emits, never derived from the checkpoint->model
+    # pass. Units are walked in reverse to mirror the checkpoint->model
+    # ordering; for statements this is cosmetic but faithful to the design.
+    for structured_prefix, unit in reversed(list(_iter_pipeline_units(model))):
+        if isinstance(unit, MultiTokenPredictionLayer):
+            mtp_scope, transformer_scope, transformer_prefix = (
+                _resolve_mtp_scopes(ctx, structured_prefix, unit, mtp_spec)
+            )
+            # Inverse order: inner transformer first, then MTP-own -- the
+            # mirror of the checkpoint->model order.
+            statements += unit.transformer_layer.gen_inv_aoa_statements(
+                ctx,
+                structured_name_prefix=transformer_prefix,
+                aoa_name_scope=transformer_scope,
+            )
+            statements += unit.gen_inv_aoa_statements(
+                ctx,
+                structured_name_prefix=structured_prefix,
+                aoa_name_scope=mtp_scope,
+            )
+        elif isinstance(unit, GPTLMHead) and not isinstance(unit, GPTMTPLMHead):
+            statements += unit.gen_inv_aoa_statements(
+                ctx,
+                structured_name_prefix=structured_prefix,
+                aoa_name_scope=_resolve_lm_head_scope(ctx, structured_prefix),
+            )
+        else:
+            statements += unit.gen_inv_aoa_statements(
+                ctx, structured_name_prefix=structured_prefix
+            )
+    statements += emit_alias_inv_aoa(alias_groups)
+    if globalize:
+        statements = _globalize_statements(statements)
+    _assert_unique_inverse_targets(statements)
+    return {"aoa_statements": statements}

--- a/src/paddlefleet/models/gpt/gpt_model.py
+++ b/src/paddlefleet/models/gpt/gpt_model.py
@@ -299,13 +299,23 @@ class GPTModel(PipelineLayer):
                 gpu_param = param.cuda()
                 gpu_param._share_buffer_to(param)
 
-    def get_layer_desc_list(self, spec, tie_word_embeddings):
-        layers = []
+    def _model_name_prefix(self) -> str:
+        """The model single-name root prefix (no trailing dot).
+
+        Authoritative for how this model roots its single-name space: used by
+        :meth:`get_layer_desc_list` to name pipeline layers and fed into
+        ``build_aoa_context``, so pipeline naming and AOA name resolution never
+        diverge (e.g. ``model.language_model`` for the qwen3_vl / qwen3_5
+        language tower instead of the ``model`` default).
+        """
         model_type = getattr(self.config, "model_type", "")
         if "qwen3_vl" in model_type or "qwen3_5" in model_type:
-            name_prefix = "model.language_model"
-        else:
-            name_prefix = "model"
+            return "model.language_model"
+        return "model"
+
+    def get_layer_desc_list(self, spec, tie_word_embeddings):
+        layers = []
+        name_prefix = self._model_name_prefix()
         if tie_word_embeddings:
             self.add_sequential_layer(
                 layers,
@@ -331,11 +341,32 @@ class GPTModel(PipelineLayer):
                 layers, LayerDesc(spec.embedding), name_prefix
             )
         i = 0
+        empty_index = 0
+        aoa_modular = getattr(
+            getattr(self, "config", None), "aoa_modular", False
+        )
+
+        def next_empty_layer_name():
+            """Name for the next EmptyLayer, advancing the right counter.
+
+            With ``aoa_modular`` empty layers live in their own
+            ``empty_layers.<i>`` namespace and do not consume a ``layers.<i>``
+            slot, so transformer layers start at ``layers.0``. Otherwise both
+            kinds share the ``i`` counter (the legacy ``+H`` offset).
+            """
+            nonlocal i, empty_index
+            if aoa_modular:
+                name = f"{name_prefix}.empty_layers.{empty_index}"
+                empty_index += 1
+            else:
+                name = f"{name_prefix}.layers.{i}"
+                i += 1
+            return name
+
         for head_empty_layer in spec.head_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(head_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(head_empty_layer), next_empty_layer_name()
             )
-            i += 1
 
         if spec.mhc_expand is not None:
             self.add_sequential_layer(
@@ -449,9 +480,8 @@ class GPTModel(PipelineLayer):
 
         for tail_empty_layer in spec.tail_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(tail_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(tail_empty_layer), next_empty_layer_name()
             )
-            i += 1
 
         if (
             self.config.gpt_model_use_experimental_version

--- a/src/paddlefleet/models/gpt/gpt_model.py
+++ b/src/paddlefleet/models/gpt/gpt_model.py
@@ -30,7 +30,15 @@ if TYPE_CHECKING:
 
 from paddle.distributed import fleet
 from paddle.distributed.fleet.meta_parallel import ScheduleChunk
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    resolve_names,
+)
 
+from paddlefleet.models.gpt.aoa_generator import (
+    build_aoa_context,
+    gen_whole_model_aoa,
+    gen_whole_model_inv_aoa,
+)
 from paddlefleet.models.gpt.gpt_embedding import GPTEmbedding
 from paddlefleet.models.gpt.lm_head import (
     GPTLMHead,
@@ -185,6 +193,31 @@ class GPTModel(PipelineLayer):
     Args:
         gpt_layer_desc:
     """
+
+    # Model-side AOA protocol: this class owns its whole-model AOA entry, so a
+    # multi-tower container must call ``gen_(inv_)aoa_statements(tower_config)``
+    # on it and must never recurse into it through the ``Layer`` protocol.
+    # Read by ``gen_multi_tower_aoa`` / ``gen_multi_tower_inv_aoa`` to pick the
+    # entry call over component recursion.
+    aoa_whole_model_boundary = True
+
+    # ``SharedLayerDesc.layer_name`` -> whether the checkpoint stores ONE tensor
+    # for the whole shared group. Read by ``_aoa_shared_layer_collapses``, which
+    # documents why this cannot be inferred and must be declared.
+    _AOA_SHARED_LAYER_COLLAPSES = {
+        # tie_word_embeddings / mtp_lm_head: a tied checkpoint omits the head
+        # weight entirely, so the embedding key feeds both model keys. With
+        # ``separate_mtp_headloss`` the MTP head is a real checkpoint producer,
+        # so ``collect_alias_plan`` splits this group per route instead.
+        "embed": True,
+        # enable_mtp_magic_send: MTPEmbeddingLayer's weight is a placeholder
+        # (perform_initialization=False, mtp_embedding_layer.py) replaced by the
+        # shared embedding, and the layout keeps no separate MTP embedding key.
+        "mtp_embed": True,
+        # mtp_shared_last_layer: the layout keeps the backbone's last layer and
+        # the MTP layer as independent keys.
+        "mtp_reuse_transformer": False,
+    }
 
     def __init__(
         self,
@@ -1260,3 +1293,109 @@ class GPTModel(PipelineLayer):
                 paddle.distributed.all_reduce(
                     grad.contiguous(), group=self._mtp_embed_global_group
                 )
+
+    # ═══════════════════════════════════════════════════════════════════════════
+    # AOA modular generation: whole-model entries + generator callbacks
+    # ═══════════════════════════════════════════════════════════════════════════
+
+    def gen_aoa_statements(self, config=None, *, globalize=True):
+        """Whole-model entry: checkpoint -> model (forward) AOA statements.
+
+        Builds the read-only context (so consumers never construct it) and hands
+        off to the modular generator. When ``config`` is passed explicitly the
+        context is built from it rather than from ``self.config``.
+        ``globalize=False`` is for a caller that unions this model's statements
+        with another's and globalizes the union itself.
+
+        The signature deliberately does not accept the ``Layer`` recursion
+        protocol's ``structured_name_prefix`` / ``aoa_name_scope``: this is a
+        whole-model boundary, so a container that recursed into it raises
+        ``TypeError`` instead of silently producing partial statements.
+        """
+        ctx = build_aoa_context(
+            self, config if config is not None else self.config
+        )
+        return gen_whole_model_aoa(self, ctx, globalize=globalize)
+
+    def gen_inv_aoa_statements(self, config=None, *, globalize=True):
+        """Whole-model entry: model -> checkpoint (inverse) AOA statements.
+
+        The independent mirror of :meth:`gen_aoa_statements`: it builds its own
+        context and never derives the inverse from the checkpoint->model
+        statements.
+        """
+        ctx = build_aoa_context(
+            self, config if config is not None else self.config
+        )
+        return gen_whole_model_inv_aoa(self, ctx, globalize=globalize)
+
+    # The three methods below are NOT called by the two entries above: they are
+    # model-side hooks the generator in ``aoa_generator`` calls back into while
+    # it walks this model.
+
+    def _raw_structured_state_dict(self):
+        """Returns the raw pipeline-structured ``state_dict`` (pre single-name
+        remap), including duplicate keys for shared tensors.
+
+        This is the same source ``_set_pipeline_name_mapping`` builds
+        ``_pp_to_single_mapping`` from, so its keys are exactly the mapping's
+        keys and its tensor identities expose tied / shared aliases.
+        """
+        return super().state_dict()
+
+    def _resolve_leaf_names(self, pipeline_name, ctx):
+        """Resolves one pipeline-local structured name to its
+        ``(checkpoint_name, single_name)`` pair.
+
+        Reuses ``_pp_to_single_mapping`` (built idempotently) for the
+        pipeline -> single step; a miss raises explicitly rather than falling
+        back. The single -> checkpoint step is delegated to the ``aoa`` naming
+        helpers so there is no parallel mapping.
+
+        Args:
+            pipeline_name: A structured (pipeline-local) tensor name, i.e. a key
+                of ``_pp_to_single_mapping``.
+            ctx: The read-only :class:`AOAContext` carrying the checkpoint-side
+                prefix and name mapping.
+
+        Returns:
+            ``(checkpoint_name, single_name)``.
+
+        Raises:
+            KeyError: If ``pipeline_name`` is not in ``_pp_to_single_mapping``.
+        """
+        if self._pipeline_name_mapping is None:
+            self._set_pipeline_name_mapping()
+        # Pass the full structured name as the local name with an empty prefix so
+        # ``resolve_single_name`` looks it up verbatim in _pp_to_single_mapping.
+        return resolve_names(
+            pipeline_name,
+            ctx.checkpoint_name_prefix,
+            "",
+            ctx.pp_to_single_mapping,
+            ctx.checkpoint_name_mapping,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+
+    def _aoa_shared_layer_collapses(self, layer_name: str) -> bool:
+        """Whether the checkpoint stores ONE tensor for a shared-weight group.
+
+        Not derivable model-side: the module tree only records WHICH names share
+        a tensor, while keeping one key for the group or one key per member is a
+        target-layout convention. ``mtp_embed`` and ``mtp_reuse_transformer``
+        are both one-tensor ``SharedLayerDesc`` groups, yet the first needs one
+        key fanned out and the second needs both keys materialized. So the
+        layout must be declared in ``_AOA_SHARED_LAYER_COLLAPSES`` (or by
+        overriding this method); an unregistered name raises instead of taking a
+        default, because either default silently writes a wrong checkpoint.
+        """
+        try:
+            return self._AOA_SHARED_LAYER_COLLAPSES[layer_name]
+        except KeyError:
+            raise ValueError(
+                f"unregistered SharedLayerDesc layer_name {layer_name!r} on "
+                f"{type(self).__name__}; declare whether the checkpoint stores "
+                f"one tensor for the whole shared group by extending "
+                f"_AOA_SHARED_LAYER_COLLAPSES or overriding "
+                f"_aoa_shared_layer_collapses"
+            ) from None

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -26,6 +26,13 @@ import paddle
 import paddle.distributed as dist
 import paddle.nn.functional as F
 from paddle.distributed.communication.reduce_scatter import _reduce_scatter_base
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    format_dtype_cast_attr,
+    format_inv_dtype_cast_attr,
+    resolve_dtype_cast_rule,
+    resolve_names,
+    should_skip,
+)
 from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
     build_sharded_state_dict,
 )
@@ -1283,6 +1290,96 @@ def linear_with_grad_accumulation_and_async_allreduce(
 linear_with_grad_accumulation_and_async_allreduce.warned = False
 
 
+def gen_linear_aoa_statements(
+    layer, ctx, *, structured_name_prefix="", aoa_name_scope=None
+):
+    """Checkpoint->model generator for the Linear family.
+
+    Weight carries a ``^T`` transpose; bias and any persistable buffer use
+    identity. A dtype cast suffix is appended when the model rules match the
+    single name. This is a plain module-level helper (not a base class) so
+    ``Linear`` / ``ColumnParallelLinear`` / ``RowParallelLinear`` share one
+    implementation without introducing a common ``LinearBase``. The transpose is
+    unconditional, so an owner whose embedded ``paddle.nn.Linear`` leaf may or
+    may not be transposed in the checkpoint (e.g.
+    ``HyperConnectionModule.mapping_proj``) emits that leaf inline instead of
+    calling this helper. The inverse direction has an independent helper and is
+    never derived from this one.
+    """
+    statements = []
+    local_state_dict = layer.state_dict(
+        structured_name_prefix="", include_sublayers=False
+    )
+    for name in local_state_dict:
+        if structured_name_prefix + name in ctx.excluded_names:
+            continue
+        checkpoint_name, single_name = resolve_names(
+            name,
+            ctx.checkpoint_name_prefix,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        cast = format_dtype_cast_attr(
+            resolve_dtype_cast_rule(
+                single_name,
+                ctx.dtype_cast_rules,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+        )
+        if name == "weight":
+            statements.append(f"{checkpoint_name}^T -> {single_name}{cast}")
+        else:
+            if should_skip(checkpoint_name, single_name, cast):
+                continue
+            statements.append(f"{checkpoint_name} -> {single_name}{cast}")
+    return statements
+
+
+def gen_linear_inv_aoa_statements(
+    layer, ctx, *, structured_name_prefix="", aoa_name_scope=None
+):
+    """Inverse (model -> checkpoint) generator for the Linear family.
+
+    Mirror of :func:`gen_linear_aoa_statements` for the opposite direction:
+    weight is transposed back (``^T`` stays on the source side), bias / buffers
+    use identity, and the dtype cast endpoints are swapped. Fully independent of
+    the checkpoint->model helper, never derived from its output text.
+    """
+    statements = []
+    local_state_dict = layer.state_dict(
+        structured_name_prefix="", include_sublayers=False
+    )
+    for name in local_state_dict:
+        if structured_name_prefix + name in ctx.excluded_names:
+            continue
+        checkpoint_name, single_name = resolve_names(
+            name,
+            ctx.checkpoint_name_prefix,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        cast = format_inv_dtype_cast_attr(
+            resolve_dtype_cast_rule(
+                single_name,
+                ctx.dtype_cast_rules,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+        )
+        if name == "weight":
+            statements.append(f"{single_name}^T -> {checkpoint_name}{cast}")
+        else:
+            if should_skip(checkpoint_name, single_name, cast):
+                continue
+            statements.append(f"{single_name} -> {checkpoint_name}{cast}")
+    return statements
+
+
 class Linear(paddle.nn.Layer):
     """Linear layer with no tensor parallelism (weight duplicated across TP ranks).
 
@@ -1593,6 +1690,37 @@ class Linear(paddle.nn.Layer):
         state_dict = self.state_dict(structured_name_prefix="")
         return build_sharded_state_dict(
             state_dict, None, structured_name_prefix
+        )
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model AOA for this Linear.
+
+        Weight is transposed (``^T``); bias / persistable buffers use identity;
+        a dtype cast suffix is appended when the model rules match.
+        """
+        return gen_linear_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) AOA for this Linear.
+
+        Independently generated, not derived from the checkpoint->model text:
+        weight is transposed back, bias / buffers use identity, dtype cast
+        endpoints are swapped.
+        """
+        return gen_linear_inv_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
         )
 
     def set_extra_state(self, state):
@@ -2123,6 +2251,37 @@ class ColumnParallelLinear(paddle.nn.Layer):
             state_dict, shard_rules, structured_name_prefix
         )
 
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model AOA for this Linear.
+
+        Weight is transposed (``^T``); bias / persistable buffers use identity;
+        a dtype cast suffix is appended when the model rules match.
+        """
+        return gen_linear_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) AOA for this Linear.
+
+        Independently generated, not derived from the checkpoint->model text:
+        weight is transposed back, bias / buffers use identity, dtype cast
+        endpoints are swapped.
+        """
+        return gen_linear_inv_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
     def set_extra_state(self, state):
         """Extra state is ignored"""
 
@@ -2439,6 +2598,37 @@ class RowParallelLinear(paddle.nn.Layer):
         shard_rules = None if self.world_size == 1 else {"weight": 0}
         return build_sharded_state_dict(
             state_dict, shard_rules, structured_name_prefix
+        )
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model AOA for this Linear.
+
+        Weight is transposed (``^T``); bias / persistable buffers use identity;
+        a dtype cast suffix is appended when the model rules match.
+        """
+        return gen_linear_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) AOA for this Linear.
+
+        Independently generated, not derived from the checkpoint->model text:
+        weight is transposed back, bias / buffers use identity, dtype cast
+        endpoints are swapped.
+        """
+        return gen_linear_inv_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
         )
 
     def set_extra_state(self, state):

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -21,7 +21,7 @@ import functools
 import logging
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 import paddle.nn.functional as F
 
@@ -1950,6 +1950,40 @@ class TransformerConfig(ModelParallelConfig):
     deepep_buffer_configs: dict | None = None
     """DeepEP buffer configuration."""
 
+    ####################
+    # AOA generator migration marker (code-level, not a config item)
+    ####################
+
+    aoa_modular: ClassVar[bool] = False
+    """Whether this model has been migrated to modular AOA.
+
+    Deliberately a ``ClassVar``, so it is not a dataclass field -- it records a
+    property of the model's *code*, not a choice the user makes per run. A
+    provider subclass flips it to ``True`` once its components carry their own
+    AOA markers and its hand-written generator is gone (see
+    ``Ernie5V2Provider``). Because ``register_attributes`` would otherwise turn
+    an ``aoa_modular`` key in a yaml / ``config.json`` into an instance
+    attribute that shadows this ``ClassVar``, ``_process_attribute`` rejects
+    that key outright, so it can only ever be set in a class body.
+
+    One marker drives two coupled behaviours, which is why they cannot be
+    separate switches:
+
+    * whole-model AOA generation: ``True`` -> module-tree recursion
+      (``gen_whole_model_aoa``), ``False`` -> the per-model hand-written
+      generator attached on the model instance (``model._gen_aoa_config``).
+    * empty-layer naming: ``True`` -> ``EmptyLayer`` instances get their own
+      ``empty_layers.<i>`` namespace and transformer layers are numbered
+      ``layers.0 .. layers.{num_hidden_layers - 1}`` regardless of
+      ``num_empty_layers_add_in_head=H``; ``False`` -> both kinds share one
+      ``layers.<i>`` counter, so the first transformer layer is ``layers.H``.
+
+    The modular generator is written against decoupled numbering and every
+    legacy generator against the shared counter, so mixing the two would
+    silently corrupt checkpoint keys. Keeping a single marker makes that
+    mixed state inexpressible.
+    """
+
     # Field name mapping rules: HuggingFace config.json name -> TransformerConfig name
     transform_rules = {
         # DSA field mapping
@@ -2080,6 +2114,12 @@ class TransformerConfig(ModelParallelConfig):
                 f"{self.renamed_config_keys_when_set[key]} Update the config "
                 f"that still sets {key}={value!r}; it would otherwise be "
                 f"silently ignored."
+            )
+        elif key == "aoa_modular":
+            raise ValueError(
+                "aoa_modular is a code-level modular-AOA migration marker "
+                "(a ClassVar flipped in a provider class body), not a config "
+                "field; it must never be set from yaml / config.json."
             )
         else:
             setattr(self, key, value)

--- a/src/paddlefleet/transformer/transformer_encoder.py
+++ b/src/paddlefleet/transformer/transformer_encoder.py
@@ -167,11 +167,31 @@ class TransformerEncoder(PipelineLayer):
 
     def get_encoder_layer_desc_list(self, layers, spec, name_prefix):
         i = 0
+        empty_index = 0
+
+        def next_empty_layer_name():
+            """Name for the next EmptyLayer, advancing the right counter.
+
+            With ``aoa_modular`` empty layers live in their own
+            ``empty_layers.<i>`` namespace and do not consume a ``layers.<i>``
+            slot, so transformer layers start at ``layers.0``. Otherwise both
+            kinds share the ``i`` counter. Kept identical to the language
+            tower's rule in ``GPTModel.get_layer_desc_list`` so the two towers
+            never name layers differently.
+            """
+            nonlocal i, empty_index
+            if getattr(getattr(self, "config", None), "aoa_modular", False):
+                name = f"{name_prefix}.empty_layers.{empty_index}"
+            else:
+                name = f"{name_prefix}.layers.{i}"
+                i += 1
+            empty_index += 1
+            return name
+
         for head_empty_layer in spec.head_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(head_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(head_empty_layer), next_empty_layer_name()
             )
-            i += 1
         for transformer_layer_spec in spec.transformer_layers:
             self.add_sequential_layer(
                 layers,
@@ -181,9 +201,8 @@ class TransformerEncoder(PipelineLayer):
             i += 1
         for tail_empty_layer in spec.tail_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(tail_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(tail_empty_layer), next_empty_layer_name()
             )
-            i += 1
 
     def overlapped_forward_backward(
         self,

--- a/tests/single_card_tests/aoa/test_aoa_config_protocol.py
+++ b/tests/single_card_tests/aoa/test_aoa_config_protocol.py
@@ -1,0 +1,289 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: pins the whole-model config-field protocol normalization -- the single
+# place that resolves the model-declared AOA name / dtype / layout attributes
+# (``build_aoa_context`` via ``_protocol_value``) and the MTP checkpoint-prefix
+# attributes (``MTPCheckpointPrefixSpec`` via
+# ``resolve_mtp_checkpoint_prefix_spec``). An unmigrated model (without an
+# explicit mapping) inherits the shared ERNIE mapping; an external model
+# overrides it via that attribute. Also carries a source-level lint pinning
+# the direction-independence contract (no ``direction`` / ``reverse`` param, a
+# ``_fwd_`` / ``_inv_`` helper split with no cross-direction calls and no
+# ``aoa_config_reverse`` call).
+import dataclasses
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+from paddle.distributed.flex_checkpoint.aoa.generation import AOAContext
+
+from paddlefleet.models.gpt.aoa_generator import (
+    DEFAULT_CHECKPOINT_NAME_MAPPING,
+    DEFAULT_CHECKPOINT_NAME_PREFIX,
+    DEFAULT_GATE_CHECKPOINT_LAYOUT,
+    DEFAULT_MLP_GATE_UP_FUSED,
+    DEFAULT_MODEL_NAME_PREFIX,
+    DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT,
+    DEFAULT_QKV_CHECKPOINT_PREFUSED,
+    FleetAOAContext,
+    MTPCheckpointPrefixSpec,
+    build_aoa_context,
+    resolve_mtp_checkpoint_prefix_spec,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+class _Cfg:
+    """Bare config stand-in; only the attributes a test sets are present."""
+
+
+class _FakeModel:
+    """Duck-types the attributes ``build_aoa_context`` reads.
+
+    ``_pipeline_name_mapping`` is pre-populated (non-None) so the idempotent
+    ``_set_pipeline_name_mapping`` side effect is skipped in the happy path.
+    ``_model_name_prefix()`` stands in for the live model's single-name root,
+    which is where the context takes it from; the value is held in a separately
+    named attribute so it does not shadow the method.
+    """
+
+    def __init__(
+        self,
+        pp_to_single_mapping=None,
+        model_name_prefix=DEFAULT_MODEL_NAME_PREFIX,
+    ):
+        self._pipeline_name_mapping = {}
+        self._pp_to_single_mapping = pp_to_single_mapping or {}
+        self._model_name_prefix_value = model_name_prefix
+
+    def _set_pipeline_name_mapping(self):
+        self._pipeline_name_mapping = {}
+
+    def _model_name_prefix(self):
+        return self._model_name_prefix_value
+
+
+class TestBuildAOAContextDefaults(unittest.TestCase):
+    def test_unmigrated_config_uses_ernie_defaults(self):
+        model = _FakeModel(pp_to_single_mapping={"s": "s"})
+        ctx = build_aoa_context(model, _Cfg())
+        self.assertIsInstance(ctx, AOAContext)
+        self.assertIsInstance(ctx, FleetAOAContext)
+        self.assertEqual(
+            ctx.checkpoint_name_prefix, DEFAULT_CHECKPOINT_NAME_PREFIX
+        )
+        self.assertEqual(
+            dict(ctx.checkpoint_name_mapping), DEFAULT_CHECKPOINT_NAME_MAPPING
+        )
+        self.assertEqual(dict(ctx.dtype_cast_rules), {})
+        self.assertEqual(ctx.model_name_prefix, DEFAULT_MODEL_NAME_PREFIX)
+        self.assertEqual(dict(ctx.pp_to_single_mapping), {"s": "s"})
+
+    def test_layout_defaults(self):
+        ctx = build_aoa_context(_FakeModel(), _Cfg())
+        self.assertEqual(
+            ctx.gate_checkpoint_layout, DEFAULT_GATE_CHECKPOINT_LAYOUT
+        )
+        self.assertEqual(
+            ctx.qkv_checkpoint_prefused, DEFAULT_QKV_CHECKPOINT_PREFUSED
+        )
+        self.assertEqual(
+            ctx.moe_expert_checkpoint_layout,
+            DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT,
+        )
+        self.assertEqual(ctx.mlp_gate_up_fused, DEFAULT_MLP_GATE_UP_FUSED)
+        self.assertFalse(ctx.mapping_proj_checkpoint_transposed)
+
+    def test_mapping_is_copied_not_aliased(self):
+        ctx = build_aoa_context(_FakeModel(), _Cfg())
+        self.assertIsNot(
+            ctx.checkpoint_name_mapping, DEFAULT_CHECKPOINT_NAME_MAPPING
+        )
+
+    def test_explicit_empty_checkpoint_mapping_overrides_default(self):
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_mapping = {}
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(dict(ctx.checkpoint_name_mapping), {})
+
+    def test_explicit_empty_checkpoint_prefix_is_preserved(self):
+        # A checkpoint rooted at the top level (DeepSeek V4) declares "" and
+        # must not silently fall back to the Ernie-series default.
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_prefix = ""
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(ctx.checkpoint_name_prefix, "")
+
+    def test_explicit_none_falls_back_to_default(self):
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_prefix = None
+        cfg.aoa_dtype_cast_rules = None
+        cfg.aoa_qkv_checkpoint_prefused = None
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(
+            ctx.checkpoint_name_prefix, DEFAULT_CHECKPOINT_NAME_PREFIX
+        )
+        self.assertEqual(dict(ctx.dtype_cast_rules), {})
+        self.assertEqual(
+            ctx.qkv_checkpoint_prefused, DEFAULT_QKV_CHECKPOINT_PREFUSED
+        )
+
+
+class TestBuildAOAContextOverrides(unittest.TestCase):
+    def test_name_and_dtype_overrides_propagate(self):
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_prefix = "hf"
+        cfg.aoa_checkpoint_name_mapping = {"a.weight": "b.weight"}
+        cfg.aoa_dtype_cast_rules = {
+            "x": {"checkpoint_dtype": "bfloat16", "model_dtype": "float32"}
+        }
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(ctx.checkpoint_name_prefix, "hf")
+        self.assertEqual(
+            dict(ctx.checkpoint_name_mapping), {"a.weight": "b.weight"}
+        )
+        self.assertEqual(
+            dict(ctx.dtype_cast_rules),
+            {"x": {"checkpoint_dtype": "bfloat16", "model_dtype": "float32"}},
+        )
+
+    def test_layout_overrides_propagate(self):
+        cfg = _Cfg()
+        cfg.aoa_gate_checkpoint_layout = "interleaved"
+        cfg.aoa_qkv_checkpoint_prefused = True
+        cfg.aoa_moe_expert_checkpoint_layout = "packed"
+        cfg.aoa_mapping_proj_checkpoint_transposed = True
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(ctx.gate_checkpoint_layout, "interleaved")
+        self.assertTrue(ctx.qkv_checkpoint_prefused)
+        self.assertEqual(ctx.moe_expert_checkpoint_layout, "packed")
+        self.assertTrue(ctx.mapping_proj_checkpoint_transposed)
+
+    def test_falsy_mlp_gate_up_fused_is_preserved(self):
+        # Qwen3-VL declares False; a truthiness-based default would swallow it.
+        cfg = _Cfg()
+        cfg.aoa_mlp_gate_up_fused = False
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertFalse(ctx.mlp_gate_up_fused)
+
+    def test_model_name_prefix_comes_from_the_live_model(self):
+        # The model single-name root comes from the live model, not the config:
+        # it must stay the same value that names the pipeline layers.
+        ctx = build_aoa_context(_FakeModel(model_name_prefix="root"), _Cfg())
+        self.assertEqual(ctx.model_name_prefix, "root")
+
+    def test_context_is_frozen(self):
+        ctx = build_aoa_context(_FakeModel(), _Cfg())
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            ctx.checkpoint_name_prefix = "mut"
+
+    def test_none_pipeline_mapping_triggers_side_effect(self):
+        model = _FakeModel()
+        model._pipeline_name_mapping = None
+        ctx = build_aoa_context(model, _Cfg())
+        self.assertIsNotNone(model._pipeline_name_mapping)
+        self.assertIsInstance(ctx, AOAContext)
+
+
+class TestMTPCheckpointPrefixSpec(unittest.TestCase):
+    def test_defaults(self):
+        spec = resolve_mtp_checkpoint_prefix_spec(_Cfg())
+        self.assertEqual(spec.checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertFalse(spec.is_absolute)
+
+    def test_transformer_inherits_own_prefix(self):
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix = "mtp.$LAYER_ID"
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertEqual(spec.checkpoint_prefix, "mtp.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "mtp.$LAYER_ID")
+
+    def test_transformer_prefix_override_independent(self):
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix = "mtp.$LAYER_ID"
+        cfg.aoa_mtp_transformer_checkpoint_prefix = "mtp.$LAYER_ID.tf"
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertEqual(spec.checkpoint_prefix, "mtp.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "mtp.$LAYER_ID.tf")
+
+    def test_absolute_flag(self):
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix_absolute = True
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertTrue(spec.is_absolute)
+
+    def test_bare_spec_defaults(self):
+        spec = MTPCheckpointPrefixSpec()
+        self.assertEqual(spec.checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertFalse(spec.is_absolute)
+
+    def test_explicit_empty_mtp_prefix_is_preserved(self):
+        # A top-level MTP checkpoint declares "" and must not silently fall
+        # back to the layers.$LAYER_ID default; the inner transformer prefix
+        # then inherits that same "".
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix = ""
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertEqual(spec.checkpoint_prefix, "")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "")
+
+
+class TestAoaModularNotConfigInjectable(unittest.TestCase):
+    """Pins that ``aoa_modular`` is a code-level marker, not a config field.
+
+    The marker is a ``ClassVar`` a migrated provider flips in its class body;
+    it must never be reachable from a yaml / ``config.json``. Two independent
+    surfaces enforce this and this test pins both: the ``ClassVar`` keeps it
+    out of the dataclass fields (so it is neither constructor-settable nor
+    instance-shadowed), and ``_process_attribute`` rejects the key outright on
+    the ``from_config`` load path.
+    """
+
+    def test_classvar_default_is_false(self):
+        self.assertFalse(TransformerConfig.aoa_modular)
+
+    def test_aoa_modular_is_not_a_dataclass_field(self):
+        field_names = {f.name for f in dataclasses.fields(TransformerConfig)}
+        self.assertNotIn("aoa_modular", field_names)
+
+    def test_from_config_rejects_aoa_modular_key(self):
+        # Rejected by the key itself, independent of the value carried.
+        for value in (True, False):
+            with self.assertRaises(ValueError):
+                TransformerConfig.from_config(
+                    SimpleNamespace(aoa_modular=value)
+                )
+
+    def test_reject_is_narrow(self):
+        # An unrelated attribute still flows through the normal setattr path.
+        inst = object.__new__(TransformerConfig)
+        inst._process_attribute("some_unrelated_attr", 123)
+        self.assertEqual(inst.some_unrelated_attr, 123)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_config_protocol.py
+++ b/tests/single_card_tests/aoa/test_aoa_config_protocol.py
@@ -22,7 +22,9 @@
 # the direction-independence contract (no ``direction`` / ``reverse`` param, a
 # ``_fwd_`` / ``_inv_`` helper split with no cross-direction calls and no
 # ``aoa_config_reverse`` call).
+import ast
 import dataclasses
+import inspect
 import os
 import sys
 import unittest
@@ -39,6 +41,7 @@ sys.path.insert(
 
 from paddle.distributed.flex_checkpoint.aoa.generation import AOAContext
 
+from paddlefleet.models.gpt import aoa_generator
 from paddlefleet.models.gpt.aoa_generator import (
     DEFAULT_CHECKPOINT_NAME_MAPPING,
     DEFAULT_CHECKPOINT_NAME_PREFIX,
@@ -283,6 +286,73 @@ class TestAoaModularNotConfigInjectable(unittest.TestCase):
         inst = object.__new__(TransformerConfig)
         inst._process_attribute("some_unrelated_attr", 123)
         self.assertEqual(inst.some_unrelated_attr, 123)
+
+
+def _module_funcs(module):
+    """Yields every ``FunctionDef`` / ``AsyncFunctionDef`` in a module's AST."""
+    tree = ast.parse(inspect.getsource(module))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node
+
+
+def _arg_names(func_node):
+    a = func_node.args
+    names = [arg.arg for arg in (*a.posonlyargs, *a.args, *a.kwonlyargs)]
+    if a.vararg:
+        names.append(a.vararg.arg)
+    if a.kwarg:
+        names.append(a.kwarg.arg)
+    return names
+
+
+def _called_identifiers(func_node):
+    ids = set()
+    for node in ast.walk(func_node):
+        if isinstance(node, ast.Call):
+            f = node.func
+            if isinstance(f, ast.Name):
+                ids.add(f.id)
+            elif isinstance(f, ast.Attribute):
+                ids.add(f.attr)
+    return ids
+
+
+class TestDirectionIndependenceLint(unittest.TestCase):
+    """Static lint pinning the direction-independence contract."""
+
+    def test_no_direction_or_reverse_param(self):
+        for func in _module_funcs(aoa_generator):
+            names = set(_arg_names(func))
+            self.assertNotIn(
+                "direction",
+                names,
+                f"{func.name} takes a forbidden 'direction' param",
+            )
+            self.assertNotIn(
+                "reverse",
+                names,
+                f"{func.name} takes a forbidden 'reverse' param",
+            )
+
+    def test_no_aoa_config_reverse_call(self):
+        src = inspect.getsource(aoa_generator)
+        self.assertNotIn("aoa_config_reverse", src)
+
+    def test_directions_do_not_cross_call(self):
+        by_name = {f.name: f for f in _module_funcs(aoa_generator)}
+        fwd = by_name["gen_whole_model_aoa"]
+        inv = by_name["gen_whole_model_inv_aoa"]
+        fwd_calls = _called_identifiers(fwd)
+        inv_calls = _called_identifiers(inv)
+        # forward must not reach into any inverse-marked emitter
+        self.assertNotIn("gen_inv_aoa_statements", fwd_calls)
+        self.assertNotIn("emit_alias_inv_aoa", fwd_calls)
+        self.assertNotIn("gen_whole_model_inv_aoa", fwd_calls)
+        # inverse must not reach into any forward emitter
+        self.assertNotIn("gen_aoa_statements", inv_calls)
+        self.assertNotIn("emit_alias_aoa", inv_calls)
+        self.assertNotIn("gen_whole_model_aoa", inv_calls)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/aoa/test_aoa_linear_component.py
+++ b/tests/single_card_tests/aoa/test_aoa_linear_component.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: the Linear family (``Linear`` / ``ColumnParallelLinear`` /
+# ``RowParallelLinear``) share a single module-level helper
+# ``gen_linear_aoa_statements`` / ``gen_linear_inv_aoa_statements``. This test
+# pins the coverage contract: ``weight`` carries ``^T``; bias / buffers use
+# identity only when their resolved names differ or a dtype cast is required;
+# and excluded aliases are omitted in both directions.
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+
+import paddle
+
+from paddlefleet.models.gpt.aoa_generator import (
+    FleetAOAContext,
+)
+
+
+def _ctx(
+    dtype_cast_rules=None,
+    *,
+    checkpoint_name_prefix="hf",
+    model_name_prefix="model",
+    excluded_names=frozenset(),
+):
+    return FleetAOAContext(
+        config=None,
+        checkpoint_name_prefix=checkpoint_name_prefix,
+        pp_to_single_mapping={},
+        checkpoint_name_mapping={},
+        dtype_cast_rules=dtype_cast_rules or {},
+        model_name_prefix=model_name_prefix,
+        excluded_names=excluded_names,
+    )
+
+
+def _make_linear_leaf(bias=False, buffer=False):
+    """Binds the Linear family AOA helpers onto a controllable stand-in.
+
+    The real ``Linear`` needs a live TP process group to construct, so we bind
+    the two override methods (which just forward to the module-level helpers)
+    onto a lightweight ``paddle.nn.Layer`` carrying real params / buffers.
+    """
+    from paddlefleet.tensor_parallel.layers import Linear
+
+    class _LinearLeaf(paddle.nn.Layer):
+        gen_aoa_statements = Linear.gen_aoa_statements
+        gen_inv_aoa_statements = Linear.gen_inv_aoa_statements
+
+        def __init__(self):
+            super().__init__()
+            self.weight = self.create_parameter(shape=[2, 2])
+            if bias:
+                self.bias = self.create_parameter(shape=[2])
+            if buffer:
+                # A persistable buffer must appear in state_dict and therefore
+                # get an identity statement (no orphan target).
+                self.register_buffer(
+                    "some_buf", paddle.zeros([2]), persistable=True
+                )
+                # A non-persistable buffer must NOT appear (no statement).
+                self.register_buffer(
+                    "tmp_buf", paddle.zeros([2]), persistable=False
+                )
+
+    return _LinearLeaf
+
+
+_PFX = "model.layers.0.mlp.down_proj."
+_W_CK = "hf.layers.0.mlp.down_proj.weight"
+_W_MD = "model.layers.0.mlp.down_proj.weight"
+
+
+class TestLinearClassContract(unittest.TestCase):
+    def test_three_linear_classes_override(self):
+        from paddlefleet.tensor_parallel.layers import (
+            ColumnParallelLinear,
+            Linear,
+            RowParallelLinear,
+        )
+
+        for cls in (Linear, ColumnParallelLinear, RowParallelLinear):
+            self.assertIn("gen_aoa_statements", cls.__dict__)
+            self.assertIn("gen_inv_aoa_statements", cls.__dict__)
+
+
+class TestLinearForward(unittest.TestCase):
+    def test_weight_transposed_bias_and_buffer_identity(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        # weight is transposed
+        self.assertIn(f"{_W_CK}^T -> {_W_MD}", stmts)
+        # bias is identity (no ^T)
+        self.assertIn(
+            "hf.layers.0.mlp.down_proj.bias -> "
+            "model.layers.0.mlp.down_proj.bias",
+            stmts,
+        )
+        # persistable buffer is identity, non-persistable buffer is absent
+        self.assertIn(
+            "hf.layers.0.mlp.down_proj.some_buf -> "
+            "model.layers.0.mlp.down_proj.some_buf",
+            stmts,
+        )
+        self.assertFalse(any("tmp_buf" in s for s in stmts))
+
+    def test_no_orphan_targets(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        # Every own state_dict key (weight/bias/some_buf) has exactly one
+        # producing statement; tmp_buf (non-persistable) has none.
+        self.assertEqual(len(stmts), 3)
+
+    def test_bias_absent_when_not_present(self):
+        model = _make_linear_leaf(bias=False, buffer=False)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        self.assertEqual(stmts, [f"{_W_CK}^T -> {_W_MD}"])
+
+    def test_same_name_identity_is_omitted(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        ctx = _ctx(checkpoint_name_prefix="model", model_name_prefix="model")
+        stmts = model.gen_aoa_statements(ctx, structured_name_prefix=_PFX)
+        self.assertEqual(stmts, [f"{_W_MD}^T -> {_W_MD}"])
+
+    def test_excluded_weight_is_omitted_in_forward_and_inverse(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        ctx = _ctx(excluded_names=frozenset({_PFX + "weight"}))
+
+        forward = model.gen_aoa_statements(ctx, structured_name_prefix=_PFX)
+        inverse = model.gen_inv_aoa_statements(ctx, structured_name_prefix=_PFX)
+
+        self.assertNotIn(f"{_W_CK}^T -> {_W_MD}", forward)
+        self.assertNotIn(f"{_W_MD}^T -> {_W_CK}", inverse)
+
+
+class TestLinearInverse(unittest.TestCase):
+    def test_weight_transposed_back_endpoints_swapped(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        stmts = model.gen_inv_aoa_statements(
+            _ctx(), structured_name_prefix=_PFX
+        )
+        self.assertIn(f"{_W_MD}^T -> {_W_CK}", stmts)
+        self.assertIn(
+            "model.layers.0.mlp.down_proj.bias -> "
+            "hf.layers.0.mlp.down_proj.bias",
+            stmts,
+        )
+        self.assertIn(
+            "model.layers.0.mlp.down_proj.some_buf -> "
+            "hf.layers.0.mlp.down_proj.some_buf",
+            stmts,
+        )
+        self.assertEqual(len(stmts), 3)
+
+
+class TestLinearDtypeCast(unittest.TestCase):
+    def test_forward_and_inverse_cast_endpoints(self):
+        rules = {
+            "layers.0.mlp.down_proj.weight": {
+                "checkpoint_dtype": "bfloat16",
+                "model_dtype": "float32",
+            }
+        }
+        model = _make_linear_leaf(bias=False)()
+        fwd = model.gen_aoa_statements(_ctx(rules), structured_name_prefix=_PFX)
+        self.assertEqual(
+            fwd,
+            [
+                f"{_W_CK}^T -> {_W_MD}, "
+                "src_dtype='bfloat16', dst_dtype='float32'"
+            ],
+        )
+        inv = model.gen_inv_aoa_statements(
+            _ctx(rules), structured_name_prefix=_PFX
+        )
+        self.assertEqual(
+            inv,
+            [
+                f"{_W_MD}^T -> {_W_CK}, "
+                "src_dtype='float32', dst_dtype='bfloat16'"
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_modular_generator.py
+++ b/tests/single_card_tests/aoa/test_aoa_modular_generator.py
@@ -1,0 +1,864 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: the whole-model modular AOA generator (whole-model entry + gate +
+# tied-alias fan-out), exercised with lightweight fakes so no pipeline / fleet
+# init is required.
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import types
+import unittest
+from unittest import mock
+
+import paddle
+
+from paddlefleet.models.gpt import aoa_generator as gen
+from paddlefleet.models.gpt.aoa_generator import FleetAOAContext
+from paddlefleet.models.gpt.gpt_model import GPTModel
+
+
+class _Leaf(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.weight = self.create_parameter(shape=[2])
+
+
+class _Cfg:
+    """Minimal stand-in for a Fleet config, carrying only AOA name fields."""
+
+    def __init__(self, **kwargs):
+        self.aoa_checkpoint_name_prefix = kwargs.get(
+            "aoa_checkpoint_name_prefix", "hf"
+        )
+        self.aoa_checkpoint_name_mapping = kwargs.get(
+            "aoa_checkpoint_name_mapping", {}
+        )
+        self.aoa_dtype_cast_rules = kwargs.get("aoa_dtype_cast_rules", {})
+        self.model_type = kwargs.get("model_type", "")
+
+
+class _FakeWholeModel:
+    """Duck-typed whole-model boundary for the pure generator functions.
+
+    Exposes exactly what ``aoa_generator`` reads: the child sub-layers, the
+    pipeline->single mapping, and the raw pipeline state_dict whose tensor
+    identities drive tied-alias / VPP grouping.
+
+    The shared-layer policy table, its lookup hook, the leaf-name resolver and
+    the model single-name root hook are borrowed from ``GPTModel`` verbatim
+    rather than stubbed: the alias plan and the whole-model entries read all
+    four, and a stub would put the test's own policy under test instead of the
+    shipped one.
+    """
+
+    _AOA_SHARED_LAYER_COLLAPSES = GPTModel._AOA_SHARED_LAYER_COLLAPSES
+    _aoa_shared_layer_collapses = GPTModel._aoa_shared_layer_collapses
+    _model_name_prefix = GPTModel._model_name_prefix
+    _resolve_leaf_names = GPTModel._resolve_leaf_names
+
+    def __init__(self, sub_layers, pp_mapping, raw_state):
+        self._sub_layers = sub_layers
+        self._pp_to_single_mapping = pp_mapping
+        self._pipeline_name_mapping = object()  # non-None: skip rebuild
+        self._raw_state = raw_state
+        # ``_model_name_prefix`` is the shipped hook and reads ``model_type``
+        # off the config, so the fake must carry one.
+        self.config = _Cfg()
+
+    def _set_pipeline_name_mapping(self):  # pragma: no cover - never hit
+        raise AssertionError("mapping already set")
+
+    def _raw_structured_state_dict(self):
+        return self._raw_state
+
+
+_ENTRY_METHODS = (
+    "gen_aoa_statements",
+    "gen_inv_aoa_statements",
+)
+
+
+def _entry_model(*, config=None):
+    """A fake boundary that borrows GPTModel's whole-model AOA entries verbatim.
+
+    Avoids constructing a real pipeline model: the entries only touch what
+    ``aoa_generator`` reads off the model. The modular path is therefore
+    exercised for real, which is what keeps the component-dispatch contract
+    under test.
+    """
+    model = _tied_model()
+    model.aoa_towers = None
+    model.config = _Cfg() if config is None else config
+    for name in _ENTRY_METHODS:
+        setattr(model, name, types.MethodType(getattr(GPTModel, name), model))
+    return model
+
+
+def _tied_model():
+    """Embedding + output_layer sharing one tensor (pp==1 tie)."""
+    emb = _Leaf()
+    out = _Leaf()
+    shared = emb.weight
+    raw = {"embedding.weight": shared, "output_layer.weight": shared}
+    pp_mapping = {
+        "embedding.weight": "model.embed_tokens.weight",
+        "output_layer.weight": "model.lm_head.weight",
+    }
+    model = _FakeWholeModel(
+        {"embedding": emb, "output_layer": out}, pp_mapping, raw
+    )
+    return model
+
+
+def _vpp_dup_model():
+    """One tensor under two structured names mapping to the *same* single."""
+    a = _Leaf()
+    shared = a.weight
+    raw = {"layer.0.weight": shared, "layer.1.weight": shared}
+    pp_mapping = {
+        "layer.0.weight": "model.layers.0.weight",
+        "layer.1.weight": "model.layers.0.weight",
+    }
+    # Recursion walks the live module tree; give it a single real leaf so the
+    # structured name "leaf.weight" is unrelated to the raw-dup keys, letting us
+    # isolate the grouping/exclusion helpers.
+    model = _FakeWholeModel({"leaf": a}, pp_mapping, raw)
+    return model
+
+
+class TestWholeModelAOAEntry(unittest.TestCase):
+    """The two whole-model entries: dispatch, config default, and boundary."""
+
+    def test_entry_runs_the_modular_generator(self):
+        model = _entry_model()
+        cfg = _Cfg()
+        fwd = model.gen_aoa_statements(cfg)["aoa_statements"]
+        inv = model.gen_inv_aoa_statements(cfg)["aoa_statements"]
+        self.assertIn("hf.embed_tokens.weight -> model.lm_head.weight", fwd)
+        self.assertIn("model.lm_head.weight -> _", inv)
+
+    def test_config_falls_back_to_self_config(self):
+        model = _entry_model(config=_Cfg())
+        self.assertTrue(model.gen_aoa_statements()["aoa_statements"])
+
+    def test_recursion_protocol_call_is_rejected(self):
+        """A container must call the entry, not recurse through it.
+
+        The entry takes ``(config=None)`` only, so it cannot absorb the base
+        ``Layer`` protocol's keyword-only ``structured_name_prefix`` /
+        ``aoa_name_scope``. Recursing into this boundary therefore raises
+        instead of silently emitting statements that skip whole-model
+        orchestration.
+        """
+        model = _entry_model()
+        ctx = gen.build_aoa_context(_tied_model(), _Cfg())
+        with self.assertRaises(TypeError):
+            model.gen_aoa_statements(ctx, structured_name_prefix="tower.")
+        with self.assertRaises(TypeError):
+            model.gen_inv_aoa_statements(ctx, structured_name_prefix="tower.")
+
+
+class TestAOAContextBuild(unittest.TestCase):
+    def test_context_snapshots_config_and_mapping(self):
+        model = _tied_model()
+        cfg = _Cfg(aoa_checkpoint_name_prefix="hf")
+        ctx = gen.build_aoa_context(model, cfg)
+        self.assertEqual(ctx.checkpoint_name_prefix, "hf")
+        self.assertEqual(ctx.pp_to_single_mapping, model._pp_to_single_mapping)
+        self.assertIs(ctx.config, cfg)
+
+    def test_context_defaults_are_resolved_not_none(self):
+        class _Bare:
+            pass
+
+        ctx = gen.build_aoa_context(_tied_model(), _Bare())
+        self.assertEqual(
+            ctx.checkpoint_name_prefix, gen.DEFAULT_CHECKPOINT_NAME_PREFIX
+        )
+        # A config that declares nothing gets the ERNIE-series checkpoint
+        # layout, not an empty mapping: the defaults describe the in-house
+        # checkpoint and an external model overrides only what diverges.
+        self.assertEqual(
+            dict(ctx.checkpoint_name_mapping),
+            gen.DEFAULT_CHECKPOINT_NAME_MAPPING,
+        )
+        self.assertEqual(ctx.dtype_cast_rules, {})
+        # The MTP checkpoint-prefix protocol lives off AOAContext now; its
+        # resolver yields same-numbering defaults for an unmigrated model.
+        spec = gen.resolve_mtp_checkpoint_prefix_spec(_Bare())
+        self.assertEqual(spec.checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertFalse(spec.is_absolute)
+        # The skip set is pinned by the whole-model function, not the builder.
+        self.assertEqual(ctx.excluded_names, frozenset())
+
+
+class TestTiedAliasFanOut(unittest.TestCase):
+    def setUp(self):
+        self.model = _tied_model()
+        self.ctx = gen.build_aoa_context(
+            self.model, _Cfg(aoa_checkpoint_name_prefix="hf")
+        )
+
+    def test_canonical_is_embedding_not_lm_head(self):
+        _excluded, groups = gen.collect_alias_plan(self.model, self.ctx)
+        self.assertEqual(len(groups), 1)
+        (group,) = groups
+        self.assertEqual(group.canonical_single, "model.embed_tokens.weight")
+        self.assertEqual(group.alias_singles, ("model.lm_head.weight",))
+        # The canonical checkpoint name is resolved once, at plan time, so the
+        # emitter never has to re-resolve a name it may not own.
+        self.assertEqual(group.canonical_checkpoint, "hf.embed_tokens.weight")
+
+    def test_alias_structured_name_is_excluded(self):
+        excluded, _groups = gen.collect_alias_plan(self.model, self.ctx)
+        self.assertEqual(excluded, frozenset({"output_layer.weight"}))
+
+    def test_forward_fans_out_canonical_source_to_alias_key(self):
+        out = gen.gen_whole_model_aoa(self.model, self.ctx)
+        stmts = out["aoa_statements"]
+        canonical = next(
+            s for s in stmts if s.endswith(" -> model.embed_tokens.weight")
+        )
+        fanout = next(
+            s for s in stmts if s.endswith(" -> model.lm_head.weight")
+        )
+        canonical_src = canonical.split(" -> ")[0]
+        fanout_src = fanout.split(" -> ")[0]
+        # Both the canonical target and the aliased target are fed from the same
+        # single checkpoint source (forward = one source fans out).
+        self.assertEqual(canonical_src, fanout_src)
+        # The excluded structured name never produced a normal recursion line.
+        self.assertEqual(
+            sum(s.endswith(" -> model.lm_head.weight") for s in stmts), 1
+        )
+
+    def test_inverse_deletes_alias_keeps_canonical_producer(self):
+        out = gen.gen_whole_model_inv_aoa(self.model, self.ctx)
+        stmts = out["aoa_statements"]
+        # Canonical producer writes the checkpoint; alias key is a DELETE.
+        self.assertTrue(
+            any(s.startswith("model.embed_tokens.weight -> ") for s in stmts)
+        )
+        self.assertIn("model.lm_head.weight -> _", stmts)
+        # No real inverse statement writes the checkpoint from the alias key.
+        self.assertFalse(
+            any(
+                s.startswith("model.lm_head.weight -> ")
+                and not s.endswith(" -> _")
+                for s in stmts
+            )
+        )
+
+    def test_forward_and_inverse_generated_independently(self):
+        fwd = gen.gen_whole_model_aoa(self.model, self.ctx)["aoa_statements"]
+        inv = gen.gen_whole_model_inv_aoa(self.model, self.ctx)[
+            "aoa_statements"
+        ]
+        # The inverse is not the textual reverse of forward (alias handling
+        # differs by direction: fan-out vs delete).
+        reversed_fwd = [" -> ".join(reversed(s.split(" -> "))) for s in fwd]
+        self.assertNotEqual(sorted(inv), sorted(reversed_fwd))
+
+
+class TestVppDuplicateDedup(unittest.TestCase):
+    def test_pure_duplicate_is_excluded_without_alias_group(self):
+        model = _vpp_dup_model()
+        ctx = gen.build_aoa_context(
+            model, _Cfg(aoa_checkpoint_name_prefix="hf")
+        )
+        # Same single-name under two structured names => dedup, not a fan-out.
+        excluded, groups = gen.collect_alias_plan(model, ctx)
+        self.assertEqual(groups, [])
+        self.assertEqual(excluded, frozenset({"layer.1.weight"}))
+
+
+class TestWholeModelKeyCoverage(unittest.TestCase):
+    def test_forward_targets_cover_distinct_single_names(self):
+        model = _tied_model()
+        ctx = gen.build_aoa_context(
+            model, _Cfg(aoa_checkpoint_name_prefix="hf")
+        )
+        targets = {
+            s.split(" -> ")[1]
+            for s in gen.gen_whole_model_aoa(model, ctx)["aoa_statements"]
+        }
+        # Every distinct model single-name is a forward target exactly once.
+        self.assertEqual(
+            targets,
+            {"model.embed_tokens.weight", "model.lm_head.weight"},
+        )
+
+
+class TestMultiTowerSkeleton(unittest.TestCase):
+    def test_aoa_towers_declared_but_unimplemented_raises(self):
+        model = _tied_model()
+        model.aoa_towers = ["vision", "language"]
+        ctx = gen.build_aoa_context(model, _Cfg())
+        with self.assertRaises(NotImplementedError):
+            gen.gen_whole_model_aoa(model, ctx)
+        with self.assertRaises(NotImplementedError):
+            gen.gen_whole_model_inv_aoa(model, ctx)
+
+
+def _multi_alias_model():
+    """Two independent alias groups: (embed/lm_head) and (adapter_a/adapter_b)."""
+    emb = _Leaf()
+    out = _Leaf()
+    adp_a = _Leaf()
+    adp_b = _Leaf()
+    shared_emb = emb.weight
+    shared_adp = adp_a.weight
+    raw = {
+        "embedding.weight": shared_emb,
+        "output_layer.weight": shared_emb,
+        "adapter_a.weight": shared_adp,
+        "adapter_b.weight": shared_adp,
+    }
+    pp_mapping = {
+        "embedding.weight": "model.embed_tokens.weight",
+        "output_layer.weight": "model.lm_head.weight",
+        "adapter_a.weight": "model.adapter_a.weight",
+        "adapter_b.weight": "model.adapter_b.weight",
+    }
+    model = _FakeWholeModel(
+        {
+            "embedding": emb,
+            "output_layer": out,
+            "adapter_a": adp_a,
+            "adapter_b": adp_b,
+        },
+        pp_mapping,
+        raw,
+    )
+    return model
+
+
+class TestMultipleAliasGroups(unittest.TestCase):
+    def test_two_independent_alias_groups_detected(self):
+        model = _multi_alias_model()
+        ctx = gen.build_aoa_context(
+            model, _Cfg(aoa_checkpoint_name_prefix="hf")
+        )
+        _excluded, groups = gen.collect_alias_plan(model, ctx)
+        self.assertEqual(len(groups), 2)
+        canonicals = sorted(g.canonical_single for g in groups)
+        self.assertIn("model.adapter_a.weight", canonicals)
+        self.assertIn("model.embed_tokens.weight", canonicals)
+
+    def test_forward_fans_out_both_groups(self):
+        model = _multi_alias_model()
+        ctx = gen.build_aoa_context(
+            model, _Cfg(aoa_checkpoint_name_prefix="hf")
+        )
+        stmts = gen.gen_whole_model_aoa(model, ctx)["aoa_statements"]
+        targets = {s.split(" -> ")[1] for s in stmts}
+        self.assertIn("model.lm_head.weight", targets)
+        self.assertIn("model.adapter_b.weight", targets)
+        self.assertIn("model.embed_tokens.weight", targets)
+        self.assertIn("model.adapter_a.weight", targets)
+
+    def test_inverse_deletes_both_alias_sets(self):
+        model = _multi_alias_model()
+        ctx = gen.build_aoa_context(
+            model, _Cfg(aoa_checkpoint_name_prefix="hf")
+        )
+        stmts = gen.gen_whole_model_inv_aoa(model, ctx)["aoa_statements"]
+        self.assertIn("model.lm_head.weight -> _", stmts)
+        self.assertIn("model.adapter_b.weight -> _", stmts)
+
+
+class _OverridingLeaf(paddle.nn.Layer):
+    """Stands in for a component-level override (Linear / SelfAttention...)."""
+
+    def __init__(self):
+        super().__init__()
+        self.weight = self.create_parameter(shape=[2])
+        self.seen_excluded = None
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        self.seen_excluded = ctx.excluded_names
+        return [f"__component__:{structured_name_prefix}"]
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        self.seen_excluded = ctx.excluded_names
+        return [f"__component_inv__:{structured_name_prefix}"]
+
+
+def _override_model():
+    """A tied pair (non-empty ``excluded``) plus a component-override child."""
+    emb = _Leaf()
+    out = _Leaf()
+    comp = _OverridingLeaf()
+    shared = emb.weight
+    raw = {
+        "embedding.weight": shared,
+        "output_layer.weight": shared,
+        "component.weight": comp.weight,
+    }
+    pp_mapping = {
+        "embedding.weight": "model.embed_tokens.weight",
+        "output_layer.weight": "model.lm_head.weight",
+        "component.weight": "model.component.weight",
+    }
+    model = _FakeWholeModel(
+        {"embedding": emb, "output_layer": out, "component": comp},
+        pp_mapping,
+        raw,
+    )
+    return model, comp
+
+
+class TestRecursionProtocol(unittest.TestCase):
+    """The whole-model walk must go through the Layer protocol, not a fork.
+
+    Regression guard: an earlier revision re-implemented the module walk inside
+    the generator and recursed into itself, which silently bypassed every
+    component override and dropped dtype casts.
+    """
+
+    def setUp(self):
+        self.model, self.comp = _override_model()
+        self.ctx = gen.build_aoa_context(
+            self.model, _Cfg(aoa_checkpoint_name_prefix="hf")
+        )
+
+    def test_component_override_is_dispatched_to(self):
+        stmts = gen.gen_whole_model_aoa(self.model, self.ctx)["aoa_statements"]
+        self.assertIn("__component__:component.", stmts)
+        # The default per-parameter line must not also be emitted for it.
+        self.assertNotIn("hf.component.weight -> model.component.weight", stmts)
+
+    def test_component_override_is_dispatched_to_in_inverse(self):
+        stmts = gen.gen_whole_model_inv_aoa(self.model, self.ctx)[
+            "aoa_statements"
+        ]
+        self.assertIn("__component_inv__:component.", stmts)
+
+    def test_excluded_names_reach_the_component_override(self):
+        gen.gen_whole_model_aoa(self.model, self.ctx)
+        self.assertEqual(
+            self.comp.seen_excluded, frozenset({"output_layer.weight"})
+        )
+
+    def test_builder_context_is_not_mutated(self):
+        gen.gen_whole_model_aoa(self.model, self.ctx)
+        # ctx is frozen: the skip set is pinned on a copy, not in place.
+        self.assertEqual(self.ctx.excluded_names, frozenset())
+
+
+class TestDtypeCastOnWholeModelPath(unittest.TestCase):
+    """``ctx.dtype_cast_rules`` is consumed by the base Layer recursion."""
+
+    def setUp(self):
+        self.model = _tied_model()
+        self.cfg = _Cfg(
+            aoa_checkpoint_name_prefix="hf",
+            aoa_dtype_cast_rules={
+                "embed_tokens.weight": {
+                    "checkpoint_dtype": "float32",
+                    "model_dtype": "bfloat16",
+                }
+            },
+        )
+        self.ctx = gen.build_aoa_context(self.model, self.cfg)
+
+    def test_forward_statement_carries_the_cast(self):
+        stmts = gen.gen_whole_model_aoa(self.model, self.ctx)["aoa_statements"]
+        self.assertIn(
+            "hf.embed_tokens.weight -> model.embed_tokens.weight"
+            ", src_dtype='float32', dst_dtype='bfloat16'",
+            stmts,
+        )
+
+    def test_inverse_statement_swaps_the_endpoints(self):
+        stmts = gen.gen_whole_model_inv_aoa(self.model, self.ctx)[
+            "aoa_statements"
+        ]
+        self.assertIn(
+            "model.embed_tokens.weight -> hf.embed_tokens.weight"
+            ", src_dtype='bfloat16', dst_dtype='float32'",
+            stmts,
+        )
+
+
+class TestAliasFanOutDtypeCast(unittest.TestCase):
+    """The alias fan-out resolves each alias single's OWN forward
+    dtype-cast rule, so a fanned-out tensor lands in the alias's declared dtype
+    even when the canonical producer carries no cast.
+
+    Before the fix, ``emit_alias_aoa`` emitted a bare
+    ``{checkpoint} -> {alias}`` with no dtype suffix, silently dropping a cast
+    declared on the alias key. The rule below is keyed on ``lm_head.weight``
+    (the alias), NOT ``embed_tokens.weight`` (the canonical), which isolates the
+    fan-out path from the base-recursion path already covered above.
+    """
+
+    def _cfg(self):
+        return _Cfg(
+            aoa_checkpoint_name_prefix="hf",
+            aoa_dtype_cast_rules={
+                "lm_head.weight": {
+                    "checkpoint_dtype": "float32",
+                    "model_dtype": "bfloat16",
+                }
+            },
+        )
+
+    def test_fanout_carries_alias_keyed_cast(self):
+        model = _tied_model()
+        ctx = gen.build_aoa_context(model, self._cfg())
+        stmts = gen.gen_whole_model_aoa(model, ctx)["aoa_statements"]
+        self.assertIn(
+            "hf.embed_tokens.weight -> model.lm_head.weight"
+            ", src_dtype='float32', dst_dtype='bfloat16'",
+            stmts,
+        )
+
+    def test_canonical_producer_is_uncast_when_only_alias_declares_it(self):
+        model = _tied_model()
+        ctx = gen.build_aoa_context(model, self._cfg())
+        stmts = gen.gen_whole_model_aoa(model, ctx)["aoa_statements"]
+        # The canonical target has no rule of its own -> plain identity line.
+        self.assertIn(
+            "hf.embed_tokens.weight -> model.embed_tokens.weight", stmts
+        )
+
+    def test_emit_alias_aoa_unit_applies_per_alias_cast(self):
+        # Direct unit check on the emitter with a hand-built group, independent
+        # of the whole-model walk.
+        ctx = FleetAOAContext(
+            config=None,
+            checkpoint_name_prefix="hf",
+            pp_to_single_mapping={
+                "embedding.weight": "model.embed_tokens.weight"
+            },
+            checkpoint_name_mapping={},
+            dtype_cast_rules={
+                "lm_head.weight": {
+                    "checkpoint_dtype": "float32",
+                    "model_dtype": "bfloat16",
+                }
+            },
+            model_name_prefix="model",
+            excluded_names=frozenset(),
+        )
+        group = gen.AliasGroup(
+            "model.embed_tokens.weight",
+            ("model.lm_head.weight",),
+            "hf.embed_tokens.weight",
+        )
+        self.assertEqual(
+            gen.emit_alias_aoa(ctx, [group]),
+            [
+                "hf.embed_tokens.weight -> model.lm_head.weight"
+                ", src_dtype='float32', dst_dtype='bfloat16'"
+            ],
+        )
+
+    def test_inverse_alias_delete_has_no_cast(self):
+        # Inverse deletes the alias key (``-> _``); a DELETE never carries a
+        # dtype cast, regardless of any rule on the alias single.
+        model = _tied_model()
+        ctx = gen.build_aoa_context(model, self._cfg())
+        stmts = gen.gen_whole_model_inv_aoa(model, ctx)["aoa_statements"]
+        self.assertIn("model.lm_head.weight -> _", stmts)
+        self.assertFalse(
+            any(
+                s.startswith("model.lm_head.weight -> ") and "dtype" in s
+                for s in stmts
+            )
+        )
+
+
+def _shared_layer_model(structured, single, *, sub_layers=None):
+    """One PP stage's view of a ``SharedLayerDesc`` group.
+
+    The peer half is built by ANOTHER process, so this rank holds exactly one
+    member and object identity relates it to nothing.
+    """
+    leaf = _Leaf()
+    return _FakeWholeModel(
+        {"leaf": leaf} if sub_layers is None else sub_layers,
+        {structured: single},
+        {structured: leaf.weight},
+    )
+
+
+def _plan_with_peer_rank(model, peer_resolved):
+    """Runs :func:`collect_alias_plan` with the world faked to two ranks.
+
+    ``peer_resolved`` is what the other rank contributes to the gather:
+    ``{layer_name: [(single_name, checkpoint_name)]}``, already resolved on its
+    owner, which is the only form allowed to cross a rank boundary.
+
+    ``is_initialized`` is faked alongside ``get_world_size`` because the gather
+    is guarded on both: a size >1 alone does not mean there is a group to gather
+    over (see ``_shared_layer_members``).
+    """
+    ctx = gen.build_aoa_context(model, _Cfg(aoa_checkpoint_name_prefix="hf"))
+
+    def _fake_all_gather_object(out, obj, *args, **kwargs):
+        out.extend([obj, peer_resolved])
+
+    with (
+        mock.patch.object(paddle.distributed, "get_world_size", return_value=2),
+        mock.patch.object(
+            paddle.distributed, "is_initialized", return_value=True
+        ),
+        mock.patch.object(
+            paddle.distributed, "all_gather_object", _fake_all_gather_object
+        ),
+    ):
+        return gen.collect_alias_plan(model, ctx)
+
+
+class TestSharedLayerTieAcrossPPStages(unittest.TestCase):
+    """A collapsing tie whose halves live on different PP stages.
+
+    Every declaring stage builds its OWN instance in its OWN process
+    (``pp_layers.py`` walks only its slice of ``_layers_desc``), so the two
+    halves are unrelated objects and no ``id()`` groups them. The plan keys on
+    ``SharedLayerDesc.layer_name`` -- globally identical, since it is what
+    Paddle itself shares on -- and all-gathers resolved names.
+    """
+
+    EMBED_SIDE = ("model.embed_tokens.weight", "hf.embed_tokens.weight")
+    HEAD_SIDE = ("model.lm_head.weight", "hf.lm_head.weight")
+
+    def test_embedding_stage_keeps_producer_and_gains_the_fanout(self):
+        model = _shared_layer_model(
+            "shared_layers.embed.weight", self.EMBED_SIDE[0]
+        )
+        excluded, groups = _plan_with_peer_rank(
+            model, {"embed": [self.HEAD_SIDE]}
+        )
+        self.assertEqual(excluded, frozenset())
+        (group,) = groups
+        self.assertEqual(group.canonical_single, self.EMBED_SIDE[0])
+        self.assertEqual(group.alias_singles, (self.HEAD_SIDE[0],))
+        self.assertEqual(group.canonical_checkpoint, self.EMBED_SIDE[1])
+
+    def test_head_stage_drops_its_producer_and_sources_the_peers_key(self):
+        # The regression this guards: without the gather this rank saw a lone
+        # structured name, emitted a plain statement, and sourced a head
+        # checkpoint key that a tied checkpoint does not contain.
+        model = _shared_layer_model(
+            "shared_layers.embed.weight", self.HEAD_SIDE[0]
+        )
+        excluded, groups = _plan_with_peer_rank(
+            model, {"embed": [self.EMBED_SIDE]}
+        )
+        self.assertEqual(excluded, frozenset({"shared_layers.embed.weight"}))
+        (group,) = groups
+        # Canonical selection is rank-invariant, so both stages emit the same
+        # fan-out and _globalize_statements dedups it.
+        self.assertEqual(group.canonical_single, self.EMBED_SIDE[0])
+        self.assertEqual(group.canonical_checkpoint, self.EMBED_SIDE[1])
+        self.assertEqual(group.alias_singles, (self.HEAD_SIDE[0],))
+
+    def test_canonical_is_the_embedding_even_under_the_shared_prefix(self):
+        # pp>1 registers the head under ``shared_head``, not ``lm_head``; the
+        # alias-segment table must cover that spelling too.
+        model = _shared_layer_model(
+            "shared_layers.embed.weight", "model.shared_head.weight"
+        )
+        _excluded, groups = _plan_with_peer_rank(
+            model, {"embed": [self.EMBED_SIDE]}
+        )
+        (group,) = groups
+        self.assertEqual(group.canonical_single, self.EMBED_SIDE[0])
+        self.assertEqual(group.alias_singles, ("model.shared_head.weight",))
+
+
+class TestNonCollapsingSharedLayer(unittest.TestCase):
+    """``mtp_reuse_transformer``: one tensor, but one checkpoint key per member.
+
+    Indistinguishable from the tie above model-side, which is why the policy is
+    declared rather than inferred.
+    """
+
+    def test_every_member_stays_an_independent_producer(self):
+        model = _shared_layer_model(
+            "shared_layers.mtp_reuse_transformer.weight",
+            "model.layers.12.weight",
+        )
+        excluded, groups = _plan_with_peer_rank(
+            model,
+            {
+                "mtp_reuse_transformer": [
+                    ("model.mtp.transformer_layer.weight", "hf.mtp.weight")
+                ]
+            },
+        )
+        self.assertEqual(groups, [])
+        self.assertEqual(excluded, frozenset())
+
+
+def _mixed_shared_and_plain_model():
+    """One identity group mixing a plain path with a ``shared_layers.*`` name.
+
+    Reachable with ``tie_word_embeddings=True``, ``pp == 1`` and
+    ``spec.mtp_lm_head`` set: ``get_layer_desc_list`` gates its embedding tie
+    branch on pp>1 so the embedding stays a plain ``LayerDesc``, while the head
+    still becomes ``SharedLayerDesc("embed")``, and
+    ``skip_weight_param_allocation`` ties the two by object.
+    """
+    embedding = _Leaf()
+    head = _Leaf()
+    shared = embedding.weight
+    return _FakeWholeModel(
+        {"embedding": embedding, "shared_head": head},
+        {
+            "embedding.weight": "model.embed_tokens.weight",
+            "shared_layers.embed.weight": "model.lm_head.weight",
+        },
+        {
+            "embedding.weight": shared,
+            "shared_layers.embed.weight": shared,
+        },
+    )
+
+
+class TestMixedSharedAndPlainGroup(unittest.TestCase):
+    def test_planned_as_one_unit_under_the_shared_layer_name(self):
+        model = _mixed_shared_and_plain_model()
+        ctx = gen.build_aoa_context(
+            model, _Cfg(aoa_checkpoint_name_prefix="hf")
+        )
+        excluded, groups = gen.collect_alias_plan(model, ctx)
+        # One unit, not two: were the plain name left to form its own identity
+        # group it would escape exclusion and a second producer would write the
+        # same checkpoint key.
+        self.assertEqual(len(groups), 1)
+        (group,) = groups
+        self.assertEqual(group.canonical_single, "model.embed_tokens.weight")
+        self.assertEqual(group.alias_singles, ("model.lm_head.weight",))
+        self.assertEqual(excluded, frozenset({"shared_layers.embed.weight"}))
+
+
+class TestSharedLayerPolicyLookup(unittest.TestCase):
+    def test_unregistered_layer_name_raises(self):
+        model = _shared_layer_model(
+            "shared_layers.mystery.weight", "model.mystery.weight"
+        )
+        ctx = gen.build_aoa_context(model, _Cfg())
+        with self.assertRaisesRegex(ValueError, "unregistered SharedLayerDesc"):
+            gen.collect_alias_plan(model, ctx)
+
+    def test_one_tensor_under_two_shared_layer_names_raises(self):
+        leaf = _Leaf()
+        shared = leaf.weight
+        model = _FakeWholeModel(
+            {"leaf": leaf},
+            {
+                "shared_layers.embed.weight": "model.embed_tokens.weight",
+                "shared_layers.mtp_embed.weight": "model.mtp_embedding.weight",
+            },
+            {
+                "shared_layers.embed.weight": shared,
+                "shared_layers.mtp_embed.weight": shared,
+            },
+        )
+        ctx = gen.build_aoa_context(model, _Cfg())
+        with self.assertRaisesRegex(ValueError, "several SharedLayerDesc"):
+            gen.collect_alias_plan(model, ctx)
+
+
+class TestGatherGuardedOnLiveProcessGroup(unittest.TestCase):
+    """``get_world_size() > 1`` does not imply there is a group to gather over.
+
+    With no group initialized it falls back to ``PADDLE_TRAINERS_NUM``, so a
+    launched-but-not-initialized process (every single-process run on a cluster
+    node, including this test suite) reports the launcher's rank count while
+    ``all_gather_object`` would raise. Both gather sites must stay rank-local
+    instead of crashing, and must say so.
+    """
+
+    def _no_group(self, world_size):
+        def _explode(*args, **kwargs):  # pragma: no cover - must not be hit
+            raise AssertionError("gathered without an initialized group")
+
+        return (
+            mock.patch.object(
+                paddle.distributed, "get_world_size", return_value=world_size
+            ),
+            mock.patch.object(
+                paddle.distributed, "is_initialized", return_value=False
+            ),
+            mock.patch.object(
+                paddle.distributed, "all_gather_object", _explode
+            ),
+        )
+
+    def test_alias_plan_stays_rank_local(self):
+        model = _tied_model()
+        ctx = gen.build_aoa_context(model, _Cfg())
+        size, init, gather = self._no_group(4)
+        with (
+            size,
+            init,
+            gather,
+            self.assertLogs(gen.__name__, level="WARNING") as logs,
+        ):
+            excluded, groups = gen.collect_alias_plan(model, ctx)
+        self.assertTrue(any("rank-local" in line for line in logs.output))
+        # The pp==1 tie is still planned from this rank's own registrations.
+        self.assertEqual(len(groups), 1)
+        self.assertTrue(excluded)
+
+    def test_globalize_statements_stays_rank_local(self):
+        local = ["hf.a -> model.a", "hf.b -> model.b"]
+        size, init, gather = self._no_group(4)
+        with (
+            size,
+            init,
+            gather,
+            self.assertLogs(gen.__name__, level="WARNING"),
+        ):
+            self.assertEqual(gen._globalize_statements(local), local)
+
+    def test_single_process_world_is_silent(self):
+        model = _tied_model()
+        ctx = gen.build_aoa_context(model, _Cfg())
+        with (
+            mock.patch.object(
+                paddle.distributed, "get_world_size", return_value=1
+            ),
+            mock.patch.object(
+                paddle.distributed, "is_initialized", return_value=False
+            ),
+            mock.patch.object(gen.logger, "warning") as warn,
+        ):
+            gen.collect_alias_plan(model, ctx)
+            gen._globalize_statements(["hf.a -> model.a"])
+        warn.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
+++ b/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
@@ -74,11 +74,13 @@ def _make_config(**overrides):
 def _layer_descs(num_mtp=1, **config_overrides):
     """Call get_layer_desc_list without building a real GPTModel.
 
-    The method only touches ``self.config`` and ``self.add_sequential_layer``,
-    so a stub carrying those two is enough and keeps this a single-card test.
+    The method only touches ``self.config``, ``self._model_name_prefix`` and
+    ``self.add_sequential_layer``, so a stub carrying those three is enough and
+    keeps this a single-card test.
     """
     fake_self = SimpleNamespace(
         config=_make_config(**config_overrides),
+        _model_name_prefix=lambda: "model",
         add_sequential_layer=lambda layers, desc, name_prefix="": layers.append(
             {"layer": desc, "name_prefix": name_prefix}
         ),


### PR DESCRIPTION
### PR Category

Distributed Strategy

### PR Types

New features

### Description

模块化 AOA 基础能力系列二（批3）：单塔整模生成器 + GPTModel 接入。

> **依赖 #2023（stacked）。** 本 PR 分支基于 #2023 的分支，因上游无法承载 #2023 的分支作为 base，这里 base 只能设为 `develop`。**在 #2023 合入前，此处 diff 会一并包含 #2023 的 c1/c2 改动**；#2023 合入后 diff 会自动收敛为本 PR 唯一的新增 commit `60803806`。请优先 review #2023，再看本 PR 的增量。

本 PR 唯一新增 commit（`60803806`）内容：

- `aoa_generator.py` — 单塔整模生成器：gather 守卫、tied/shared 别名规划、模型侧名字解析、语句文本不变量，以及 `gen_whole_model_(inv_)aoa` 入口。多塔容器入口延后到后续 PR。
- `gpt_model.py` — GPTModel 的整模 AOA 入口与生成器回调（`gen_(inv_)aoa_statements`、`_raw_structured_state_dict`、`_resolve_leaf_names`、`_aoa_shared_layer_collapses`）。
- 单测落在非受限目录 `tests/single_card_tests/aoa/`（`test_aoa_config_protocol.py` +70、`test_aoa_modular_generator.py` 新增）。

`aoa_modular` 保持 `False`（当前无任何模型翻 True）时，以上全部静态不可达。

前置 PR：
1、#2023 空层命名解耦 + 构建 AOA 上下文 

### 是否引起精度变化

否。

纯新增代码，仅在 `aoa_modular=True` 时进入；当前无模型开启，gate 关闭时静态不可达，不进入任何计算或 checkpoint 路径。
