### PR TITLE
[FlexCheckpoint] Modular AOA: MLP and MoE component leaves

### DIFF
--- a/src/paddlefleet/models/gpt/aoa_generator.py
+++ b/src/paddlefleet/models/gpt/aoa_generator.py
@@ -1,0 +1,278 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Whole-model modular AOA statement generation for boundary models.
+
+Pure functions backing the ``GPTModel`` boundary's modular AOA generation, plus
+the container entries a multi-tower model uses to drive several roots. The flow
+is:
+
+1. :func:`build_aoa_context` builds the read-only ``AOAContext`` once, using the
+   live model's ``_pp_to_single_mapping`` (same source as ``sharded_state_dict``,
+   so names come from the live module tree rather than a re-derived guess).
+2. :func:`collect_alias_plan` resolves tied / shared aliases and the pipeline
+   names to skip in one pass, **before** recursion (no post-hoc text dedup).
+   The skip set is pinned into ``ctx.excluded_names`` so every component
+   override honors it.
+3. :func:`gen_whole_model_aoa` / :func:`gen_whole_model_inv_aoa` hand each child
+   to the standard ``Layer.gen_aoa_statements`` / ``gen_inv_aoa_statements``
+   protocol -- that polymorphic call is the component dispatch point, so the
+   module walk is never re-implemented here. The two directions are generated
+   independently and never derived from one another.
+4. :func:`gen_multi_tower_aoa` / :func:`gen_multi_tower_inv_aoa` are the entry
+   points for a container that owns several roots (a vision tower beside a
+   language model). Every tower is dispatched on what its root is: a boundary
+   root goes through step 3, any other root through plain component recursion.
+   The container keeps globalization to itself so it runs once over the union
+   of all its towers.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    AOAContext,
+    validate_checkpoint_name_mapping,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# MTP checkpoint prefix protocol
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MTPCheckpointPrefixSpec:
+    """Checkpoint-side prefix protocol for MTP layers, resolved once per pass.
+
+    Producer-side state built at the whole-model entry from the model-declared
+    ``aoa_mtp_*`` attributes and threaded straight into
+    :func:`_resolve_mtp_scopes`. Deliberately *not* a field of the
+    component-facing :class:`AOAContext`: no component override reads it, so it
+    does not belong on the frozen recursion context forwarded to every
+    component.
+
+    Defaults cover the common case: MTP layers share the normal-layer
+    checkpoint numbering ``layers.$LAYER_ID`` and the inner transformer inherits
+    that same prefix. A boundary overrides via the three model attributes.
+    """
+
+    checkpoint_prefix: str = "layers.$LAYER_ID"
+    transformer_checkpoint_prefix: str = "layers.$LAYER_ID"
+    is_absolute: bool = False
+
+
+def resolve_mtp_checkpoint_prefix_spec(config) -> MTPCheckpointPrefixSpec:
+    """Normalizes the model-declared MTP checkpoint-prefix attributes.
+
+    Reads ``aoa_mtp_checkpoint_prefix`` /
+    ``aoa_mtp_transformer_checkpoint_prefix`` /
+    ``aoa_mtp_checkpoint_prefix_absolute`` off ``config`` with the defaulting an
+    unmigrated model relies on: the MTP-own prefix defaults to
+    ``layers.$LAYER_ID`` (same numbering as normal layers), the inner
+    transformer prefix inherits the MTP-own prefix, and no absolute-prefix
+    escape. Both prefixes route through :func:`_protocol_value`, so only an
+    absent / ``None`` attribute falls back; an explicitly declared value
+    (including an empty ``""`` for a top-level checkpoint) is taken verbatim.
+    """
+    checkpoint_prefix = _protocol_value(
+        config, "aoa_mtp_checkpoint_prefix", "layers.$LAYER_ID"
+    )
+    return MTPCheckpointPrefixSpec(
+        checkpoint_prefix=checkpoint_prefix,
+        transformer_checkpoint_prefix=_protocol_value(
+            config, "aoa_mtp_transformer_checkpoint_prefix", checkpoint_prefix
+        ),
+        is_absolute=bool(
+            getattr(config, "aoa_mtp_checkpoint_prefix_absolute", False)
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint protocol defaults and context construction
+# ---------------------------------------------------------------------------
+
+
+# Defaults for the model-declarable ``aoa_*`` checkpoint protocol. Each default
+# is named exactly once here and referenced by every consumer (the
+# :class:`FleetAOAContext` fields, :func:`build_aoa_context` and
+# :func:`_build_tower_ctx`), so no default literal is duplicated. The values
+# describe the ERNIE-series self-developed checkpoint; an external model
+# overrides only the attributes whose layout diverges.
+#
+# Only naming divergences belong in the mapping below: names the components
+# already emit identically (layernorms, ``model.norm``, the MTP layer's
+# ``enorm`` / ``hnorm`` / ``eh_proj``, and the CSA subtree) are deliberately
+# absent. The logical layer root also intentionally omits ``transformer_layer``
+# so the same entries cover ordinary layers and an MTP layer's inner
+# transformer.
+DEFAULT_CHECKPOINT_NAME_MAPPING = {
+    "embedding.embed_tokens.weight": "embed_tokens.weight",
+    "layers.$LAYER_ID.mlp.gate.weight": "layers.$LAYER_ID.block_sparse_moe.gate.weight",
+    "layers.$LAYER_ID.mlp.gate.weight_1": "layers.$LAYER_ID.block_sparse_moe.gate.weight_1",
+    "layers.$LAYER_ID.mlp.gate.routed_scaling_factor_param": "layers.$LAYER_ID.block_sparse_moe.gate.routed_scaling_factor_param",
+    "layers.$LAYER_ID.mlp.gate.e_score_correction_bias": "layers.$LAYER_ID.block_sparse_moe.e_score_correction_bias",
+    "layers.$LAYER_ID.mlp.fc1_latent_proj.weight": "layers.$LAYER_ID.block_sparse_moe.fc1_latent_proj.weight",
+    "layers.$LAYER_ID.mlp.fc2_latent_proj.weight": "layers.$LAYER_ID.block_sparse_moe.fc2_latent_proj.weight",
+    "layers.$LAYER_ID.mlp.experts.$EXPERT_ID.gate_proj.weight": "layers.$LAYER_ID.block_sparse_moe.experts.$EXPERT_ID.w1.weight",
+    "layers.$LAYER_ID.mlp.experts.$EXPERT_ID.up_proj.weight": "layers.$LAYER_ID.block_sparse_moe.experts.$EXPERT_ID.w3.weight",
+    "layers.$LAYER_ID.mlp.experts.$EXPERT_ID.down_proj.weight": "layers.$LAYER_ID.block_sparse_moe.experts.$EXPERT_ID.w2.weight",
+    "layers.$LAYER_ID.mlp.shared_experts.gate_proj.weight": "layers.$LAYER_ID.block_sparse_moe.shared_experts.w1.weight",
+    "layers.$LAYER_ID.mlp.shared_experts.up_proj.weight": "layers.$LAYER_ID.block_sparse_moe.shared_experts.w3.weight",
+    "layers.$LAYER_ID.mlp.shared_experts.down_proj.weight": "layers.$LAYER_ID.block_sparse_moe.shared_experts.w2.weight",
+    "layers.$LAYER_ID.norm.weight": "layers.$LAYER_ID.shared_head.norm.weight",
+}
+DEFAULT_CHECKPOINT_NAME_PREFIX = "model"
+DEFAULT_DTYPE_CAST_RULES = {}
+DEFAULT_GATE_CHECKPOINT_LAYOUT = "separate"
+DEFAULT_QKV_CHECKPOINT_PREFUSED = False
+DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT = "per_expert"
+DEFAULT_MLP_GATE_UP_FUSED = True
+DEFAULT_MAPPING_PROJ_CHECKPOINT_TRANSPOSED = False
+
+# Model-side single-name root, taken from the live model rather than declared on
+# the config; kept next to its checkpoint-side counterpart for readability.
+DEFAULT_MODEL_NAME_PREFIX = "model"
+
+
+@dataclass(frozen=True)
+class FleetAOAContext(AOAContext):
+    """Adds the checkpoint-layout declarations this library's components consume.
+
+    Paddle owns the recursion contract (names, dtype rules, exclusions); the
+    layouts below are paddlefleet's own protocol and grow with the models it
+    supports, so they live here rather than in the framework. Each is a
+    checkpoint-format fact that cannot be inferred from the live module, so the
+    model declares it; it only selects an emit branch and never overrides the
+    live structure.
+    """
+
+    gate_checkpoint_layout: str = DEFAULT_GATE_CHECKPOINT_LAYOUT
+    """Attention output gate placement for gated attention. ``"separate"``
+    (default) is the ERNIE-Lite layout with a standalone ``gate_proj`` tensor;
+    ``"interleaved"`` is a gate packed head-interleaved inside ``q_proj`` that
+    must be de-interleaved before fusing into ``qkv_proj``. Only consulted when
+    the live attention is gated."""
+
+    qkv_checkpoint_prefused: bool = DEFAULT_QKV_CHECKPOINT_PREFUSED
+    """``False`` (default) is the usual checkpoint with distinct ``q_proj`` /
+    ``k_proj`` / ``v_proj`` tensors; ``True`` is a single pre-fused ``qkv``
+    tensor that must be split before the ``fused_qkv`` re-fusion."""
+
+    moe_expert_checkpoint_layout: str = DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT
+    """``"per_expert"`` (default) for one projection tensor per expert,
+    ``"packed"`` for two 3D tensors packing every expert. Only consulted on the
+    grouped-GEMM branch, so one model may mix layouts across layers."""
+
+    mlp_gate_up_fused: bool = DEFAULT_MLP_GATE_UP_FUSED
+    """``True`` (default) is the gated MLP whose separate checkpoint
+    ``gate_proj`` / ``up_proj`` fuse into the model ``up_gate_proj``; ``False``
+    is a non-gated MLP handled by the generic Linear family."""
+
+    mapping_proj_checkpoint_transposed: bool = (
+        DEFAULT_MAPPING_PROJ_CHECKPOINT_TRANSPOSED
+    )
+    """Whether the checkpoint stores the mHC ``mapping_proj`` weight as
+    ``(out, in)`` (the torch layout, needing a ``^T``) instead of the live
+    ``(in, out)``. Orthogonal to the alpha layout; the accompanying leaf rename
+    is expressed by ``checkpoint_name_mapping``, which cannot carry a
+    transpose."""
+
+
+def _protocol_value(config, attr, default):
+    """Reads one model-declared ``aoa_*`` attribute with the single rule.
+
+    An attribute that is absent or explicitly ``None`` falls back to the
+    default; every other declared value is taken verbatim, including the falsy
+    ones a real model relies on (an empty ``""`` checkpoint prefix, a ``False``
+    ``mlp_gate_up_fused``). Keeping this the only reading path is what makes the
+    eight attributes behave uniformly.
+    """
+    value = getattr(config, attr, None)
+    return default if value is None else value
+
+
+def build_aoa_context(model, config) -> FleetAOAContext:
+    """Builds the read-only :class:`FleetAOAContext` for a whole-model pass.
+
+    Ensures ``_set_pipeline_name_mapping`` has run (idempotent; the same
+    side-effect ``state_dict`` / ``sharded_state_dict`` rely on), then resolves
+    every model-declared ``aoa_*`` attribute through :func:`_protocol_value`
+    against the module-level ``DEFAULT_*`` constants. The name mapping is the
+    one field with extra handling: it is copied so the context never aliases the
+    shared default, and validated as a name template.
+
+    Args:
+        model: The live ``GPTModel`` (or subclass) whose pipeline mapping backs
+            the single-name resolution and whose ``_model_name_prefix``
+            reports the authoritative model single-name root -- the same value
+            ``get_layer_desc_list`` uses to name its pipeline layers, so pipeline
+            naming and AOA name resolution never diverge.
+        config: The sub-structure config threaded into the context (whole-model
+            config for single-tower models, per-tower config for multi-tower).
+
+    Returns:
+        A frozen :class:`FleetAOAContext`.
+    """
+    if model._pipeline_name_mapping is None:
+        model._set_pipeline_name_mapping()
+    checkpoint_name_mapping = dict(
+        _protocol_value(
+            config,
+            "aoa_checkpoint_name_mapping",
+            DEFAULT_CHECKPOINT_NAME_MAPPING,
+        )
+    )
+    validate_checkpoint_name_mapping(checkpoint_name_mapping)
+    return FleetAOAContext(
+        config=config,
+        pp_to_single_mapping=model._pp_to_single_mapping or {},
+        model_name_prefix=model._model_name_prefix(),
+        checkpoint_name_mapping=checkpoint_name_mapping,
+        checkpoint_name_prefix=_protocol_value(
+            config,
+            "aoa_checkpoint_name_prefix",
+            DEFAULT_CHECKPOINT_NAME_PREFIX,
+        ),
+        dtype_cast_rules=_protocol_value(
+            config, "aoa_dtype_cast_rules", DEFAULT_DTYPE_CAST_RULES
+        ),
+        gate_checkpoint_layout=_protocol_value(
+            config,
+            "aoa_gate_checkpoint_layout",
+            DEFAULT_GATE_CHECKPOINT_LAYOUT,
+        ),
+        qkv_checkpoint_prefused=_protocol_value(
+            config,
+            "aoa_qkv_checkpoint_prefused",
+            DEFAULT_QKV_CHECKPOINT_PREFUSED,
+        ),
+        moe_expert_checkpoint_layout=_protocol_value(
+            config,
+            "aoa_moe_expert_checkpoint_layout",
+            DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT,
+        ),
+        mlp_gate_up_fused=_protocol_value(
+            config, "aoa_mlp_gate_up_fused", DEFAULT_MLP_GATE_UP_FUSED
+        ),
+        mapping_proj_checkpoint_transposed=_protocol_value(
+            config,
+            "aoa_mapping_proj_checkpoint_transposed",
+            DEFAULT_MAPPING_PROJ_CHECKPOINT_TRANSPOSED,
+        ),
+    )

--- a/src/paddlefleet/models/gpt/gpt_model.py
+++ b/src/paddlefleet/models/gpt/gpt_model.py
@@ -299,13 +299,23 @@ class GPTModel(PipelineLayer):
                 gpu_param = param.cuda()
                 gpu_param._share_buffer_to(param)
 
-    def get_layer_desc_list(self, spec, tie_word_embeddings):
-        layers = []
+    def _model_name_prefix(self) -> str:
+        """The model single-name root prefix (no trailing dot).
+
+        Authoritative for how this model roots its single-name space: used by
+        :meth:`get_layer_desc_list` to name pipeline layers and fed into
+        ``build_aoa_context``, so pipeline naming and AOA name resolution never
+        diverge (e.g. ``model.language_model`` for the qwen3_vl / qwen3_5
+        language tower instead of the ``model`` default).
+        """
         model_type = getattr(self.config, "model_type", "")
         if "qwen3_vl" in model_type or "qwen3_5" in model_type:
-            name_prefix = "model.language_model"
-        else:
-            name_prefix = "model"
+            return "model.language_model"
+        return "model"
+
+    def get_layer_desc_list(self, spec, tie_word_embeddings):
+        layers = []
+        name_prefix = self._model_name_prefix()
         if tie_word_embeddings:
             self.add_sequential_layer(
                 layers,
@@ -331,11 +341,32 @@ class GPTModel(PipelineLayer):
                 layers, LayerDesc(spec.embedding), name_prefix
             )
         i = 0
+        empty_index = 0
+        aoa_modular = getattr(
+            getattr(self, "config", None), "aoa_modular", False
+        )
+
+        def next_empty_layer_name():
+            """Name for the next EmptyLayer, advancing the right counter.
+
+            With ``aoa_modular`` empty layers live in their own
+            ``empty_layers.<i>`` namespace and do not consume a ``layers.<i>``
+            slot, so transformer layers start at ``layers.0``. Otherwise both
+            kinds share the ``i`` counter (the legacy ``+H`` offset).
+            """
+            nonlocal i, empty_index
+            if aoa_modular:
+                name = f"{name_prefix}.empty_layers.{empty_index}"
+                empty_index += 1
+            else:
+                name = f"{name_prefix}.layers.{i}"
+                i += 1
+            return name
+
         for head_empty_layer in spec.head_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(head_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(head_empty_layer), next_empty_layer_name()
             )
-            i += 1
 
         if spec.mhc_expand is not None:
             self.add_sequential_layer(
@@ -449,9 +480,8 @@ class GPTModel(PipelineLayer):
 
         for tail_empty_layer in spec.tail_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(tail_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(tail_empty_layer), next_empty_layer_name()
             )
-            i += 1
 
         if (
             self.config.gpt_model_use_experimental_version

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -26,6 +26,13 @@ import paddle
 import paddle.distributed as dist
 import paddle.nn.functional as F
 from paddle.distributed.communication.reduce_scatter import _reduce_scatter_base
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    format_dtype_cast_attr,
+    format_inv_dtype_cast_attr,
+    resolve_dtype_cast_rule,
+    resolve_names,
+    should_skip,
+)
 from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
     build_sharded_state_dict,
 )
@@ -1283,6 +1290,96 @@ def linear_with_grad_accumulation_and_async_allreduce(
 linear_with_grad_accumulation_and_async_allreduce.warned = False
 
 
+def gen_linear_aoa_statements(
+    layer, ctx, *, structured_name_prefix="", aoa_name_scope=None
+):
+    """Checkpoint->model generator for the Linear family.
+
+    Weight carries a ``^T`` transpose; bias and any persistable buffer use
+    identity. A dtype cast suffix is appended when the model rules match the
+    single name. This is a plain module-level helper (not a base class) so
+    ``Linear`` / ``ColumnParallelLinear`` / ``RowParallelLinear`` share one
+    implementation without introducing a common ``LinearBase``. The transpose is
+    unconditional, so an owner whose embedded ``paddle.nn.Linear`` leaf may or
+    may not be transposed in the checkpoint (e.g.
+    ``HyperConnectionModule.mapping_proj``) emits that leaf inline instead of
+    calling this helper. The inverse direction has an independent helper and is
+    never derived from this one.
+    """
+    statements = []
+    local_state_dict = layer.state_dict(
+        structured_name_prefix="", include_sublayers=False
+    )
+    for name in local_state_dict:
+        if structured_name_prefix + name in ctx.excluded_names:
+            continue
+        checkpoint_name, single_name = resolve_names(
+            name,
+            ctx.checkpoint_name_prefix,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        cast = format_dtype_cast_attr(
+            resolve_dtype_cast_rule(
+                single_name,
+                ctx.dtype_cast_rules,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+        )
+        if name == "weight":
+            statements.append(f"{checkpoint_name}^T -> {single_name}{cast}")
+        else:
+            if should_skip(checkpoint_name, single_name, cast):
+                continue
+            statements.append(f"{checkpoint_name} -> {single_name}{cast}")
+    return statements
+
+
+def gen_linear_inv_aoa_statements(
+    layer, ctx, *, structured_name_prefix="", aoa_name_scope=None
+):
+    """Inverse (model -> checkpoint) generator for the Linear family.
+
+    Mirror of :func:`gen_linear_aoa_statements` for the opposite direction:
+    weight is transposed back (``^T`` stays on the source side), bias / buffers
+    use identity, and the dtype cast endpoints are swapped. Fully independent of
+    the checkpoint->model helper, never derived from its output text.
+    """
+    statements = []
+    local_state_dict = layer.state_dict(
+        structured_name_prefix="", include_sublayers=False
+    )
+    for name in local_state_dict:
+        if structured_name_prefix + name in ctx.excluded_names:
+            continue
+        checkpoint_name, single_name = resolve_names(
+            name,
+            ctx.checkpoint_name_prefix,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        cast = format_inv_dtype_cast_attr(
+            resolve_dtype_cast_rule(
+                single_name,
+                ctx.dtype_cast_rules,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+        )
+        if name == "weight":
+            statements.append(f"{single_name}^T -> {checkpoint_name}{cast}")
+        else:
+            if should_skip(checkpoint_name, single_name, cast):
+                continue
+            statements.append(f"{single_name} -> {checkpoint_name}{cast}")
+    return statements
+
+
 class Linear(paddle.nn.Layer):
     """Linear layer with no tensor parallelism (weight duplicated across TP ranks).
 
@@ -1593,6 +1690,37 @@ class Linear(paddle.nn.Layer):
         state_dict = self.state_dict(structured_name_prefix="")
         return build_sharded_state_dict(
             state_dict, None, structured_name_prefix
+        )
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model AOA for this Linear.
+
+        Weight is transposed (``^T``); bias / persistable buffers use identity;
+        a dtype cast suffix is appended when the model rules match.
+        """
+        return gen_linear_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) AOA for this Linear.
+
+        Independently generated, not derived from the checkpoint->model text:
+        weight is transposed back, bias / buffers use identity, dtype cast
+        endpoints are swapped.
+        """
+        return gen_linear_inv_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
         )
 
     def set_extra_state(self, state):
@@ -2123,6 +2251,37 @@ class ColumnParallelLinear(paddle.nn.Layer):
             state_dict, shard_rules, structured_name_prefix
         )
 
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model AOA for this Linear.
+
+        Weight is transposed (``^T``); bias / persistable buffers use identity;
+        a dtype cast suffix is appended when the model rules match.
+        """
+        return gen_linear_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) AOA for this Linear.
+
+        Independently generated, not derived from the checkpoint->model text:
+        weight is transposed back, bias / buffers use identity, dtype cast
+        endpoints are swapped.
+        """
+        return gen_linear_inv_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
     def set_extra_state(self, state):
         """Extra state is ignored"""
 
@@ -2439,6 +2598,37 @@ class RowParallelLinear(paddle.nn.Layer):
         shard_rules = None if self.world_size == 1 else {"weight": 0}
         return build_sharded_state_dict(
             state_dict, shard_rules, structured_name_prefix
+        )
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model AOA for this Linear.
+
+        Weight is transposed (``^T``); bias / persistable buffers use identity;
+        a dtype cast suffix is appended when the model rules match.
+        """
+        return gen_linear_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) AOA for this Linear.
+
+        Independently generated, not derived from the checkpoint->model text:
+        weight is transposed back, bias / buffers use identity, dtype cast
+        endpoints are swapped.
+        """
+        return gen_linear_inv_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
         )
 
     def set_extra_state(self, state):

--- a/src/paddlefleet/transformer/mlp.py
+++ b/src/paddlefleet/transformer/mlp.py
@@ -52,6 +52,18 @@ from paddlefleet.transformer.layer import FleetLayer
 
 if TYPE_CHECKING:
     from paddlefleet.transformer.transformer_config import TransformerConfig
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    format_dtype_cast_attr,
+    format_inv_dtype_cast_attr,
+    join_name,
+    resolve_checkpoint_name_from_anchor,
+    resolve_dtype_cast_rule,
+    resolve_names,
+    resolve_single_name,
+    should_skip,
+    strip_name_suffix,
+)
+
 from paddlefleet.utils import (
     get_tensor_model_parallel_group_if_none,
     nvtx_range_pop,
@@ -405,3 +417,365 @@ class MLP(FleetLayer):
     def backward_dw(self):
         self.down_proj.backward_dw()
         self.up_gate_proj.backward_dw()
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model generator for gated MLP.
+
+        ``up_gate_proj`` fuses checkpoint ``gate_proj`` and ``up_proj`` (each
+        transposed) via the ``fused_ffn`` macro; ``down_proj`` is delegated to
+        the Linear family. Any own directly-held param/buffer of this MLP (not a
+        sublayer) is caught by a generic fallback loop between the fused body
+        and the ``down_proj`` delegation, mirroring ``SelfAttention``. Statement
+        order is semantic. Inverse is implemented independently in
+        :meth:`gen_inv_aoa_statements` (no cross-call).
+        """
+        if not ctx.mlp_gate_up_fused:
+            return self._gen_nongated_mlp_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+
+        fused_local_name = "up_gate_proj.weight"
+        fused_model_name = resolve_single_name(
+            fused_local_name,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        gate_checkpoint_name = resolve_checkpoint_name_from_anchor(
+            fused_model_name,
+            fused_local_name,
+            "gate_proj.weight",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        up_checkpoint_name = resolve_checkpoint_name_from_anchor(
+            fused_model_name,
+            fused_local_name,
+            "up_proj.weight",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        # ``excluded_names`` holds model names another statement already
+        # produces, so re-emitting one here would duplicate the target. A
+        # fusion is all-or-nothing: the whole statement goes or stays. Weight
+        # and bias are excluded independently.
+        if structured_name_prefix + fused_local_name in ctx.excluded_names:
+            statements = []
+        else:
+            statements = self._gen_up_gate_fusion_aoa_statements(
+                gate_checkpoint_name, up_checkpoint_name, fused_model_name
+            )
+        if self.up_gate_proj.bias is not None:
+            statements += self._gen_up_gate_bias_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+        local_state_dict = self.state_dict(
+            structured_name_prefix="", include_sublayers=False
+        )
+        for name in local_state_dict:
+            if structured_name_prefix + name in ctx.excluded_names:
+                continue
+            source_name, target_name = resolve_names(
+                name,
+                ctx.checkpoint_name_prefix,
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            cast = format_dtype_cast_attr(
+                resolve_dtype_cast_rule(
+                    target_name,
+                    ctx.dtype_cast_rules,
+                    ctx.model_name_prefix,
+                )
+            )
+            if should_skip(source_name, target_name, cast):
+                continue
+            statements.append(f"{source_name} -> {target_name}{cast}")
+        statements += self.down_proj.gen_aoa_statements(
+            ctx,
+            structured_name_prefix=f"{structured_name_prefix}down_proj.",
+            aoa_name_scope=aoa_name_scope,
+        )
+        return statements
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) generator for gated MLP.
+
+        Independently splits the fused ``up_gate_proj`` back into checkpoint
+        ``gate_proj`` and ``up_proj`` via ``fused_ffn``, catches any own
+        directly-held param/buffer via a generic fallback loop, then delegates
+        ``down_proj``. Not derived from the checkpoint->model text. The inverse
+        ``fused_ffn`` carries no ``^T`` (matches the validated existing
+        generators in ``aoa_config_base``/``qwen3_moe``/``glm4_moe``; the fused
+        macro handles the layout, so no explicit inverse transpose is emitted).
+        """
+        if not ctx.mlp_gate_up_fused:
+            return self._gen_inv_nongated_mlp_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+
+        fused_local_name = "up_gate_proj.weight"
+        fused_model_name = resolve_single_name(
+            fused_local_name,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        # Split targets use the model-side gate/up half names, derived from the
+        # fused anchor's scope (never sent through pp_to_single_mapping, since
+        # the halves are not real params under the fused up_gate_proj). Same
+        # anchor-scope mechanism used for the checkpoint names below.
+        scope_single = strip_name_suffix(fused_model_name, fused_local_name)
+        gate_model_name = join_name(scope_single, "gate_proj.weight")
+        up_model_name = join_name(scope_single, "up_proj.weight")
+        gate_checkpoint_name = resolve_checkpoint_name_from_anchor(
+            fused_model_name,
+            fused_local_name,
+            "gate_proj.weight",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        up_checkpoint_name = resolve_checkpoint_name_from_anchor(
+            fused_model_name,
+            fused_local_name,
+            "up_proj.weight",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        if structured_name_prefix + fused_local_name in ctx.excluded_names:
+            statements = []
+        else:
+            statements = self._gen_inv_up_gate_fusion_aoa_statements(
+                fused_model_name,
+                gate_model_name,
+                up_model_name,
+                gate_checkpoint_name,
+                up_checkpoint_name,
+            )
+        if self.up_gate_proj.bias is not None:
+            statements += self._gen_inv_up_gate_bias_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+        local_state_dict = self.state_dict(
+            structured_name_prefix="", include_sublayers=False
+        )
+        for name in local_state_dict:
+            if structured_name_prefix + name in ctx.excluded_names:
+                continue
+            target_name, source_name = resolve_names(
+                name,
+                ctx.checkpoint_name_prefix,
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            cast = format_inv_dtype_cast_attr(
+                resolve_dtype_cast_rule(
+                    source_name,
+                    ctx.dtype_cast_rules,
+                    ctx.model_name_prefix,
+                )
+            )
+            if should_skip(source_name, target_name, cast):
+                continue
+            statements.append(f"{source_name} -> {target_name}{cast}")
+        statements += self.down_proj.gen_inv_aoa_statements(
+            ctx,
+            structured_name_prefix=f"{structured_name_prefix}down_proj.",
+            aoa_name_scope=aoa_name_scope,
+        )
+        return statements
+
+    def _gen_nongated_mlp_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Checkpoint->model for a non-gated MLP (e.g. Qwen3-VL vision tower):
+        ``up_gate_proj`` / ``down_proj`` are plain Linears with no gate/up
+        split, so delegate both to the generic Linear family (per-tensor ``^T``
+        weight rename + identity bias) and emit no ``fused_ffn``."""
+        statements = self.up_gate_proj.gen_aoa_statements(
+            ctx,
+            structured_name_prefix=f"{structured_name_prefix}up_gate_proj.",
+            aoa_name_scope=aoa_name_scope,
+        )
+        statements += self.down_proj.gen_aoa_statements(
+            ctx,
+            structured_name_prefix=f"{structured_name_prefix}down_proj.",
+            aoa_name_scope=aoa_name_scope,
+        )
+        return statements
+
+    def _gen_inv_nongated_mlp_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Model->checkpoint for a non-gated MLP. Independently mirrors
+        :meth:`_gen_nongated_mlp_aoa_statements` by delegating both plain
+        Linears to their inverse generators."""
+        statements = self.up_gate_proj.gen_inv_aoa_statements(
+            ctx,
+            structured_name_prefix=f"{structured_name_prefix}up_gate_proj.",
+            aoa_name_scope=aoa_name_scope,
+        )
+        statements += self.down_proj.gen_inv_aoa_statements(
+            ctx,
+            structured_name_prefix=f"{structured_name_prefix}down_proj.",
+            aoa_name_scope=aoa_name_scope,
+        )
+        return statements
+
+    def _gen_up_gate_fusion_aoa_statements(
+        self, gate_checkpoint_name, up_checkpoint_name, fused_model_name
+    ):
+        """Checkpoint->model fusion of gate/up into ``up_gate_proj``.
+
+        Default uses the ``fused_ffn`` macro, whose TP-rank interleaving is
+        required for dense and shared MLPs that are tensor-parallel sharded.
+        Routed experts are expert-parallel (their fused weight is not
+        TP-interleaved), so they override this with a plain ``axis=1`` concat.
+        """
+        return [
+            f"{gate_checkpoint_name}^T, {up_checkpoint_name}^T "
+            f"-> {fused_model_name}, fused_ffn"
+        ]
+
+    def _gen_inv_up_gate_fusion_aoa_statements(
+        self,
+        fused_model_name,
+        gate_model_name,
+        up_model_name,
+        gate_checkpoint_name,
+        up_checkpoint_name,
+    ):
+        """Model->checkpoint split of ``up_gate_proj`` back into gate/up.
+
+        Split the fused weight via the TP-interleaving ``fused_ffn`` macro onto
+        the model-side gate/up half names (still in model ``(out,in)`` layout),
+        then transpose each half back to its checkpoint ``(in,out)`` name. The
+        transpose is a separate statement because ``^T`` binds to the source
+        (left) side while ``fused_ffn`` emits its halves on the target side.
+        Routed experts override only the fusion macro (``axis=1``); the
+        split-then-transpose shape is identical.
+        """
+        return [
+            f"{fused_model_name} -> "
+            f"{gate_model_name}, {up_model_name}, fused_ffn",
+            f"{gate_model_name}^T -> {gate_checkpoint_name}",
+            f"{up_model_name}^T -> {up_checkpoint_name}",
+        ]
+
+    def _gen_up_gate_bias_fusion_aoa_statements(
+        self, gate_checkpoint_name, up_checkpoint_name, fused_model_name
+    ):
+        """Checkpoint->model fusion of the gate/up 1-D bias.
+
+        Same TP-interleaving requirement as the weight, on the single bias axis
+        (``axis=0``); routed experts are expert-parallel and override this with
+        a plain concat.
+        """
+        return [
+            f"{gate_checkpoint_name}, {up_checkpoint_name} "
+            f"-> {fused_model_name}, fused_ffn, axis=0"
+        ]
+
+    def _gen_inv_up_gate_bias_fusion_aoa_statements(
+        self, fused_model_name, gate_checkpoint_name, up_checkpoint_name
+    ):
+        """Model->checkpoint split of the fused 1-D bias.
+
+        No transpose on either side, so unlike the weight this is a single
+        statement straight onto the checkpoint names.
+        """
+        return [
+            f"{fused_model_name} -> "
+            f"{gate_checkpoint_name}, {up_checkpoint_name}, fused_ffn, axis=0"
+        ]
+
+    def _gen_up_gate_bias_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Checkpoint->model helper: fuse checkpoint gate/up 1-D bias into the
+        model fused bias (no transpose). Anchored on the real
+        ``up_gate_proj.bias`` key."""
+        fused_local_name = "up_gate_proj.bias"
+        if structured_name_prefix + fused_local_name in ctx.excluded_names:
+            return []
+        fused_model_name = resolve_single_name(
+            fused_local_name,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        gate_checkpoint_name = resolve_checkpoint_name_from_anchor(
+            fused_model_name,
+            fused_local_name,
+            "gate_proj.bias",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        up_checkpoint_name = resolve_checkpoint_name_from_anchor(
+            fused_model_name,
+            fused_local_name,
+            "up_proj.bias",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        return self._gen_up_gate_bias_fusion_aoa_statements(
+            gate_checkpoint_name, up_checkpoint_name, fused_model_name
+        )
+
+    def _gen_inv_up_gate_bias_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Inverse-only helper: split the model fused 1-D bias back into
+        checkpoint gate/up bias (no transpose)."""
+        fused_local_name = "up_gate_proj.bias"
+        if structured_name_prefix + fused_local_name in ctx.excluded_names:
+            return []
+        fused_model_name = resolve_single_name(
+            fused_local_name,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        gate_checkpoint_name = resolve_checkpoint_name_from_anchor(
+            fused_model_name,
+            fused_local_name,
+            "gate_proj.bias",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        up_checkpoint_name = resolve_checkpoint_name_from_anchor(
+            fused_model_name,
+            fused_local_name,
+            "up_proj.bias",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        return self._gen_inv_up_gate_bias_fusion_aoa_statements(
+            fused_model_name, gate_checkpoint_name, up_checkpoint_name
+        )

--- a/src/paddlefleet/transformer/moe/moe_expert.py
+++ b/src/paddlefleet/transformer/moe/moe_expert.py
@@ -1027,3 +1027,53 @@ class StandardMLPExpert(MLP):
                 intermediate_size=moe_intermediate_size,
                 # tp_group=pg_collection.expt_tp,
             )
+
+    def _gen_up_gate_fusion_aoa_statements(
+        self, gate_checkpoint_name, up_checkpoint_name, fused_model_name
+    ):
+        """Routed experts are expert-parallel, so gate/up fuse via a plain
+        ``axis=1`` concat rather than the TP-interleaving ``fused_ffn`` macro
+        used by dense and shared MLPs."""
+        return [
+            f"{gate_checkpoint_name}^T, {up_checkpoint_name}^T "
+            f"-> {fused_model_name}, axis=1"
+        ]
+
+    def _gen_inv_up_gate_fusion_aoa_statements(
+        self,
+        fused_model_name,
+        gate_model_name,
+        up_model_name,
+        gate_checkpoint_name,
+        up_checkpoint_name,
+    ):
+        """Routed experts are expert-parallel, so the fused weight splits via a
+        plain ``axis=1`` concat instead of the TP-interleaving ``fused_ffn``
+        macro. Same split-then-transpose structure as the dense/shared default:
+        split onto model-side gate/up half names, then transpose each to its
+        checkpoint name."""
+        return [
+            f"{fused_model_name} -> {gate_model_name}, {up_model_name}, axis=1",
+            f"{gate_model_name}^T -> {gate_checkpoint_name}",
+            f"{up_model_name}^T -> {up_checkpoint_name}",
+        ]
+
+    def _gen_up_gate_bias_fusion_aoa_statements(
+        self, gate_checkpoint_name, up_checkpoint_name, fused_model_name
+    ):
+        """Same expert-parallel reason as the weight: a plain concat on the
+        bias axis instead of the TP-interleaving ``fused_ffn`` macro."""
+        return [
+            f"{gate_checkpoint_name}, {up_checkpoint_name} "
+            f"-> {fused_model_name}, axis=0"
+        ]
+
+    def _gen_inv_up_gate_bias_fusion_aoa_statements(
+        self, fused_model_name, gate_checkpoint_name, up_checkpoint_name
+    ):
+        """Expert-parallel inverse of the fused bias: a plain split on the bias
+        axis, straight onto the checkpoint names (no transpose)."""
+        return [
+            f"{fused_model_name} -> "
+            f"{gate_checkpoint_name}, {up_checkpoint_name}, axis=0"
+        ]

--- a/src/paddlefleet/transformer/moe/moe_layer.py
+++ b/src/paddlefleet/transformer/moe/moe_layer.py
@@ -78,6 +78,25 @@ from .token_dispatcher import (
 logger = logging.getLogger(__name__)
 
 
+MOE_EXPERT_CHECKPOINT_LAYOUTS = ("per_expert", "packed")
+
+
+def _check_expert_checkpoint_layout(layout):
+    """Rejects an unknown expert layout instead of defaulting silently.
+
+    Both grouped-GEMM emit paths branch on ``layout == "packed"`` with the
+    per-expert concat as the else-branch, so a typo would otherwise produce
+    plausible but wrong statements that only surface as a shape mismatch at load
+    time. Only the grouped branch validates: the per-expert live branch
+    deliberately ignores the declaration, so one model may mix layouts.
+    """
+    if layout not in MOE_EXPERT_CHECKPOINT_LAYOUTS:
+        raise ValueError(
+            f"unknown moe_expert_checkpoint_layout {layout!r}; expected one of "
+            f"{MOE_EXPERT_CHECKPOINT_LAYOUTS}"
+        )
+
+
 # MD5 logging for MoE precision debugging
 _LOG_LAYER_MD5 = os.environ.get("LOG_LAYER_MD5", "0") == "1"
 
@@ -102,6 +121,22 @@ def _log_moe_md5(tensor, name, layer_idx=None):
             flush=True,
         )
 
+
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    format_dtype_cast_attr,
+    format_inv_dtype_cast_attr,
+    join_name,
+    resolve_checkpoint_name_from_anchor,
+    resolve_dtype_cast_rule,
+    resolve_names,
+    resolve_single_name,
+    strip_name_suffix,
+)
+
+from paddlefleet.tensor_parallel.layers import (
+    gen_linear_aoa_statements,
+    gen_linear_inv_aoa_statements,
+)
 
 from .moe_utils import (
     global_moe_balance_training_logs_enabled,
@@ -2210,6 +2245,658 @@ class MoELayer(nn.Layer):
             if color not in (None, -1):
                 continue
             p.color = {"color": color_key, "group": self.moe_grad_group}
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model generator for MoELayer.
+
+        Composes: gate (TopKRouter), optional MoE Latent Projection
+        (``fc1/fc2_latent_proj`` are ``paddle.nn.Linear`` leaves so the Linear
+        helper is reused for their ``^T``), optional shared experts (MLP), and
+        the routed experts. Routed experts are recursed through their own
+        ``StandardMLPExpert`` (an ``MLP`` subclass) so the per-expert
+        ``fused_ffn`` + ``down_proj`` layout comes from the MLP component. The
+        cross-expert grouped-GEMM / sonic fusion is delegated to a
+        direction-inner helper. Inverse is independent.
+        """
+        statements = self.gate.gen_aoa_statements(
+            ctx,
+            structured_name_prefix=f"{structured_name_prefix}gate.",
+            aoa_name_scope=aoa_name_scope,
+        )
+        if getattr(self, "fc1_latent_proj", None) is not None:
+            statements += gen_linear_aoa_statements(
+                self.fc1_latent_proj,
+                ctx,
+                structured_name_prefix=(
+                    f"{structured_name_prefix}fc1_latent_proj."
+                ),
+                aoa_name_scope=aoa_name_scope,
+            )
+            statements += gen_linear_aoa_statements(
+                self.fc2_latent_proj,
+                ctx,
+                structured_name_prefix=(
+                    f"{structured_name_prefix}fc2_latent_proj."
+                ),
+                aoa_name_scope=aoa_name_scope,
+            )
+        if getattr(self, "shared_experts", None) is not None:
+            statements += self.shared_experts.gen_aoa_statements(
+                ctx,
+                structured_name_prefix=(
+                    f"{structured_name_prefix}shared_experts."
+                ),
+                aoa_name_scope=aoa_name_scope,
+            )
+        if getattr(self, "grouped_gemm_experts", None) is not None:
+            statements += self._gen_grouped_expert_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+        else:
+            # Per-expert live layout: emit one expert-recursion per expert.
+            # ``ctx.moe_expert_checkpoint_layout`` is NOT consulted here -- it
+            # only selects the *grouped* branch's packed-vs-concat sub-path. A
+            # model may legitimately mix layouts across layers under a single
+            # model-level flag (e.g. Qwen3.5 main layers are grouped+packed but
+            # its MTP layers are built per-expert with per-expert checkpoint
+            # keys), so a per-expert live layer is always valid regardless of
+            # the flag.
+            for expert_id, expert in enumerate(self.experts):
+                if expert is None:
+                    continue
+                statements += expert.gen_aoa_statements(
+                    ctx,
+                    structured_name_prefix=(
+                        f"{structured_name_prefix}experts.{expert_id}."
+                    ),
+                    aoa_name_scope=aoa_name_scope,
+                )
+        return statements
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) generator for MoELayer.
+
+        Independently mirrors :meth:`gen_aoa_statements` without deriving from
+        its output text: gate, latent
+        projection, shared experts, then routed experts (per-expert MLP inverse
+        or the grouped-fusion inverse helper).
+        """
+        statements = self.gate.gen_inv_aoa_statements(
+            ctx,
+            structured_name_prefix=f"{structured_name_prefix}gate.",
+            aoa_name_scope=aoa_name_scope,
+        )
+        if getattr(self, "fc1_latent_proj", None) is not None:
+            statements += gen_linear_inv_aoa_statements(
+                self.fc1_latent_proj,
+                ctx,
+                structured_name_prefix=(
+                    f"{structured_name_prefix}fc1_latent_proj."
+                ),
+                aoa_name_scope=aoa_name_scope,
+            )
+            statements += gen_linear_inv_aoa_statements(
+                self.fc2_latent_proj,
+                ctx,
+                structured_name_prefix=(
+                    f"{structured_name_prefix}fc2_latent_proj."
+                ),
+                aoa_name_scope=aoa_name_scope,
+            )
+        if getattr(self, "shared_experts", None) is not None:
+            statements += self.shared_experts.gen_inv_aoa_statements(
+                ctx,
+                structured_name_prefix=(
+                    f"{structured_name_prefix}shared_experts."
+                ),
+                aoa_name_scope=aoa_name_scope,
+            )
+        if getattr(self, "grouped_gemm_experts", None) is not None:
+            statements += self._gen_inv_grouped_expert_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+        else:
+            # Per-expert live layout (see the forward note): the layout flag is
+            # not consulted here; a per-expert layer is always valid, including
+            # under a model-level ``"packed"`` flag whose packed sub-path only
+            # applies to the grouped branch.
+            for expert_id, expert in enumerate(self.experts):
+                if expert is None:
+                    continue
+                statements += expert.gen_inv_aoa_statements(
+                    ctx,
+                    structured_name_prefix=(
+                        f"{structured_name_prefix}experts.{expert_id}."
+                    ),
+                    aoa_name_scope=aoa_name_scope,
+                )
+        return statements
+
+    # Local names of the two 3D packed grouped-GEMM tensors. Used by the
+    # ``"packed"`` checkpoint-layout branch (checkpoint also packs every expert
+    # into two 3D tensors that map by a per-expert transpose), so no per-expert
+    # concat is needed.
+    _GROUPED_EXPERT_LOCAL_NAMES = (
+        "grouped_gemm_experts.weight1",
+        "grouped_gemm_experts.weight2",
+    )
+
+    def _intermediate_ep_size(self):
+        """EP degree when the fused expert weights are intermediate-sharded.
+
+        ``None`` on the ordinary layout (deepep, or EP disabled), where
+        ``weight1`` / ``weight2`` carry disjoint experts on their leading axis
+        and the checkpoint-facing statements need no un-interleaving.
+
+        A degree means the 'allgather' dispatcher layout: this rank holds every
+        expert but only ``I // EP`` of each one's intermediate dim, so
+        ``GroupedMLPExpert._get_intermediate_sharded_state_dict`` declares
+        ``weight1`` 4-D ``[E, io, 2, I_local]`` sharded on ``axis=3`` and
+        ``weight2`` 3-D ``[E, I_local, io]`` sharded on ``axis=1``. The HF
+        directions run against a 2-D re-declaration of those shards (AOA cannot
+        lower a tensor's rank on save), and that re-declared *global* layout is
+        rank-major interleaved -- ``weight1`` columns are
+        ``gate_r0|up_r0|gate_r1|up_r1|...`` and ``weight2`` rows are
+        ``(r0: e0..eE-1)|(r1: e0..eE-1)|...`` -- because each rank's block has
+        to stay one contiguous rectangle. Un-interleaving that ordering is all
+        the two intermediate-sharded branches below do.
+
+        Predicate and degree are both read off the live expert, the same source
+        ``sharded_state_dict`` dispatches on, so the statements cannot drift
+        from the shards they describe. ``intermediate_ep_sharded`` implies a
+        real EP group with ``nranks > 1`` (see ``GroupedMLPExpert``'s
+        ``expert_parallel``), so the ``ep_group`` read below is safe.
+        """
+        experts = self.grouped_gemm_experts
+        if not experts.intermediate_ep_sharded:
+            return None
+        return experts.ep_group.nranks
+
+    def _reject_packed_intermediate_ep(self, ep_size):
+        """Guard the one unvalidated layout combination.
+
+        ``moe_expert_checkpoint_layout`` describes the *checkpoint* side and
+        ``intermediate_ep_sharded`` the *model* side, so the two are
+        orthogonal; only ``per_expert`` x intermediate-sharded is implemented.
+        The packed path maps whole 3D checkpoint tensors per expert through a
+        ``permute``, which leaves nowhere to un-interleave the rank-major EP
+        ordering, so it must fail loudly rather than emit plausible-looking
+        statements that silently produce wrong data.
+        """
+        if ep_size is not None:
+            raise NotImplementedError(
+                "the 'packed' MoE expert checkpoint layout is not supported "
+                "together with the intermediate-sharded (allgather EP) model "
+                f"layout (ep_size={ep_size}); this combination has never been "
+                "validated."
+            )
+
+    def _reject_nongated_grouped_experts(self, ctx):
+        """Guard the non-gated grouped-expert layout, which is not implemented.
+
+        Both grouped paths assume a gated linear unit: ``weight1`` is sized
+        ``[E, io, 2I]`` and its last axis is cut into a gate half and an up
+        half, and the checkpoint is expected to carry a ``gate_proj`` per
+        expert. A non-gated MoE builds ``weight1`` as ``[E, io, I]`` with no
+        gate half and its checkpoint has no ``gate_proj``, so emitting these
+        statements would reference a nonexistent key and fuse on a nonexistent
+        half instead of failing.
+        """
+        if not ctx.mlp_gate_up_fused:
+            raise NotImplementedError(
+                "grouped-GEMM routed experts currently assume a gated linear "
+                "unit; the non-gated expert layout is not implemented."
+            )
+
+    def _gen_grouped_expert_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Checkpoint->model generator for the grouped-GEMM / sonic cross-expert
+        fusion.
+
+        When ``ctx.moe_expert_checkpoint_layout == "packed"`` the checkpoint
+        itself packs every expert into two 3D tensors (``experts.gate_up_proj``
+        / ``experts.down_proj``) that map onto the model ``weight1`` / ``weight2``
+        by a per-expert ``permute='[0,2,1]'`` -- no per-expert concat -- so that
+        branch is delegated to :meth:`_gen_packed_grouped_expert_aoa_statements`.
+        The default ``"per_expert"`` layout below stores one
+        ``gate_proj`` / ``up_proj`` / ``down_proj`` per expert and fuses+concats.
+
+        Routed experts are stored as two packed tensors:
+        ``grouped_gemm_experts.weight1`` (every expert's fused gate+up,
+        concatenated on the expert axis) and ``grouped_gemm_experts.weight2``
+        (every expert's down projection). The checkpoint carries one
+        ``gate_proj`` / ``up_proj`` / ``down_proj`` per expert. The build is
+        two-stage: (1) per expert, fuse ``gate``+``up`` into a transient
+        model-side ``up_gate_proj`` and stage the ``down`` projection into a
+        transient ``down_proj``; (2) concatenate the per-expert transients on
+        ``axis=0`` into the packed ``weight1`` / ``weight2``.
+
+        Every expert type shares one checkpoint-facing layout, the grouped-GEMM
+        one: ``weight1`` is ``[E, io, 2I]`` with ``gate``/``up`` as the two
+        contiguous halves of the last axis and ``weight2`` is ``[E, I, io]``.
+        So every checkpoint tensor is transposed (``^T``) and ``gate``/``up``
+        fuse on ``axis=1``. :class:`SonicMoEExpert` holds a different layout
+        while computing, but its ``sharded_state_dict()`` converts back to the
+        grouped layout first, so that layout never reaches a checkpoint and the
+        expert type must not be branched on here. Should a checkpoint layout
+        ever diverge, it belongs in ``ctx.moe_expert_checkpoint_layout``
+        (declared by the model) rather than in an expert-type check.
+
+        When the live weights are intermediate-sharded (allgather with EP > 1,
+        see :meth:`_intermediate_ep_size`) each checkpoint tensor is first cut
+        into ``ep_size`` intermediate slices and the gate/up slices are then
+        re-interleaved rank-major into the per-expert transient, matching the
+        2-D re-declaration the HF load path feeds the engine. The cross-expert
+        concat is unchanged for ``weight1`` (rows stay expert-major) while
+        ``weight2`` concatenates rank-major.
+
+        Inverse is independent.
+        """
+        self._reject_nongated_grouped_experts(ctx)
+        ep_size = self._intermediate_ep_size()
+        _check_expert_checkpoint_layout(ctx.moe_expert_checkpoint_layout)
+        if ctx.moe_expert_checkpoint_layout == "packed":
+            self._reject_packed_intermediate_ep(ep_size)
+            return self._gen_packed_grouped_expert_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+        w1_local = "grouped_gemm_experts.weight1"
+        w2_local = "grouped_gemm_experts.weight2"
+        # Shared-tensor dedup (e.g. mtp_shared_last_layer reuse of the last
+        # transformer layer): the packed weights get registered under two
+        # structured paths and the alias plan excludes the non-canonical one.
+        # Both packed weights belong to the same physical MoE instance, so they
+        # share one exclusion fate; skip the whole coupled emission on exclusion.
+        if structured_name_prefix + w1_local in ctx.excluded_names:
+            return []
+        w1_model = resolve_single_name(
+            w1_local,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        w2_model = resolve_single_name(
+            w2_local,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        # Enclosing single-name scope (e.g. "...mlp") obtained by stripping the
+        # leaf local name off the resolved single name; used to build the
+        # transient per-expert model names that the concat consumes.
+        scope = strip_name_suffix(w1_model, w1_local)
+
+        up_gate_models = []
+        down_models = []
+        down_parts = []
+        statements = []
+        for e in range(self.num_experts):
+            gate_ckpt = resolve_checkpoint_name_from_anchor(
+                w1_model,
+                w1_local,
+                f"experts.{e}.gate_proj.weight",
+                ctx.checkpoint_name_prefix,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            up_ckpt = resolve_checkpoint_name_from_anchor(
+                w1_model,
+                w1_local,
+                f"experts.{e}.up_proj.weight",
+                ctx.checkpoint_name_prefix,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            down_ckpt = resolve_checkpoint_name_from_anchor(
+                w2_model,
+                w2_local,
+                f"experts.{e}.down_proj.weight",
+                ctx.checkpoint_name_prefix,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            # Per-expert model-side transient targets (not real params); the
+            # cross-expert concat below consumes them into the packed weights.
+            up_gate_model = join_name(scope, f"experts.{e}.up_gate_proj.weight")
+            down_model = join_name(scope, f"experts.{e}.down_proj.weight")
+            up_gate_models.append(up_gate_model)
+            if ep_size is None:
+                down_models.append(down_model)
+                # Grouped-GEMM checkpoint layout (the only one, see the
+                # docstring): transpose every checkpoint tensor and fuse
+                # gate/up on axis=1.
+                statements.append(
+                    f"{gate_ckpt}^T, {up_ckpt}^T -> {up_gate_model}, axis=1"
+                )
+                statements.append(f"{down_ckpt}^T -> {down_model}")
+                continue
+            # Intermediate-sharded: cut each checkpoint matrix into the
+            # ``ep_size`` intermediate slices the re-declared global layout
+            # expects, then re-interleave gate/up rank-major.
+            gate_slices = [
+                f"{up_gate_model}.gate_ep{r}" for r in range(ep_size)
+            ]
+            up_slices = [f"{up_gate_model}.up_ep{r}" for r in range(ep_size)]
+            down_slices = [f"{down_model}.ep{r}" for r in range(ep_size)]
+            interleaved = [
+                var
+                for r in range(ep_size)
+                for var in (gate_slices[r], up_slices[r])
+            ]
+            statements.append(
+                f"{gate_ckpt}^T -> {','.join(gate_slices)}, axis=1"
+            )
+            statements.append(f"{up_ckpt}^T -> {','.join(up_slices)}, axis=1")
+            statements.append(
+                f"{','.join(interleaved)} -> {up_gate_model}, axis=1"
+            )
+            statements.append(
+                f"{down_ckpt}^T -> {','.join(down_slices)}, axis=0"
+            )
+            down_parts.append(down_slices)
+
+        # Cross-expert concat: per-expert transients (left) -> packed weight
+        # (right), matching the ernie5_v2 reference grouped-GEMM statements.
+        # ``weight1`` rows are expert-major under both layouts. ``weight2`` rows
+        # are expert-major on the ordinary layout but rank-major-then-expert on
+        # the re-declared intermediate-sharded one, so its sources are walked
+        # rank-outer there.
+        statements.append(f"{','.join(up_gate_models)} -> {w1_model}, axis=0")
+        if ep_size is None:
+            w2_sources = down_models
+        else:
+            w2_sources = [
+                down_parts[e][r]
+                for r in range(ep_size)
+                for e in range(self.num_experts)
+            ]
+        statements.append(f"{','.join(w2_sources)} -> {w2_model}, axis=0")
+        return statements
+
+    def _gen_inv_grouped_expert_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Model->checkpoint generator for the grouped-GEMM / sonic cross-expert
+        fusion.
+
+        Independently mirrors :meth:`_gen_grouped_expert_aoa_statements` without
+        deriving from its text. Two stages: (1) split the packed ``weight1`` on
+        ``axis=0`` into per-expert transient ``up_gate_proj`` tensors and split
+        ``weight2`` on ``axis=0`` straight into the per-expert checkpoint
+        ``down_proj`` tensors; (2) per expert, de-fuse the ``up_gate_proj``
+        transient into the checkpoint ``gate``/``up``. The de-fuse is always on
+        ``axis=1`` with a per-tensor transpose of every checkpoint tensor
+        (``gate``/``up``/``down``), because the checkpoint-facing layout is the
+        grouped-GEMM one for every expert type -- :class:`SonicMoEExpert`
+        converts back to it in ``sharded_state_dict()``, so its compute-time
+        layout never reaches a checkpoint and must not be branched on here.
+
+        When the live weights are intermediate-sharded (allgather with EP > 1,
+        see :meth:`_intermediate_ep_size`) only stage (1) changes: the packed
+        weights are un-interleaved out of the rank-major re-declared layout
+        into exactly the same per-expert transients the ordinary layout
+        produces, so stage (2) is shared verbatim.
+        """
+        self._reject_nongated_grouped_experts(ctx)
+        ep_size = self._intermediate_ep_size()
+        _check_expert_checkpoint_layout(ctx.moe_expert_checkpoint_layout)
+        if ctx.moe_expert_checkpoint_layout == "packed":
+            self._reject_packed_intermediate_ep(ep_size)
+            return self._gen_inv_packed_grouped_expert_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+        w1_local = "grouped_gemm_experts.weight1"
+        w2_local = "grouped_gemm_experts.weight2"
+        # Mirror of the forward helper: skip the coupled emission when the
+        # packed weights are the non-canonical copy of a shared tensor.
+        if structured_name_prefix + w1_local in ctx.excluded_names:
+            return []
+        w1_model = resolve_single_name(
+            w1_local,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        w2_model = resolve_single_name(
+            w2_local,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        scope = strip_name_suffix(w1_model, w1_local)
+
+        gate_ckpts = []
+        up_ckpts = []
+        down_ckpts = []
+        up_gate_models = []
+        for e in range(self.num_experts):
+            gate_ckpts.append(
+                resolve_checkpoint_name_from_anchor(
+                    w1_model,
+                    w1_local,
+                    f"experts.{e}.gate_proj.weight",
+                    ctx.checkpoint_name_prefix,
+                    ctx.checkpoint_name_mapping,
+                    aoa_name_scope=aoa_name_scope,
+                    model_name_prefix=ctx.model_name_prefix,
+                )
+            )
+            up_ckpts.append(
+                resolve_checkpoint_name_from_anchor(
+                    w1_model,
+                    w1_local,
+                    f"experts.{e}.up_proj.weight",
+                    ctx.checkpoint_name_prefix,
+                    ctx.checkpoint_name_mapping,
+                    aoa_name_scope=aoa_name_scope,
+                    model_name_prefix=ctx.model_name_prefix,
+                )
+            )
+            down_ckpts.append(
+                resolve_checkpoint_name_from_anchor(
+                    w2_model,
+                    w2_local,
+                    f"experts.{e}.down_proj.weight",
+                    ctx.checkpoint_name_prefix,
+                    ctx.checkpoint_name_mapping,
+                    aoa_name_scope=aoa_name_scope,
+                    model_name_prefix=ctx.model_name_prefix,
+                )
+            )
+            up_gate_models.append(
+                join_name(scope, f"experts.{e}.up_gate_proj.weight")
+            )
+
+        # Split/de-fuse into per-expert intermediate names (model layout), then
+        # transpose each intermediate into its final checkpoint name. Distinct
+        # intermediate names keep every checkpoint target single-assignment;
+        # reusing a final name as its own transpose intermediate
+        # (``w1^T -> w1``) trips the inverse duplicate-target guard even though
+        # AOAEngine chains it correctly.
+        gate_intermediates = [
+            join_name(scope, f"experts.{e}.gate_proj.weight.intermediate")
+            for e in range(self.num_experts)
+        ]
+        up_intermediates = [
+            join_name(scope, f"experts.{e}.up_proj.weight.intermediate")
+            for e in range(self.num_experts)
+        ]
+        down_intermediates = [
+            join_name(scope, f"experts.{e}.down_proj.weight.intermediate")
+            for e in range(self.num_experts)
+        ]
+        if ep_size is None:
+            statements = [
+                f"{w1_model} -> {','.join(up_gate_models)}, axis=0",
+                f"{w2_model} -> {','.join(down_intermediates)}, axis=0",
+            ]
+        else:
+            statements = self._inv_intermediate_ep_unpack_statements(
+                w1_model,
+                w2_model,
+                up_gate_models,
+                down_intermediates,
+                ep_size,
+            )
+        for e in range(self.num_experts):
+            statements.append(
+                f"{up_gate_models[e]} -> {gate_intermediates[e]}, "
+                f"{up_intermediates[e]}, axis=1"
+            )
+            statements.append(f"{gate_intermediates[e]}^T -> {gate_ckpts[e]}")
+            statements.append(f"{up_intermediates[e]}^T -> {up_ckpts[e]}")
+            statements.append(f"{down_intermediates[e]}^T -> {down_ckpts[e]}")
+        return statements
+
+    def _inv_intermediate_ep_unpack_statements(
+        self,
+        w1_model,
+        w2_model,
+        up_gate_models,
+        down_intermediates,
+        ep_size,
+    ):
+        """Stage (1) of the inverse on the intermediate-sharded layout.
+
+        Replaces the two plain per-expert splits with an un-interleaving of the
+        rank-major re-declared global layout, landing on exactly the transients
+        the ordinary layout produces (``up_gate_models[e]`` holding gate/up as
+        the two contiguous halves of ``axis=1``, ``down_intermediates[e]``
+        holding the whole per-expert down projection), so the caller's stage (2)
+        is shared unchanged.
+
+        ``weight1`` ``[E*io, 2*I_full]``: columns are ``gate_r0|up_r0|gate_r1|
+        ...`` in ``I_local`` blocks, so cutting into ``2*ep_size`` blocks and
+        taking the even / odd ones regroups the full gate and up. Rows are
+        expert-major, hence the plain ``axis=0`` split afterwards.
+
+        ``weight2`` ``[E*I_full, io]``: rows are rank-outer, expert-inner, so
+        one expert's rows are ``ep_size`` disjoint blocks that have to be
+        gathered back per expert -- a plain ``axis=0`` split into ``E`` pieces
+        would mix experts.
+        """
+        num_experts = self.num_experts
+        blocks = [f"{w1_model}.ep_blk{i}" for i in range(2 * ep_size)]
+        gate_all = f"{w1_model}.gate_all"
+        up_all = f"{w1_model}.up_all"
+        gates = [f"{w1_model}.gate_e{e}" for e in range(num_experts)]
+        ups = [f"{w1_model}.up_e{e}" for e in range(num_experts)]
+        parts = [
+            [f"{w2_model}.r{r}e{e}" for e in range(num_experts)]
+            for r in range(ep_size)
+        ]
+        statements = [
+            f"{w1_model} -> {','.join(blocks)}, axis=1",
+            f"{','.join(blocks[0::2])} -> {gate_all}, axis=1",
+            f"{','.join(blocks[1::2])} -> {up_all}, axis=1",
+            f"{gate_all} -> {','.join(gates)}, axis=0",
+            f"{up_all} -> {','.join(ups)}, axis=0",
+        ]
+        statements += [
+            f"{gates[e]},{ups[e]} -> {up_gate_models[e]}, axis=1"
+            for e in range(num_experts)
+        ]
+        flat_parts = [part for row in parts for part in row]
+        statements.append(f"{w2_model} -> {','.join(flat_parts)}, axis=0")
+        statements += [
+            f"{','.join(parts[r][e] for r in range(ep_size))} -> "
+            f"{down_intermediates[e]}, axis=0"
+            for e in range(num_experts)
+        ]
+        return statements
+
+    def _gen_packed_grouped_expert_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Checkpoint->model generator for the ``"packed"`` expert layout.
+
+        The checkpoint packs every routed expert into two 3D tensors
+        (``experts.gate_up_proj`` ``[E, I*2, H]`` / ``experts.down_proj``
+        ``[E, H, I]``) that map onto the model grouped weights
+        (``grouped_gemm_experts.weight1`` ``[E, H, I*2]`` / ``weight2``
+        ``[E, I, H]``) by swapping the last two dims per expert, so the only
+        layout transform this branch owns is ``permute='[0,2,1]'`` (an
+        involution reused verbatim by the inverse). The checkpoint<->model
+        *name* divergence is a model-level ``aoa_checkpoint_name_mapping``
+        concern, resolved here through ``resolve_names``. Inverse is
+        independent.
+
+        (Selected by ``ctx.moe_expert_checkpoint_layout == "packed"``.)
+        """
+        statements = []
+        for local_name in self._GROUPED_EXPERT_LOCAL_NAMES:
+            checkpoint_name, model_name = resolve_names(
+                local_name,
+                ctx.checkpoint_name_prefix,
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            cast = format_dtype_cast_attr(
+                resolve_dtype_cast_rule(
+                    model_name, ctx.dtype_cast_rules, ctx.model_name_prefix
+                )
+            )
+            if not cast:
+                statements.append(
+                    f"{checkpoint_name} -> {model_name}, permute='[0,2,1]'"
+                )
+                continue
+            # A cast rides only a 1->1 statement whose sole attributes are the
+            # dtype pair, so the permute gets its own statement first.
+            permuted = f"{model_name}._perm"
+            statements.append(
+                f"{checkpoint_name} -> {permuted}, permute='[0,2,1]'"
+            )
+            statements.append(f"{permuted} -> {model_name}{cast}")
+        return statements
+
+    def _gen_inv_packed_grouped_expert_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Model->checkpoint inverse for the ``"packed"`` expert layout.
+
+        Independently mirrors
+        :meth:`_gen_packed_grouped_expert_aoa_statements` without deriving from
+        its text: the same ``permute='[0,2,1]'`` (its own inverse) is re-emitted
+        with the endpoints swapped and the dtype cast rendered for the inverse
+        direction.
+        """
+        statements = []
+        for local_name in self._GROUPED_EXPERT_LOCAL_NAMES:
+            checkpoint_name, model_name = resolve_names(
+                local_name,
+                ctx.checkpoint_name_prefix,
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            cast = format_inv_dtype_cast_attr(
+                resolve_dtype_cast_rule(
+                    model_name, ctx.dtype_cast_rules, ctx.model_name_prefix
+                )
+            )
+            if not cast:
+                statements.append(
+                    f"{model_name} -> {checkpoint_name}, permute='[0,2,1]'"
+                )
+                continue
+            permuted = f"{model_name}._inv_perm"
+            statements.append(f"{model_name} -> {permuted}, permute='[0,2,1]'")
+            statements.append(f"{permuted} -> {checkpoint_name}{cast}")
+        return statements
 
 
 class Gemma4TopKRouter(TopKRouter):

--- a/src/paddlefleet/transformer/moe/moe_router.py
+++ b/src/paddlefleet/transformer/moe/moe_router.py
@@ -42,6 +42,13 @@ from paddle.distributed.fleet.meta_parallel.zero_bubble_utils import (
     WeightGradStore,
 )
 from paddle.distributed.fleet.utils.sequence_parallel_utils import ScatterOp
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    format_dtype_cast_attr,
+    format_inv_dtype_cast_attr,
+    resolve_dtype_cast_rule,
+    resolve_names,
+    should_skip,
+)
 
 from paddlefleet.context_parallel_utils import (
     ContextParallelAllGatherOp,
@@ -1970,3 +1977,78 @@ class TopKRouter(StandardMoERouter):
             l_aux,
             l_zloss,
         )
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model AOA for the router.
+
+        The router owns no fused layout: its own ``local_state_dict`` (this
+        layer only, no sub-layers) is the sole enumeration source, so hash
+        layers naturally cover ``weight`` / ``tid2eid`` and normal layers cover
+        the ``weight`` / ``weight_1`` / ``e_score_correction_bias`` /
+        ``routed_scaling_factor_param`` that actually exist. Every statement is
+        a plain rename; a dtype cast suffix is appended when the model rules
+        match. dtype is never guessed from ``model_type`` and never written as a
+        literal ``dtype=``.
+        """
+        statements = []
+        local_state_dict = self.state_dict(
+            structured_name_prefix="", include_sublayers=False
+        )
+        for name in local_state_dict:
+            if structured_name_prefix + name in ctx.excluded_names:
+                continue
+            checkpoint_name, model_name = resolve_names(
+                name,
+                ctx.checkpoint_name_prefix,
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            cast = format_dtype_cast_attr(
+                resolve_dtype_cast_rule(
+                    model_name, ctx.dtype_cast_rules, ctx.model_name_prefix
+                )
+            )
+            if should_skip(checkpoint_name, model_name, cast):
+                continue
+            statements.append(f"{checkpoint_name} -> {model_name}{cast}")
+        return statements
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) AOA for the router.
+
+        Independently generated: the same ``local_state_dict`` keys are
+        resolved, but emitted model -> checkpoint with the dtype cast endpoints
+        swapped.
+        """
+        statements = []
+        local_state_dict = self.state_dict(
+            structured_name_prefix="", include_sublayers=False
+        )
+        for name in local_state_dict:
+            if structured_name_prefix + name in ctx.excluded_names:
+                continue
+            checkpoint_name, model_name = resolve_names(
+                name,
+                ctx.checkpoint_name_prefix,
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            cast = format_inv_dtype_cast_attr(
+                resolve_dtype_cast_rule(
+                    model_name, ctx.dtype_cast_rules, ctx.model_name_prefix
+                )
+            )
+            if should_skip(checkpoint_name, model_name, cast):
+                continue
+            statements.append(f"{model_name} -> {checkpoint_name}{cast}")
+        return statements

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -21,7 +21,7 @@ import functools
 import logging
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 import paddle.nn.functional as F
 
@@ -1950,6 +1950,40 @@ class TransformerConfig(ModelParallelConfig):
     deepep_buffer_configs: dict | None = None
     """DeepEP buffer configuration."""
 
+    ####################
+    # AOA generator migration marker (code-level, not a config item)
+    ####################
+
+    aoa_modular: ClassVar[bool] = False
+    """Whether this model has been migrated to modular AOA.
+
+    Deliberately a ``ClassVar``, so it is not a dataclass field -- it records a
+    property of the model's *code*, not a choice the user makes per run. A
+    provider subclass flips it to ``True`` once its components carry their own
+    AOA markers and its hand-written generator is gone (see
+    ``Ernie5V2Provider``). Because ``register_attributes`` would otherwise turn
+    an ``aoa_modular`` key in a yaml / ``config.json`` into an instance
+    attribute that shadows this ``ClassVar``, ``_process_attribute`` rejects
+    that key outright, so it can only ever be set in a class body.
+
+    One marker drives two coupled behaviours, which is why they cannot be
+    separate switches:
+
+    * whole-model AOA generation: ``True`` -> module-tree recursion
+      (``gen_whole_model_aoa``), ``False`` -> the per-model hand-written
+      generator attached on the model instance (``model._gen_aoa_config``).
+    * empty-layer naming: ``True`` -> ``EmptyLayer`` instances get their own
+      ``empty_layers.<i>`` namespace and transformer layers are numbered
+      ``layers.0 .. layers.{num_hidden_layers - 1}`` regardless of
+      ``num_empty_layers_add_in_head=H``; ``False`` -> both kinds share one
+      ``layers.<i>`` counter, so the first transformer layer is ``layers.H``.
+
+    The modular generator is written against decoupled numbering and every
+    legacy generator against the shared counter, so mixing the two would
+    silently corrupt checkpoint keys. Keeping a single marker makes that
+    mixed state inexpressible.
+    """
+
     # Field name mapping rules: HuggingFace config.json name -> TransformerConfig name
     transform_rules = {
         # DSA field mapping
@@ -2080,6 +2114,12 @@ class TransformerConfig(ModelParallelConfig):
                 f"{self.renamed_config_keys_when_set[key]} Update the config "
                 f"that still sets {key}={value!r}; it would otherwise be "
                 f"silently ignored."
+            )
+        elif key == "aoa_modular":
+            raise ValueError(
+                "aoa_modular is a code-level modular-AOA migration marker "
+                "(a ClassVar flipped in a provider class body), not a config "
+                "field; it must never be set from yaml / config.json."
             )
         else:
             setattr(self, key, value)

--- a/src/paddlefleet/transformer/transformer_encoder.py
+++ b/src/paddlefleet/transformer/transformer_encoder.py
@@ -167,11 +167,31 @@ class TransformerEncoder(PipelineLayer):
 
     def get_encoder_layer_desc_list(self, layers, spec, name_prefix):
         i = 0
+        empty_index = 0
+
+        def next_empty_layer_name():
+            """Name for the next EmptyLayer, advancing the right counter.
+
+            With ``aoa_modular`` empty layers live in their own
+            ``empty_layers.<i>`` namespace and do not consume a ``layers.<i>``
+            slot, so transformer layers start at ``layers.0``. Otherwise both
+            kinds share the ``i`` counter. Kept identical to the language
+            tower's rule in ``GPTModel.get_layer_desc_list`` so the two towers
+            never name layers differently.
+            """
+            nonlocal i, empty_index
+            if getattr(getattr(self, "config", None), "aoa_modular", False):
+                name = f"{name_prefix}.empty_layers.{empty_index}"
+            else:
+                name = f"{name_prefix}.layers.{i}"
+                i += 1
+            empty_index += 1
+            return name
+
         for head_empty_layer in spec.head_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(head_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(head_empty_layer), next_empty_layer_name()
             )
-            i += 1
         for transformer_layer_spec in spec.transformer_layers:
             self.add_sequential_layer(
                 layers,
@@ -181,9 +201,8 @@ class TransformerEncoder(PipelineLayer):
             i += 1
         for tail_empty_layer in spec.tail_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(tail_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(tail_empty_layer), next_empty_layer_name()
             )
-            i += 1
 
     def overlapped_forward_backward(
         self,

--- a/tests/single_card_tests/aoa/test_aoa_config_protocol.py
+++ b/tests/single_card_tests/aoa/test_aoa_config_protocol.py
@@ -1,0 +1,289 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: pins the whole-model config-field protocol normalization -- the single
+# place that resolves the model-declared AOA name / dtype / layout attributes
+# (``build_aoa_context`` via ``_protocol_value``) and the MTP checkpoint-prefix
+# attributes (``MTPCheckpointPrefixSpec`` via
+# ``resolve_mtp_checkpoint_prefix_spec``). An unmigrated model (without an
+# explicit mapping) inherits the shared ERNIE mapping; an external model
+# overrides it via that attribute. Also carries a source-level lint pinning
+# the direction-independence contract (no ``direction`` / ``reverse`` param, a
+# ``_fwd_`` / ``_inv_`` helper split with no cross-direction calls and no
+# ``aoa_config_reverse`` call).
+import dataclasses
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+from paddle.distributed.flex_checkpoint.aoa.generation import AOAContext
+
+from paddlefleet.models.gpt.aoa_generator import (
+    DEFAULT_CHECKPOINT_NAME_MAPPING,
+    DEFAULT_CHECKPOINT_NAME_PREFIX,
+    DEFAULT_GATE_CHECKPOINT_LAYOUT,
+    DEFAULT_MLP_GATE_UP_FUSED,
+    DEFAULT_MODEL_NAME_PREFIX,
+    DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT,
+    DEFAULT_QKV_CHECKPOINT_PREFUSED,
+    FleetAOAContext,
+    MTPCheckpointPrefixSpec,
+    build_aoa_context,
+    resolve_mtp_checkpoint_prefix_spec,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+class _Cfg:
+    """Bare config stand-in; only the attributes a test sets are present."""
+
+
+class _FakeModel:
+    """Duck-types the attributes ``build_aoa_context`` reads.
+
+    ``_pipeline_name_mapping`` is pre-populated (non-None) so the idempotent
+    ``_set_pipeline_name_mapping`` side effect is skipped in the happy path.
+    ``_model_name_prefix()`` stands in for the live model's single-name root,
+    which is where the context takes it from; the value is held in a separately
+    named attribute so it does not shadow the method.
+    """
+
+    def __init__(
+        self,
+        pp_to_single_mapping=None,
+        model_name_prefix=DEFAULT_MODEL_NAME_PREFIX,
+    ):
+        self._pipeline_name_mapping = {}
+        self._pp_to_single_mapping = pp_to_single_mapping or {}
+        self._model_name_prefix_value = model_name_prefix
+
+    def _set_pipeline_name_mapping(self):
+        self._pipeline_name_mapping = {}
+
+    def _model_name_prefix(self):
+        return self._model_name_prefix_value
+
+
+class TestBuildAOAContextDefaults(unittest.TestCase):
+    def test_unmigrated_config_uses_ernie_defaults(self):
+        model = _FakeModel(pp_to_single_mapping={"s": "s"})
+        ctx = build_aoa_context(model, _Cfg())
+        self.assertIsInstance(ctx, AOAContext)
+        self.assertIsInstance(ctx, FleetAOAContext)
+        self.assertEqual(
+            ctx.checkpoint_name_prefix, DEFAULT_CHECKPOINT_NAME_PREFIX
+        )
+        self.assertEqual(
+            dict(ctx.checkpoint_name_mapping), DEFAULT_CHECKPOINT_NAME_MAPPING
+        )
+        self.assertEqual(dict(ctx.dtype_cast_rules), {})
+        self.assertEqual(ctx.model_name_prefix, DEFAULT_MODEL_NAME_PREFIX)
+        self.assertEqual(dict(ctx.pp_to_single_mapping), {"s": "s"})
+
+    def test_layout_defaults(self):
+        ctx = build_aoa_context(_FakeModel(), _Cfg())
+        self.assertEqual(
+            ctx.gate_checkpoint_layout, DEFAULT_GATE_CHECKPOINT_LAYOUT
+        )
+        self.assertEqual(
+            ctx.qkv_checkpoint_prefused, DEFAULT_QKV_CHECKPOINT_PREFUSED
+        )
+        self.assertEqual(
+            ctx.moe_expert_checkpoint_layout,
+            DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT,
+        )
+        self.assertEqual(ctx.mlp_gate_up_fused, DEFAULT_MLP_GATE_UP_FUSED)
+        self.assertFalse(ctx.mapping_proj_checkpoint_transposed)
+
+    def test_mapping_is_copied_not_aliased(self):
+        ctx = build_aoa_context(_FakeModel(), _Cfg())
+        self.assertIsNot(
+            ctx.checkpoint_name_mapping, DEFAULT_CHECKPOINT_NAME_MAPPING
+        )
+
+    def test_explicit_empty_checkpoint_mapping_overrides_default(self):
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_mapping = {}
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(dict(ctx.checkpoint_name_mapping), {})
+
+    def test_explicit_empty_checkpoint_prefix_is_preserved(self):
+        # A checkpoint rooted at the top level (DeepSeek V4) declares "" and
+        # must not silently fall back to the Ernie-series default.
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_prefix = ""
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(ctx.checkpoint_name_prefix, "")
+
+    def test_explicit_none_falls_back_to_default(self):
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_prefix = None
+        cfg.aoa_dtype_cast_rules = None
+        cfg.aoa_qkv_checkpoint_prefused = None
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(
+            ctx.checkpoint_name_prefix, DEFAULT_CHECKPOINT_NAME_PREFIX
+        )
+        self.assertEqual(dict(ctx.dtype_cast_rules), {})
+        self.assertEqual(
+            ctx.qkv_checkpoint_prefused, DEFAULT_QKV_CHECKPOINT_PREFUSED
+        )
+
+
+class TestBuildAOAContextOverrides(unittest.TestCase):
+    def test_name_and_dtype_overrides_propagate(self):
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_prefix = "hf"
+        cfg.aoa_checkpoint_name_mapping = {"a.weight": "b.weight"}
+        cfg.aoa_dtype_cast_rules = {
+            "x": {"checkpoint_dtype": "bfloat16", "model_dtype": "float32"}
+        }
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(ctx.checkpoint_name_prefix, "hf")
+        self.assertEqual(
+            dict(ctx.checkpoint_name_mapping), {"a.weight": "b.weight"}
+        )
+        self.assertEqual(
+            dict(ctx.dtype_cast_rules),
+            {"x": {"checkpoint_dtype": "bfloat16", "model_dtype": "float32"}},
+        )
+
+    def test_layout_overrides_propagate(self):
+        cfg = _Cfg()
+        cfg.aoa_gate_checkpoint_layout = "interleaved"
+        cfg.aoa_qkv_checkpoint_prefused = True
+        cfg.aoa_moe_expert_checkpoint_layout = "packed"
+        cfg.aoa_mapping_proj_checkpoint_transposed = True
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(ctx.gate_checkpoint_layout, "interleaved")
+        self.assertTrue(ctx.qkv_checkpoint_prefused)
+        self.assertEqual(ctx.moe_expert_checkpoint_layout, "packed")
+        self.assertTrue(ctx.mapping_proj_checkpoint_transposed)
+
+    def test_falsy_mlp_gate_up_fused_is_preserved(self):
+        # Qwen3-VL declares False; a truthiness-based default would swallow it.
+        cfg = _Cfg()
+        cfg.aoa_mlp_gate_up_fused = False
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertFalse(ctx.mlp_gate_up_fused)
+
+    def test_model_name_prefix_comes_from_the_live_model(self):
+        # The model single-name root comes from the live model, not the config:
+        # it must stay the same value that names the pipeline layers.
+        ctx = build_aoa_context(_FakeModel(model_name_prefix="root"), _Cfg())
+        self.assertEqual(ctx.model_name_prefix, "root")
+
+    def test_context_is_frozen(self):
+        ctx = build_aoa_context(_FakeModel(), _Cfg())
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            ctx.checkpoint_name_prefix = "mut"
+
+    def test_none_pipeline_mapping_triggers_side_effect(self):
+        model = _FakeModel()
+        model._pipeline_name_mapping = None
+        ctx = build_aoa_context(model, _Cfg())
+        self.assertIsNotNone(model._pipeline_name_mapping)
+        self.assertIsInstance(ctx, AOAContext)
+
+
+class TestMTPCheckpointPrefixSpec(unittest.TestCase):
+    def test_defaults(self):
+        spec = resolve_mtp_checkpoint_prefix_spec(_Cfg())
+        self.assertEqual(spec.checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertFalse(spec.is_absolute)
+
+    def test_transformer_inherits_own_prefix(self):
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix = "mtp.$LAYER_ID"
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertEqual(spec.checkpoint_prefix, "mtp.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "mtp.$LAYER_ID")
+
+    def test_transformer_prefix_override_independent(self):
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix = "mtp.$LAYER_ID"
+        cfg.aoa_mtp_transformer_checkpoint_prefix = "mtp.$LAYER_ID.tf"
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertEqual(spec.checkpoint_prefix, "mtp.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "mtp.$LAYER_ID.tf")
+
+    def test_absolute_flag(self):
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix_absolute = True
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertTrue(spec.is_absolute)
+
+    def test_bare_spec_defaults(self):
+        spec = MTPCheckpointPrefixSpec()
+        self.assertEqual(spec.checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertFalse(spec.is_absolute)
+
+    def test_explicit_empty_mtp_prefix_is_preserved(self):
+        # A top-level MTP checkpoint declares "" and must not silently fall
+        # back to the layers.$LAYER_ID default; the inner transformer prefix
+        # then inherits that same "".
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix = ""
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertEqual(spec.checkpoint_prefix, "")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "")
+
+
+class TestAoaModularNotConfigInjectable(unittest.TestCase):
+    """Pins that ``aoa_modular`` is a code-level marker, not a config field.
+
+    The marker is a ``ClassVar`` a migrated provider flips in its class body;
+    it must never be reachable from a yaml / ``config.json``. Two independent
+    surfaces enforce this and this test pins both: the ``ClassVar`` keeps it
+    out of the dataclass fields (so it is neither constructor-settable nor
+    instance-shadowed), and ``_process_attribute`` rejects the key outright on
+    the ``from_config`` load path.
+    """
+
+    def test_classvar_default_is_false(self):
+        self.assertFalse(TransformerConfig.aoa_modular)
+
+    def test_aoa_modular_is_not_a_dataclass_field(self):
+        field_names = {f.name for f in dataclasses.fields(TransformerConfig)}
+        self.assertNotIn("aoa_modular", field_names)
+
+    def test_from_config_rejects_aoa_modular_key(self):
+        # Rejected by the key itself, independent of the value carried.
+        for value in (True, False):
+            with self.assertRaises(ValueError):
+                TransformerConfig.from_config(
+                    SimpleNamespace(aoa_modular=value)
+                )
+
+    def test_reject_is_narrow(self):
+        # An unrelated attribute still flows through the normal setattr path.
+        inst = object.__new__(TransformerConfig)
+        inst._process_attribute("some_unrelated_attr", 123)
+        self.assertEqual(inst.some_unrelated_attr, 123)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_linear_component.py
+++ b/tests/single_card_tests/aoa/test_aoa_linear_component.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: the Linear family (``Linear`` / ``ColumnParallelLinear`` /
+# ``RowParallelLinear``) share a single module-level helper
+# ``gen_linear_aoa_statements`` / ``gen_linear_inv_aoa_statements``. This test
+# pins the coverage contract: ``weight`` carries ``^T``; bias / buffers use
+# identity only when their resolved names differ or a dtype cast is required;
+# and excluded aliases are omitted in both directions.
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+
+import paddle
+
+from paddlefleet.models.gpt.aoa_generator import (
+    FleetAOAContext,
+)
+
+
+def _ctx(
+    dtype_cast_rules=None,
+    *,
+    checkpoint_name_prefix="hf",
+    model_name_prefix="model",
+    excluded_names=frozenset(),
+):
+    return FleetAOAContext(
+        config=None,
+        checkpoint_name_prefix=checkpoint_name_prefix,
+        pp_to_single_mapping={},
+        checkpoint_name_mapping={},
+        dtype_cast_rules=dtype_cast_rules or {},
+        model_name_prefix=model_name_prefix,
+        excluded_names=excluded_names,
+    )
+
+
+def _make_linear_leaf(bias=False, buffer=False):
+    """Binds the Linear family AOA helpers onto a controllable stand-in.
+
+    The real ``Linear`` needs a live TP process group to construct, so we bind
+    the two override methods (which just forward to the module-level helpers)
+    onto a lightweight ``paddle.nn.Layer`` carrying real params / buffers.
+    """
+    from paddlefleet.tensor_parallel.layers import Linear
+
+    class _LinearLeaf(paddle.nn.Layer):
+        gen_aoa_statements = Linear.gen_aoa_statements
+        gen_inv_aoa_statements = Linear.gen_inv_aoa_statements
+
+        def __init__(self):
+            super().__init__()
+            self.weight = self.create_parameter(shape=[2, 2])
+            if bias:
+                self.bias = self.create_parameter(shape=[2])
+            if buffer:
+                # A persistable buffer must appear in state_dict and therefore
+                # get an identity statement (no orphan target).
+                self.register_buffer(
+                    "some_buf", paddle.zeros([2]), persistable=True
+                )
+                # A non-persistable buffer must NOT appear (no statement).
+                self.register_buffer(
+                    "tmp_buf", paddle.zeros([2]), persistable=False
+                )
+
+    return _LinearLeaf
+
+
+_PFX = "model.layers.0.mlp.down_proj."
+_W_CK = "hf.layers.0.mlp.down_proj.weight"
+_W_MD = "model.layers.0.mlp.down_proj.weight"
+
+
+class TestLinearClassContract(unittest.TestCase):
+    def test_three_linear_classes_override(self):
+        from paddlefleet.tensor_parallel.layers import (
+            ColumnParallelLinear,
+            Linear,
+            RowParallelLinear,
+        )
+
+        for cls in (Linear, ColumnParallelLinear, RowParallelLinear):
+            self.assertIn("gen_aoa_statements", cls.__dict__)
+            self.assertIn("gen_inv_aoa_statements", cls.__dict__)
+
+
+class TestLinearForward(unittest.TestCase):
+    def test_weight_transposed_bias_and_buffer_identity(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        # weight is transposed
+        self.assertIn(f"{_W_CK}^T -> {_W_MD}", stmts)
+        # bias is identity (no ^T)
+        self.assertIn(
+            "hf.layers.0.mlp.down_proj.bias -> "
+            "model.layers.0.mlp.down_proj.bias",
+            stmts,
+        )
+        # persistable buffer is identity, non-persistable buffer is absent
+        self.assertIn(
+            "hf.layers.0.mlp.down_proj.some_buf -> "
+            "model.layers.0.mlp.down_proj.some_buf",
+            stmts,
+        )
+        self.assertFalse(any("tmp_buf" in s for s in stmts))
+
+    def test_no_orphan_targets(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        # Every own state_dict key (weight/bias/some_buf) has exactly one
+        # producing statement; tmp_buf (non-persistable) has none.
+        self.assertEqual(len(stmts), 3)
+
+    def test_bias_absent_when_not_present(self):
+        model = _make_linear_leaf(bias=False, buffer=False)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        self.assertEqual(stmts, [f"{_W_CK}^T -> {_W_MD}"])
+
+    def test_same_name_identity_is_omitted(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        ctx = _ctx(checkpoint_name_prefix="model", model_name_prefix="model")
+        stmts = model.gen_aoa_statements(ctx, structured_name_prefix=_PFX)
+        self.assertEqual(stmts, [f"{_W_MD}^T -> {_W_MD}"])
+
+    def test_excluded_weight_is_omitted_in_forward_and_inverse(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        ctx = _ctx(excluded_names=frozenset({_PFX + "weight"}))
+
+        forward = model.gen_aoa_statements(ctx, structured_name_prefix=_PFX)
+        inverse = model.gen_inv_aoa_statements(ctx, structured_name_prefix=_PFX)
+
+        self.assertNotIn(f"{_W_CK}^T -> {_W_MD}", forward)
+        self.assertNotIn(f"{_W_MD}^T -> {_W_CK}", inverse)
+
+
+class TestLinearInverse(unittest.TestCase):
+    def test_weight_transposed_back_endpoints_swapped(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        stmts = model.gen_inv_aoa_statements(
+            _ctx(), structured_name_prefix=_PFX
+        )
+        self.assertIn(f"{_W_MD}^T -> {_W_CK}", stmts)
+        self.assertIn(
+            "model.layers.0.mlp.down_proj.bias -> "
+            "hf.layers.0.mlp.down_proj.bias",
+            stmts,
+        )
+        self.assertIn(
+            "model.layers.0.mlp.down_proj.some_buf -> "
+            "hf.layers.0.mlp.down_proj.some_buf",
+            stmts,
+        )
+        self.assertEqual(len(stmts), 3)
+
+
+class TestLinearDtypeCast(unittest.TestCase):
+    def test_forward_and_inverse_cast_endpoints(self):
+        rules = {
+            "layers.0.mlp.down_proj.weight": {
+                "checkpoint_dtype": "bfloat16",
+                "model_dtype": "float32",
+            }
+        }
+        model = _make_linear_leaf(bias=False)()
+        fwd = model.gen_aoa_statements(_ctx(rules), structured_name_prefix=_PFX)
+        self.assertEqual(
+            fwd,
+            [
+                f"{_W_CK}^T -> {_W_MD}, "
+                "src_dtype='bfloat16', dst_dtype='float32'"
+            ],
+        )
+        inv = model.gen_inv_aoa_statements(
+            _ctx(rules), structured_name_prefix=_PFX
+        )
+        self.assertEqual(
+            inv,
+            [
+                f"{_W_MD}^T -> {_W_CK}, "
+                "src_dtype='float32', dst_dtype='bfloat16'"
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_mlp_component.py
+++ b/tests/single_card_tests/aoa/test_aoa_mlp_component.py
@@ -1,0 +1,215 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: the gated ``MLP`` fuses the checkpoint ``gate_proj`` and ``up_proj``
+# (each transposed) into the model ``up_gate_proj`` via the ``fused_ffn``
+# macro, adds an optional fused bias (no transpose), then delegates
+# ``down_proj`` to the Linear family. MLP has no own parameters/buffers of its
+# own; every statement comes from the fused pair or the delegated ``down_proj``
+# leaf. This test pins that contract and the independent inverse split.
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+
+import paddle
+
+from paddlefleet.models.gpt.aoa_generator import (
+    FleetAOAContext,
+)
+
+
+def _ctx(dtype_cast_rules=None):
+    return FleetAOAContext(
+        config=None,
+        checkpoint_name_prefix="hf",
+        pp_to_single_mapping={},
+        checkpoint_name_mapping={},
+        dtype_cast_rules=dtype_cast_rules or {},
+        model_name_prefix="model",
+        excluded_names=frozenset(),
+    )
+
+
+def _make_linear_leaf(bias=False):
+    from paddlefleet.tensor_parallel.layers import Linear
+
+    class _LinearLeaf(paddle.nn.Layer):
+        gen_aoa_statements = Linear.gen_aoa_statements
+        gen_inv_aoa_statements = Linear.gen_inv_aoa_statements
+
+        def __init__(self):
+            super().__init__()
+            self.weight = self.create_parameter(shape=[2, 2])
+            self.bias = self.create_parameter(shape=[2]) if bias else None
+
+    return _LinearLeaf
+
+
+def _make_mlp_leaf(up_gate_bias=False, down_bias=False):
+    """Binds the gated MLP AOA overrides onto a controllable stand-in.
+
+    ``up_gate_proj`` only needs a ``.bias`` attribute (it gates the fused-bias
+    statement and is never recursed); ``down_proj`` is a real Linear leaf that
+    the MLP delegates to.
+    """
+    from paddlefleet.transformer.mlp import MLP
+
+    up_gate_cls = _make_linear_leaf(bias=up_gate_bias)
+    down_cls = _make_linear_leaf(bias=down_bias)
+
+    class _MLPLeaf(paddle.nn.Layer):
+        gen_aoa_statements = MLP.gen_aoa_statements
+        gen_inv_aoa_statements = MLP.gen_inv_aoa_statements
+        _gen_up_gate_fusion_aoa_statements = (
+            MLP._gen_up_gate_fusion_aoa_statements
+        )
+        _gen_inv_up_gate_fusion_aoa_statements = (
+            MLP._gen_inv_up_gate_fusion_aoa_statements
+        )
+        _gen_up_gate_bias_aoa_statements = MLP._gen_up_gate_bias_aoa_statements
+        _gen_inv_up_gate_bias_aoa_statements = (
+            MLP._gen_inv_up_gate_bias_aoa_statements
+        )
+        _gen_up_gate_bias_fusion_aoa_statements = (
+            MLP._gen_up_gate_bias_fusion_aoa_statements
+        )
+        _gen_inv_up_gate_bias_fusion_aoa_statements = (
+            MLP._gen_inv_up_gate_bias_fusion_aoa_statements
+        )
+
+        def __init__(self):
+            super().__init__()
+            self.up_gate_proj = up_gate_cls()
+            self.down_proj = down_cls()
+
+    return _MLPLeaf
+
+
+_PFX = "model.layers.0.mlp."
+_HF = "hf.layers.0.mlp."
+_MD = "model.layers.0.mlp."
+
+
+class TestMLPClassContract(unittest.TestCase):
+    def test_override_present(self):
+        from paddlefleet.transformer.mlp import MLP
+
+        for name in (
+            "gen_aoa_statements",
+            "gen_inv_aoa_statements",
+            "_gen_up_gate_fusion_aoa_statements",
+            "_gen_inv_up_gate_fusion_aoa_statements",
+            "_gen_up_gate_bias_aoa_statements",
+            "_gen_inv_up_gate_bias_aoa_statements",
+            "_gen_up_gate_bias_fusion_aoa_statements",
+            "_gen_inv_up_gate_bias_fusion_aoa_statements",
+        ):
+            self.assertIn(name, MLP.__dict__)
+
+
+class TestMLPForward(unittest.TestCase):
+    def test_fused_ffn_and_down_proj_delegation(self):
+        model = _make_mlp_leaf(up_gate_bias=False, down_bias=False)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        self.assertEqual(
+            stmts,
+            [
+                f"{_HF}gate_proj.weight^T, {_HF}up_proj.weight^T "
+                f"-> {_MD}up_gate_proj.weight, fused_ffn",
+                f"{_HF}down_proj.weight^T -> {_MD}down_proj.weight",
+            ],
+        )
+
+    def test_fused_bias_present_when_up_gate_has_bias(self):
+        model = _make_mlp_leaf(up_gate_bias=True, down_bias=True)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        # fused bias (no transpose) sits between the fused weight and down_proj;
+        # the single bias axis has to be named explicitly for fused_ffn
+        self.assertIn(
+            f"{_HF}gate_proj.bias, {_HF}up_proj.bias "
+            f"-> {_MD}up_gate_proj.bias, fused_ffn, axis=0",
+            stmts,
+        )
+        # down_proj leaf now carries its own bias identity too
+        self.assertIn(f"{_HF}down_proj.bias -> {_MD}down_proj.bias", stmts)
+
+
+class TestMLPInverse(unittest.TestCase):
+    def test_fused_split_and_down_proj_delegation(self):
+        model = _make_mlp_leaf(up_gate_bias=True, down_bias=False)()
+        stmts = model.gen_inv_aoa_statements(
+            _ctx(), structured_name_prefix=_PFX
+        )
+        # The fused weight splits onto model-side half names (no ^T: fused_ffn
+        # emits its halves on the target side), then each half is transposed
+        # back onto its checkpoint name.
+        self.assertIn(
+            f"{_MD}up_gate_proj.weight "
+            f"-> {_MD}gate_proj.weight, {_MD}up_proj.weight, fused_ffn",
+            stmts,
+        )
+        self.assertIn(
+            f"{_MD}gate_proj.weight^T -> {_HF}gate_proj.weight", stmts
+        )
+        self.assertIn(f"{_MD}up_proj.weight^T -> {_HF}up_proj.weight", stmts)
+        # The 1-D bias needs no transpose, so it splits straight onto the
+        # checkpoint names in one statement.
+        self.assertIn(
+            f"{_MD}up_gate_proj.bias "
+            f"-> {_HF}gate_proj.bias, {_HF}up_proj.bias, fused_ffn, axis=0",
+            stmts,
+        )
+        # down_proj inverse transpose (endpoints swapped)
+        self.assertIn(
+            f"{_MD}down_proj.weight^T -> {_HF}down_proj.weight", stmts
+        )
+
+
+class TestMLPDtypeCast(unittest.TestCase):
+    def test_down_proj_cast_endpoints(self):
+        rules = {
+            "layers.0.mlp.down_proj.weight": {
+                "checkpoint_dtype": "bfloat16",
+                "model_dtype": "float32",
+            }
+        }
+        model = _make_mlp_leaf(up_gate_bias=False, down_bias=False)()
+        fwd = model.gen_aoa_statements(_ctx(rules), structured_name_prefix=_PFX)
+        self.assertIn(
+            f"{_HF}down_proj.weight^T -> {_MD}down_proj.weight, "
+            "src_dtype='bfloat16', dst_dtype='float32'",
+            fwd,
+        )
+        inv = model.gen_inv_aoa_statements(
+            _ctx(rules), structured_name_prefix=_PFX
+        )
+        self.assertIn(
+            f"{_MD}down_proj.weight^T -> {_HF}down_proj.weight, "
+            "src_dtype='float32', dst_dtype='bfloat16'",
+            inv,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_mlp_nongated_component.py
+++ b/tests/single_card_tests/aoa/test_aoa_mlp_nongated_component.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: the base ``MLP`` NON-gated checkpoint layout, selected by the AOA flag
+# ``ctx.mlp_gate_up_fused = False`` (declared per-model, e.g. the Qwen3-VL vision
+# tower's ``aoa_mlp_gate_up_fused = False``). The default gated layout
+# UNCONDITIONALLY fuses checkpoint ``gate_proj`` + ``up_proj`` into
+# ``up_gate_proj`` via ``fused_ffn``. The non-gated layout instead treats
+# ``up_gate_proj`` / ``down_proj`` as two plain Linears with no gate/up split,
+# delegating both to the generic Linear family (plain ``^T`` weight renames +
+# identity bias, NO ``fused_ffn``).
+#
+# We bind the base ``MLP`` non-gated head helpers onto a stand-in that owns real
+# ``paddle.nn.Layer`` Linear children (whose generators route through the shared
+# ``gen_linear_(inv_)aoa_statements`` helpers), which exercises the delegation
+# contract without the heavy TP-linear ``MLP.__init__``. We also assert the
+# flag-routing contract on the real ``MLP`` class.
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+
+import paddle
+
+from paddlefleet.models.gpt.aoa_generator import (
+    FleetAOAContext,
+)
+from paddlefleet.tensor_parallel.layers import (
+    gen_linear_aoa_statements,
+    gen_linear_inv_aoa_statements,
+)
+
+
+class _FakeLinear(paddle.nn.Layer):
+    """A minimal transposed-weight Linear leaf whose AOA generators route
+    through the shared Linear-family helpers (the same helpers the real
+    ColumnParallelLinear / RowParallelLinear delegate to)."""
+
+    def __init__(self, bias=False):
+        super().__init__()
+        self.weight = self.create_parameter(shape=[2, 2])
+        self.bias = self.create_parameter(shape=[2]) if bias else None
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        return gen_linear_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        return gen_linear_inv_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
+
+def _make_fake_cls():
+    from paddlefleet.transformer.mlp import MLP
+
+    class _FakeNonGatedMLP(paddle.nn.Layer):
+        # Bind the base MLP non-gated head helpers (the branch selected by
+        # ``ctx.mlp_gate_up_fused == False`` inside ``gen_aoa_statements``).
+        _gen_nongated_mlp_aoa_statements = MLP._gen_nongated_mlp_aoa_statements
+        _gen_inv_nongated_mlp_aoa_statements = (
+            MLP._gen_inv_nongated_mlp_aoa_statements
+        )
+
+        def __init__(self, bias=False):
+            super().__init__()
+            self.up_gate_proj = _FakeLinear(bias=bias)
+            self.down_proj = _FakeLinear(bias=bias)
+
+        def gen_aoa_statements(
+            self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+        ):
+            return self._gen_nongated_mlp_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+
+        def gen_inv_aoa_statements(
+            self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+        ):
+            return self._gen_inv_nongated_mlp_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+
+    return _FakeNonGatedMLP
+
+
+_PFX = "mlp."
+_PP = {
+    _PFX + "up_gate_proj.weight": "model.mlp.up_gate_proj.weight",
+    _PFX + "up_gate_proj.bias": "model.mlp.up_gate_proj.bias",
+    _PFX + "down_proj.weight": "model.mlp.down_proj.weight",
+    _PFX + "down_proj.bias": "model.mlp.down_proj.bias",
+}
+
+
+def _ctx():
+    return FleetAOAContext(
+        config=None,
+        checkpoint_name_prefix="hf",
+        pp_to_single_mapping=_PP,
+        checkpoint_name_mapping={},
+        dtype_cast_rules={},
+        model_name_prefix="model",
+        excluded_names=frozenset(),
+        mlp_gate_up_fused=False,
+    )
+
+
+class TestNonGatedMLPForward(unittest.TestCase):
+    """Forward (checkpoint -> model): both projections are plain Linear ``^T``
+    renames; no gate/up split, no ``fused_ffn``."""
+
+    def setUp(self):
+        self.ctx = _ctx()
+
+    def test_weight_golden_no_fusion(self):
+        m = _make_fake_cls()(bias=False)
+        stmts = m.gen_aoa_statements(self.ctx, structured_name_prefix=_PFX)
+        expected = [
+            "hf.mlp.up_gate_proj.weight^T -> model.mlp.up_gate_proj.weight",
+            "hf.mlp.down_proj.weight^T -> model.mlp.down_proj.weight",
+        ]
+        self.assertEqual(stmts, expected)
+
+    def test_bias_is_identity_no_transpose(self):
+        m = _make_fake_cls()(bias=True)
+        stmts = m.gen_aoa_statements(self.ctx, structured_name_prefix=_PFX)
+        expected = [
+            "hf.mlp.up_gate_proj.weight^T -> model.mlp.up_gate_proj.weight",
+            "hf.mlp.up_gate_proj.bias -> model.mlp.up_gate_proj.bias",
+            "hf.mlp.down_proj.weight^T -> model.mlp.down_proj.weight",
+            "hf.mlp.down_proj.bias -> model.mlp.down_proj.bias",
+        ]
+        self.assertEqual(stmts, expected)
+
+    def test_no_fused_ffn_either_bias_mode(self):
+        for bias in (False, True):
+            m = _make_fake_cls()(bias=bias)
+            stmts = m.gen_aoa_statements(self.ctx, structured_name_prefix=_PFX)
+            self.assertFalse(any("fused_ffn" in s for s in stmts))
+
+
+class TestNonGatedMLPInverse(unittest.TestCase):
+    """Inverse (model -> checkpoint): plain Linear ``^T`` renames the other way;
+    still no ``fused_ffn`` (independently generated)."""
+
+    def setUp(self):
+        self.ctx = _ctx()
+
+    def test_weight_golden_no_fusion(self):
+        m = _make_fake_cls()(bias=False)
+        stmts = m.gen_inv_aoa_statements(self.ctx, structured_name_prefix=_PFX)
+        expected = [
+            "model.mlp.up_gate_proj.weight^T -> hf.mlp.up_gate_proj.weight",
+            "model.mlp.down_proj.weight^T -> hf.mlp.down_proj.weight",
+        ]
+        self.assertEqual(stmts, expected)
+
+    def test_bias_is_identity_no_transpose(self):
+        m = _make_fake_cls()(bias=True)
+        stmts = m.gen_inv_aoa_statements(self.ctx, structured_name_prefix=_PFX)
+        expected = [
+            "model.mlp.up_gate_proj.weight^T -> hf.mlp.up_gate_proj.weight",
+            "model.mlp.up_gate_proj.bias -> hf.mlp.up_gate_proj.bias",
+            "model.mlp.down_proj.weight^T -> hf.mlp.down_proj.weight",
+            "model.mlp.down_proj.bias -> hf.mlp.down_proj.bias",
+        ]
+        self.assertEqual(stmts, expected)
+
+    def test_no_fused_ffn_either_bias_mode(self):
+        for bias in (False, True):
+            m = _make_fake_cls()(bias=bias)
+            stmts = m.gen_inv_aoa_statements(
+                self.ctx, structured_name_prefix=_PFX
+            )
+            self.assertFalse(any("fused_ffn" in s for s in stmts))
+
+
+class TestNonGatedMLPRoundTrip(unittest.TestCase):
+    """Forward and inverse are endpoint-swaps over the same name pairs (the
+    plain-Linear leaves have no head reorder, so each fwd ``a -> b`` has an
+    inverse ``b -> a`` with matching ``^T`` placement)."""
+
+    def setUp(self):
+        self.ctx = _ctx()
+
+    def test_endpoints_swap(self):
+        m = _make_fake_cls()(bias=True)
+        fwd = m.gen_aoa_statements(self.ctx, structured_name_prefix=_PFX)
+        inv = m.gen_inv_aoa_statements(self.ctx, structured_name_prefix=_PFX)
+
+        def _endpoints(stmt):
+            lhs, rhs = stmt.split(" -> ")
+            return lhs.replace("^T", ""), rhs.replace("^T", "")
+
+        fwd_pairs = {_endpoints(s) for s in fwd}
+        inv_pairs = {(rhs, lhs) for (lhs, rhs) in (_endpoints(s) for s in inv)}
+        self.assertEqual(fwd_pairs, inv_pairs)
+
+
+class TestFlagRoutingContract(unittest.TestCase):
+    """The base ``MLP`` owns the non-gated head helpers and its public
+    generators route to them only when ``ctx.mlp_gate_up_fused`` is False (no
+    AOA-only subclass involved)."""
+
+    def test_base_mlp_has_nongated_helpers(self):
+        from paddlefleet.transformer.mlp import MLP
+
+        self.assertIn("_gen_nongated_mlp_aoa_statements", MLP.__dict__)
+        self.assertIn("_gen_inv_nongated_mlp_aoa_statements", MLP.__dict__)
+
+    def test_generators_branch_on_flag(self):
+        import inspect
+
+        from paddlefleet.transformer.mlp import MLP
+
+        fwd_src = inspect.getsource(MLP.gen_aoa_statements)
+        inv_src = inspect.getsource(MLP.gen_inv_aoa_statements)
+        self.assertIn("mlp_gate_up_fused", fwd_src)
+        self.assertIn("_gen_nongated_mlp_aoa_statements", fwd_src)
+        self.assertIn("mlp_gate_up_fused", inv_src)
+        self.assertIn("_gen_inv_nongated_mlp_aoa_statements", inv_src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_moe_layer_component.py
+++ b/tests/single_card_tests/aoa/test_aoa_moe_layer_component.py
@@ -1,0 +1,760 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: ``MoELayer`` owns no parameters of its own; it composes gate
+# (TopKRouter), optional latent projection, optional shared experts (MLP), and
+# the routed experts. The routed-expert emission is dispatched on the *live*
+# structure:
+#   * no ``grouped_gemm_experts`` -> per-expert recursion (each expert is its
+#     own MLP with an ``experts.{id}.`` prefix);
+#   * ``grouped_gemm_experts is not None`` -> the grouped-GEMM helper, which
+#     itself has two checkpoint-layout sub-paths selected by
+#     ``ctx.moe_expert_checkpoint_layout``:
+#       - ``"per_expert"`` (default): per-expert fuse+concat into the two packed
+#         model weights;
+#       - ``"packed"``: the checkpoint already packs every expert into two 3D
+#         tensors, so the only transform is a per-tensor ``permute='[0,2,1]'``.
+# The ``"packed"`` flag is consulted ONLY on the grouped branch; a per-expert
+# live layer ignores it, so a single model may mix layouts across layers under
+# one model-level flag (Qwen3.5: grouped+packed backbone, per-expert MTP). The
+# grouped emission does NOT depend on the expert class -- SonicMoEExpert saves
+# through the grouped layout -- which is pinned here too. Orthogonally, the
+# grouped branch also reads the *model-side* layout off the live expert
+# (``intermediate_ep_sharded``: 'allgather' dispatcher with EP > 1 gives every
+# rank all experts but only ``I // EP`` of each), which adds an un-interleaving
+# stage on both directions. This test pins the composition contract, both packed
+# directions, the grouped per-expert concat, the expert-type independence, the
+# per-expert-branch flag-independence, the mixed coexistence, and the
+# intermediate-sharded un-interleaving plus its rejection of the packed
+# combination.
+import os
+import sys
+import types
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+
+import paddle
+
+from paddlefleet.models.gpt.aoa_generator import (
+    FleetAOAContext,
+)
+
+
+def _ctx(moe_expert_checkpoint_layout="per_expert"):
+    return FleetAOAContext(
+        config=None,
+        checkpoint_name_prefix="hf",
+        pp_to_single_mapping={},
+        checkpoint_name_mapping={},
+        dtype_cast_rules={},
+        model_name_prefix="model",
+        excluded_names=frozenset(),
+        moe_expert_checkpoint_layout=moe_expert_checkpoint_layout,
+    )
+
+
+def _make_linear_leaf(bias=False):
+    from paddlefleet.tensor_parallel.layers import Linear
+
+    class _LinearLeaf(paddle.nn.Layer):
+        gen_aoa_statements = Linear.gen_aoa_statements
+        gen_inv_aoa_statements = Linear.gen_inv_aoa_statements
+
+        def __init__(self):
+            super().__init__()
+            self.weight = self.create_parameter(shape=[2, 2])
+            self.bias = self.create_parameter(shape=[2]) if bias else None
+
+    return _LinearLeaf
+
+
+def _make_mlp_leaf():
+    from paddlefleet.transformer.mlp import MLP
+
+    up_gate_cls = _make_linear_leaf(bias=False)
+    down_cls = _make_linear_leaf(bias=False)
+
+    class _MLPLeaf(paddle.nn.Layer):
+        gen_aoa_statements = MLP.gen_aoa_statements
+        gen_inv_aoa_statements = MLP.gen_inv_aoa_statements
+        _gen_up_gate_fusion_aoa_statements = (
+            MLP._gen_up_gate_fusion_aoa_statements
+        )
+        _gen_inv_up_gate_fusion_aoa_statements = (
+            MLP._gen_inv_up_gate_fusion_aoa_statements
+        )
+        _gen_up_gate_bias_aoa_statements = MLP._gen_up_gate_bias_aoa_statements
+        _gen_inv_up_gate_bias_aoa_statements = (
+            MLP._gen_inv_up_gate_bias_aoa_statements
+        )
+
+        def __init__(self):
+            super().__init__()
+            self.up_gate_proj = up_gate_cls()
+            self.down_proj = down_cls()
+
+    return _MLPLeaf
+
+
+def _make_grouped_marker(
+    dispatcher="deepep", expert_parallel=False, ep_size=None
+):
+    """Stand-in for the live ``grouped_gemm_experts``.
+
+    The generators read the *model-side* weight layout off the live expert
+    (``intermediate_ep_sharded``, then ``ep_group.nranks``), the same source
+    ``sharded_state_dict`` dispatches on, so a marker that merely hard-codes
+    the answer would pin nothing. The real property is borrowed here and fed
+    its two real inputs instead: ``config.moe_token_dispatcher_type`` and
+    ``expert_parallel``. Everything else a real expert owns (parameters,
+    device state, a full TransformerConfig) is irrelevant to plan generation.
+    """
+    from paddlefleet.transformer.moe.moe_expert import GroupedMLPExpert
+
+    class _GroupedMarker:
+        intermediate_ep_sharded = GroupedMLPExpert.intermediate_ep_sharded
+
+        def __init__(self):
+            self.config = types.SimpleNamespace(
+                moe_token_dispatcher_type=dispatcher
+            )
+            self.expert_parallel = expert_parallel
+            self.ep_group = (
+                None
+                if ep_size is None
+                else types.SimpleNamespace(nranks=ep_size)
+            )
+
+    return _GroupedMarker
+
+
+def _make_router_leaf():
+    from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+    class _RouterLeaf(paddle.nn.Layer):
+        gen_aoa_statements = TopKRouter.gen_aoa_statements
+        gen_inv_aoa_statements = TopKRouter.gen_inv_aoa_statements
+
+        def __init__(self):
+            super().__init__()
+            self.weight = self.create_parameter(shape=[2, 2])
+
+    return _RouterLeaf
+
+
+def _make_moe_leaf(
+    num_experts=2, shared=False, grouped=False, grouped_marker_factory=None
+):
+    """Binds the MoELayer AOA overrides onto a controllable stand-in.
+
+    ``gate`` is a router leaf; ``experts`` is a ``LayerList`` of MLP leaves.
+    ``shared_experts`` is an optional MLP leaf. When ``grouped`` is set a
+    ``grouped_gemm_experts`` stand-in forces the grouped-fusion branch;
+    ``num_experts`` is exposed for the per-expert concat sub-path. The
+    generators consult the marker for the *model-side* layout only
+    (``intermediate_ep_sharded`` / ``ep_group.nranks``) and never for the
+    checkpoint layout -- the grouped emission is one layout for every expert
+    type -- so the default stand-in reports the ordinary (deepep) layout.
+    ``grouped_marker_factory`` overrides it to pin the expert-type
+    independence or to select the intermediate-sharded layout.
+    """
+    from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+    router_cls = _make_router_leaf()
+    mlp_cls = _make_mlp_leaf()
+
+    class _MoELeaf(paddle.nn.Layer):
+        gen_aoa_statements = MoELayer.gen_aoa_statements
+        gen_inv_aoa_statements = MoELayer.gen_inv_aoa_statements
+        _gen_grouped_expert_aoa_statements = (
+            MoELayer._gen_grouped_expert_aoa_statements
+        )
+        _gen_inv_grouped_expert_aoa_statements = (
+            MoELayer._gen_inv_grouped_expert_aoa_statements
+        )
+        _gen_packed_grouped_expert_aoa_statements = (
+            MoELayer._gen_packed_grouped_expert_aoa_statements
+        )
+        _gen_inv_packed_grouped_expert_aoa_statements = (
+            MoELayer._gen_inv_packed_grouped_expert_aoa_statements
+        )
+        _GROUPED_EXPERT_LOCAL_NAMES = MoELayer._GROUPED_EXPERT_LOCAL_NAMES
+        _intermediate_ep_size = MoELayer._intermediate_ep_size
+        _reject_packed_intermediate_ep = MoELayer._reject_packed_intermediate_ep
+        _reject_nongated_grouped_experts = (
+            MoELayer._reject_nongated_grouped_experts
+        )
+        _inv_intermediate_ep_unpack_statements = (
+            MoELayer._inv_intermediate_ep_unpack_statements
+        )
+
+        def __init__(self):
+            super().__init__()
+            self.num_experts = num_experts
+            self.gate = router_cls()
+            self.experts = paddle.nn.LayerList(
+                [mlp_cls() for _ in range(num_experts)]
+            )
+            if shared:
+                self.shared_experts = mlp_cls()
+            if grouped:
+                factory = (
+                    _make_grouped_marker()
+                    if grouped_marker_factory is None
+                    else grouped_marker_factory
+                )
+                self.grouped_gemm_experts = factory()
+
+    return _MoELeaf
+
+
+_PFX = "model.layers.0.mlp."
+_HF = "hf.layers.0.mlp."
+_MD = "model.layers.0.mlp."
+
+# MTP-side prefix used by the mixed-layout coexistence test.
+_MTP_PFX = "model.mtp.layers.0.mlp."
+_MTP_HF = "hf.mtp.layers.0.mlp."
+_MTP_MD = "model.mtp.layers.0.mlp."
+
+
+class TestMoELayerClassContract(unittest.TestCase):
+    def test_override_present(self):
+        from paddlefleet.transformer.moe.moe_layer import MoELayer
+
+        for name in (
+            "gen_aoa_statements",
+            "gen_inv_aoa_statements",
+            "_gen_grouped_expert_aoa_statements",
+            "_gen_inv_grouped_expert_aoa_statements",
+            "_gen_packed_grouped_expert_aoa_statements",
+            "_gen_inv_packed_grouped_expert_aoa_statements",
+            "_intermediate_ep_size",
+            "_reject_packed_intermediate_ep",
+            "_reject_nongated_grouped_experts",
+            "_inv_intermediate_ep_unpack_statements",
+        ):
+            self.assertIn(name, MoELayer.__dict__)
+
+
+class TestMoELayerForward(unittest.TestCase):
+    def test_gate_then_per_expert_composition(self):
+        model = _make_moe_leaf(num_experts=2, shared=False)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        # gate rename (router leaf)
+        self.assertIn(f"{_HF}gate.weight -> {_MD}gate.weight", stmts)
+        # each expert recursed as an MLP: fused_ffn + down_proj
+        for eid in (0, 1):
+            self.assertIn(
+                f"{_HF}experts.{eid}.gate_proj.weight^T, "
+                f"{_HF}experts.{eid}.up_proj.weight^T "
+                f"-> {_MD}experts.{eid}.up_gate_proj.weight, fused_ffn",
+                stmts,
+            )
+            self.assertIn(
+                f"{_HF}experts.{eid}.down_proj.weight^T "
+                f"-> {_MD}experts.{eid}.down_proj.weight",
+                stmts,
+            )
+        # gate(1) + 2 experts * 2 statements each = 5
+        self.assertEqual(len(stmts), 5)
+
+    def test_shared_experts_included(self):
+        model = _make_moe_leaf(num_experts=1, shared=True)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        self.assertIn(
+            f"{_HF}shared_experts.gate_proj.weight^T, "
+            f"{_HF}shared_experts.up_proj.weight^T "
+            f"-> {_MD}shared_experts.up_gate_proj.weight, fused_ffn",
+            stmts,
+        )
+
+
+class TestMoELayerInverse(unittest.TestCase):
+    def test_gate_then_per_expert_inverse(self):
+        model = _make_moe_leaf(num_experts=2, shared=False)()
+        stmts = model.gen_inv_aoa_statements(
+            _ctx(), structured_name_prefix=_PFX
+        )
+        self.assertIn(f"{_MD}gate.weight -> {_HF}gate.weight", stmts)
+        for eid in (0, 1):
+            # fused_ffn splits into model-side halves, each then transposed
+            # into its checkpoint name.
+            self.assertIn(
+                f"{_MD}experts.{eid}.up_gate_proj.weight "
+                f"-> {_MD}experts.{eid}.gate_proj.weight, "
+                f"{_MD}experts.{eid}.up_proj.weight, fused_ffn",
+                stmts,
+            )
+            for leaf in ("gate_proj", "up_proj", "down_proj"):
+                self.assertIn(
+                    f"{_MD}experts.{eid}.{leaf}.weight^T "
+                    f"-> {_HF}experts.{eid}.{leaf}.weight",
+                    stmts,
+                )
+        # gate(1) + 2 experts * (1 fused_ffn split + 3 transposes) = 9
+        self.assertEqual(len(stmts), 9)
+
+
+class TestMoELayerGroupedPerExpertConcat(unittest.TestCase):
+    """Grouped-GEMM live layer with the default ``"per_expert"`` checkpoint
+    layout: per-expert fuse (``^T`` / ``axis=1``) into transients, then concat
+    on ``axis=0`` into the two packed model weights (GroupedMLPExpert
+    convention)."""
+
+    def test_forward_concat(self):
+        model = _make_moe_leaf(num_experts=2, grouped=True)()
+        stmts = model._gen_grouped_expert_aoa_statements(_ctx(), _PFX, None)
+        for eid in (0, 1):
+            self.assertIn(
+                f"{_HF}experts.{eid}.gate_proj.weight^T, "
+                f"{_HF}experts.{eid}.up_proj.weight^T "
+                f"-> {_MD}experts.{eid}.up_gate_proj.weight, axis=1",
+                stmts,
+            )
+            self.assertIn(
+                f"{_HF}experts.{eid}.down_proj.weight^T "
+                f"-> {_MD}experts.{eid}.down_proj.weight",
+                stmts,
+            )
+        self.assertIn(
+            f"{_MD}experts.0.up_gate_proj.weight,"
+            f"{_MD}experts.1.up_gate_proj.weight "
+            f"-> {_MD}grouped_gemm_experts.weight1, axis=0",
+            stmts,
+        )
+        self.assertIn(
+            f"{_MD}experts.0.down_proj.weight,"
+            f"{_MD}experts.1.down_proj.weight "
+            f"-> {_MD}grouped_gemm_experts.weight2, axis=0",
+            stmts,
+        )
+        # 2 experts * 2 fuse/stage + 2 concat = 6
+        self.assertEqual(len(stmts), 6)
+
+    def test_inverse_split_then_defuse(self):
+        model = _make_moe_leaf(num_experts=2, grouped=True)()
+        stmts = model._gen_inv_grouped_expert_aoa_statements(_ctx(), _PFX, None)
+        # stage 1: split the two packed weights
+        self.assertIn(
+            f"{_MD}grouped_gemm_experts.weight1 "
+            f"-> {_MD}experts.0.up_gate_proj.weight,"
+            f"{_MD}experts.1.up_gate_proj.weight, axis=0",
+            stmts,
+        )
+        self.assertIn(
+            f"{_MD}grouped_gemm_experts.weight2 "
+            f"-> {_MD}experts.0.down_proj.weight.intermediate,"
+            f"{_MD}experts.1.down_proj.weight.intermediate, axis=0",
+            stmts,
+        )
+        # stage 2: per-expert de-fuse on axis=1 into transposition
+        # intermediates, then transpose each into its checkpoint name.
+        for eid in (0, 1):
+            self.assertIn(
+                f"{_MD}experts.{eid}.up_gate_proj.weight "
+                f"-> {_MD}experts.{eid}.gate_proj.weight.intermediate, "
+                f"{_MD}experts.{eid}.up_proj.weight.intermediate, axis=1",
+                stmts,
+            )
+            for leaf in ("gate_proj", "up_proj", "down_proj"):
+                self.assertIn(
+                    f"{_MD}experts.{eid}.{leaf}.weight.intermediate^T "
+                    f"-> {_HF}experts.{eid}.{leaf}.weight",
+                    stmts,
+                )
+        # 2 split + 2 experts * (1 de-fuse + 3 transposes) = 10
+        self.assertEqual(len(stmts), 10)
+
+
+class TestGroupedExpertLayoutIsExpertTypeAgnostic(unittest.TestCase):
+    """The checkpoint-facing expert layout is the grouped-GEMM one regardless of
+    the expert class.
+
+    ``SonicMoEExpert`` keeps a different in-memory layout while computing
+    (``weight1`` ``[E, 2I, io]`` with gate/up interleaved row-wise), but its
+    ``sharded_state_dict()`` calls ``convert_weights_to_grouped_layout()`` first,
+    so that layout never reaches a checkpoint. Branching the generators on the
+    expert type therefore produced statements for a layout that is never saved;
+    these tests pin the type-independence so the special case cannot come back.
+    A genuine checkpoint layout divergence belongs in
+    ``ctx.moe_expert_checkpoint_layout``, which the model declares.
+    """
+
+    @staticmethod
+    def _sonic_marker():
+        from paddlefleet.transformer.moe.moe_expert import SonicMoEExpert
+
+        # ``__new__`` only: the generators may inspect nothing but the
+        # model-side layout predicate, and a real expert would need a full
+        # TransformerConfig plus device state to construct. The two inputs
+        # ``intermediate_ep_sharded`` reads are supplied so the inherited
+        # property answers for real (ordinary layout here).
+        marker = SonicMoEExpert.__new__(SonicMoEExpert)
+        marker.config = types.SimpleNamespace(
+            moe_token_dispatcher_type="deepep"
+        )
+        marker.expert_parallel = False
+        return marker
+
+    def test_intermediate_ep_sharded_is_inherited(self):
+        from paddlefleet.transformer.moe.moe_expert import (
+            GroupedMLPExpert,
+            SonicMoEExpert,
+        )
+
+        # One property covers both expert types, so the layout branch in the
+        # generators needs no expert-type dispatch of its own.
+        self.assertIs(
+            SonicMoEExpert.intermediate_ep_sharded,
+            GroupedMLPExpert.intermediate_ep_sharded,
+        )
+
+    def _pair(self):
+        plain = _make_moe_leaf(num_experts=2, grouped=True)()
+        sonic = _make_moe_leaf(
+            num_experts=2,
+            grouped=True,
+            grouped_marker_factory=self._sonic_marker,
+        )()
+        return plain, sonic
+
+    def test_forward_statements_match(self):
+        plain, sonic = self._pair()
+        self.assertEqual(
+            sonic._gen_grouped_expert_aoa_statements(_ctx(), _PFX, None),
+            plain._gen_grouped_expert_aoa_statements(_ctx(), _PFX, None),
+        )
+
+    def test_inverse_statements_match(self):
+        plain, sonic = self._pair()
+        self.assertEqual(
+            sonic._gen_inv_grouped_expert_aoa_statements(_ctx(), _PFX, None),
+            plain._gen_inv_grouped_expert_aoa_statements(_ctx(), _PFX, None),
+        )
+
+    def test_no_axis_zero_defuse_for_sonic(self):
+        _, sonic = self._pair()
+        stmts = sonic._gen_inv_grouped_expert_aoa_statements(_ctx(), _PFX, None)
+        # The de-fuse of the per-expert fused gate+up is the only place an
+        # axis=0 split would be wrong; the cross-expert splits legitimately use
+        # axis=0 (the expert axis).
+        for eid in (0, 1):
+            self.assertIn(
+                f"{_MD}experts.{eid}.up_gate_proj.weight "
+                f"-> {_MD}experts.{eid}.gate_proj.weight.intermediate, "
+                f"{_MD}experts.{eid}.up_proj.weight.intermediate, axis=1",
+                stmts,
+            )
+
+
+class TestGroupedExpertIntermediateEPSharded(unittest.TestCase):
+    """Grouped-GEMM live layer under the 'allgather' dispatcher with EP > 1.
+
+    Every rank then holds all ``E`` experts but only ``I // EP`` of each one's
+    intermediate dim, and the HF directions run against a 2-D re-declaration of
+    those shards (AOA cannot lower a tensor's rank on save). That re-declared
+    *global* layout is rank-major interleaved, because each rank's local block
+    has to stay one contiguous rectangle::
+
+        weight1 [E*io, 2*I_full]  columns: gate_r0 | up_r0 | gate_r1 | up_r1 |..
+        weight2 [E*I_full, io]    rows:    (r0: e0..eE-1) | (r1: e0..eE-1) |..
+
+    So the ordinary statements are numerically wrong here even though every
+    shape still checks out: their ``axis=1`` bisection of ``weight1`` takes
+    ``gate_r0 + up_r0`` as "gate", and their E-way ``axis=0`` split of
+    ``weight2`` mixes experts. These tests pin the un-interleaving on both
+    directions, that it lands on exactly the per-expert transients the ordinary
+    layout produces (so the shared stages are untouched), and that the ordinary
+    layout is unaffected.
+    """
+
+    EP = 2
+    E = 2
+
+    W1 = f"{_MD}grouped_gemm_experts.weight1"
+    W2 = f"{_MD}grouped_gemm_experts.weight2"
+
+    def _model(self, dispatcher="allgather", expert_parallel=True, ep_size=EP):
+        return _make_moe_leaf(
+            num_experts=self.E,
+            grouped=True,
+            grouped_marker_factory=_make_grouped_marker(
+                dispatcher=dispatcher,
+                expert_parallel=expert_parallel,
+                ep_size=ep_size,
+            ),
+        )()
+
+    def test_ep_size_read_off_the_live_expert(self):
+        model = self._model()
+        self.assertEqual(model._intermediate_ep_size(), self.EP)
+        # Both inputs of the predicate must hold, and neither implies the
+        # other: allgather without EP, and EP without allgather, are ordinary.
+        self.assertIsNone(
+            self._model(expert_parallel=False)._intermediate_ep_size()
+        )
+        self.assertIsNone(
+            self._model(dispatcher="deepep")._intermediate_ep_size()
+        )
+
+    def test_forward_slices_then_reinterleaves(self):
+        model = self._model()
+        stmts = model._gen_grouped_expert_aoa_statements(_ctx(), _PFX, None)
+
+        expected = []
+        for e in range(self.E):
+            ug = f"{_MD}experts.{e}.up_gate_proj.weight"
+            dm = f"{_MD}experts.{e}.down_proj.weight"
+            # Each checkpoint matrix is cut into the EP intermediate slices the
+            # re-declared layout expects, then gate/up are re-interleaved
+            # rank-major into the per-expert transient.
+            expected += [
+                f"{_HF}experts.{e}.gate_proj.weight^T "
+                f"-> {ug}.gate_ep0,{ug}.gate_ep1, axis=1",
+                f"{_HF}experts.{e}.up_proj.weight^T "
+                f"-> {ug}.up_ep0,{ug}.up_ep1, axis=1",
+                f"{ug}.gate_ep0,{ug}.up_ep0,{ug}.gate_ep1,{ug}.up_ep1 "
+                f"-> {ug}, axis=1",
+                f"{_HF}experts.{e}.down_proj.weight^T "
+                f"-> {dm}.ep0,{dm}.ep1, axis=0",
+            ]
+        # weight1 rows stay expert-major; weight2 rows are rank-outer.
+        expected.append(
+            f"{_MD}experts.0.up_gate_proj.weight,"
+            f"{_MD}experts.1.up_gate_proj.weight -> {self.W1}, axis=0"
+        )
+        expected.append(
+            f"{_MD}experts.0.down_proj.weight.ep0,"
+            f"{_MD}experts.1.down_proj.weight.ep0,"
+            f"{_MD}experts.0.down_proj.weight.ep1,"
+            f"{_MD}experts.1.down_proj.weight.ep1 -> {self.W2}, axis=0"
+        )
+        self.assertEqual(stmts, expected)
+
+    def test_inverse_unpacks_into_the_ordinary_transients(self):
+        model = self._model()
+        stmts = model._gen_inv_grouped_expert_aoa_statements(_ctx(), _PFX, None)
+
+        w1, w2 = self.W1, self.W2
+        ug = [f"{_MD}experts.{e}.up_gate_proj.weight" for e in range(self.E)]
+        di = [
+            f"{_MD}experts.{e}.down_proj.weight.intermediate"
+            for e in range(self.E)
+        ]
+        # Stage (1): un-interleave. weight1 -> 2*EP column blocks, even ones
+        # regroup into the full gate and odd ones into the full up, each then
+        # cut expert-wise; weight2 -> EP*E row parts gathered back per expert.
+        stage1 = [
+            f"{w1} -> {w1}.ep_blk0,{w1}.ep_blk1,{w1}.ep_blk2,{w1}.ep_blk3, "
+            f"axis=1",
+            f"{w1}.ep_blk0,{w1}.ep_blk2 -> {w1}.gate_all, axis=1",
+            f"{w1}.ep_blk1,{w1}.ep_blk3 -> {w1}.up_all, axis=1",
+            f"{w1}.gate_all -> {w1}.gate_e0,{w1}.gate_e1, axis=0",
+            f"{w1}.up_all -> {w1}.up_e0,{w1}.up_e1, axis=0",
+            f"{w1}.gate_e0,{w1}.up_e0 -> {ug[0]}, axis=1",
+            f"{w1}.gate_e1,{w1}.up_e1 -> {ug[1]}, axis=1",
+            f"{w2} -> {w2}.r0e0,{w2}.r0e1,{w2}.r1e0,{w2}.r1e1, axis=0",
+            f"{w2}.r0e0,{w2}.r1e0 -> {di[0]}, axis=0",
+            f"{w2}.r0e1,{w2}.r1e1 -> {di[1]}, axis=0",
+        ]
+        self.assertEqual(stmts[: len(stage1)], stage1)
+
+        # Stage (2) is shared verbatim with the ordinary layout: the whole
+        # point of landing on the same transients. Compared against the
+        # ordinary generator's own tail rather than re-spelled here.
+        ordinary = _make_moe_leaf(
+            num_experts=self.E, grouped=True
+        )()._gen_inv_grouped_expert_aoa_statements(_ctx(), _PFX, None)
+        tail = 4 * self.E
+        self.assertEqual(stmts[-tail:], ordinary[-tail:])
+        self.assertEqual(len(stmts), len(stage1) + tail)
+
+    def test_round_trip_names_are_consistent(self):
+        # The two directions are written independently; the per-expert
+        # transients they meet on must still agree, otherwise the save plan
+        # would target names the load plan never produces.
+        model = self._model()
+        fwd = model._gen_grouped_expert_aoa_statements(_ctx(), _PFX, None)
+        inv = model._gen_inv_grouped_expert_aoa_statements(_ctx(), _PFX, None)
+        for e in range(self.E):
+            ug = f"{_MD}experts.{e}.up_gate_proj.weight"
+            self.assertTrue(any(s.endswith(f"-> {ug}, axis=1") for s in fwd))
+            self.assertTrue(any(s.endswith(f"-> {ug}, axis=1") for s in inv))
+
+    def test_packed_layout_combination_rejected(self):
+        model = self._model()
+        ctx = _ctx(moe_expert_checkpoint_layout="packed")
+        # Orthogonal dimensions: "packed" describes the checkpoint side and
+        # intermediate-sharded the model side. The packed branch maps whole 3D
+        # checkpoint tensors through a permute, leaving nowhere to un-interleave
+        # the rank-major ordering, so it must fail loudly instead of emitting
+        # plausible statements that silently produce wrong data.
+        with self.assertRaises(NotImplementedError):
+            model._gen_grouped_expert_aoa_statements(ctx, _PFX, None)
+        with self.assertRaises(NotImplementedError):
+            model._gen_inv_grouped_expert_aoa_statements(ctx, _PFX, None)
+        # The ordinary layout still reaches the packed branch.
+        self.assertEqual(
+            len(
+                self._model(
+                    dispatcher="deepep"
+                )._gen_grouped_expert_aoa_statements(ctx, _PFX, None)
+            ),
+            2,
+        )
+
+    def test_ordinary_layout_statements_unchanged(self):
+        # Regression guard: the deepep path must be byte-identical to the
+        # pre-existing expectations pinned by
+        # TestMoELayerGroupedPerExpertConcat, i.e. the new branch is inert
+        # unless the live expert says otherwise.
+        marker_default = _make_moe_leaf(num_experts=self.E, grouped=True)()
+        explicit_deepep = self._model(dispatcher="deepep")
+        for gen in (
+            "_gen_grouped_expert_aoa_statements",
+            "_gen_inv_grouped_expert_aoa_statements",
+        ):
+            self.assertEqual(
+                getattr(explicit_deepep, gen)(_ctx(), _PFX, None),
+                getattr(marker_default, gen)(_ctx(), _PFX, None),
+            )
+
+
+class TestMoELayerPackedLayout(unittest.TestCase):
+    """``"packed"`` checkpoint layout on the grouped branch: the only transform
+    is a per-weight ``permute='[0,2,1]'`` (an involution reused verbatim by the
+    inverse). Selected by ``ctx.moe_expert_checkpoint_layout == "packed"``."""
+
+    def test_forward_permute(self):
+        model = _make_moe_leaf(num_experts=2, grouped=True)()
+        stmts = model._gen_grouped_expert_aoa_statements(
+            _ctx(moe_expert_checkpoint_layout="packed"), _PFX, None
+        )
+        self.assertEqual(
+            stmts,
+            [
+                f"{_HF}grouped_gemm_experts.weight1 "
+                f"-> {_MD}grouped_gemm_experts.weight1, permute='[0,2,1]'",
+                f"{_HF}grouped_gemm_experts.weight2 "
+                f"-> {_MD}grouped_gemm_experts.weight2, permute='[0,2,1]'",
+            ],
+        )
+
+    def test_inverse_permute(self):
+        model = _make_moe_leaf(num_experts=2, grouped=True)()
+        stmts = model._gen_inv_grouped_expert_aoa_statements(
+            _ctx(moe_expert_checkpoint_layout="packed"), _PFX, None
+        )
+        self.assertEqual(
+            stmts,
+            [
+                f"{_MD}grouped_gemm_experts.weight1 "
+                f"-> {_HF}grouped_gemm_experts.weight1, permute='[0,2,1]'",
+                f"{_MD}grouped_gemm_experts.weight2 "
+                f"-> {_HF}grouped_gemm_experts.weight2, permute='[0,2,1]'",
+            ],
+        )
+
+    def test_top_level_gen_routes_packed(self):
+        # Going through the public generator (gate + grouped packed) confirms
+        # the branch selection wiring, not just the inner helper.
+        model = _make_moe_leaf(num_experts=2, grouped=True)()
+        stmts = model.gen_aoa_statements(
+            _ctx(moe_expert_checkpoint_layout="packed"),
+            structured_name_prefix=_PFX,
+        )
+        self.assertIn(f"{_HF}gate.weight -> {_MD}gate.weight", stmts)
+        self.assertIn(
+            f"{_HF}grouped_gemm_experts.weight1 "
+            f"-> {_MD}grouped_gemm_experts.weight1, permute='[0,2,1]'",
+            stmts,
+        )
+        # gate(1) + weight1 + weight2 = 3, no per-expert concat noise
+        self.assertEqual(len(stmts), 3)
+
+
+class TestMoELayerPerExpertIgnoresPackedFlag(unittest.TestCase):
+    """A per-expert *live* layer (no ``grouped_gemm_experts``) must produce the
+    same statements whether or not the model-level ``"packed"`` flag is set --
+    the flag only selects a grouped-branch sub-path. This is what lets Qwen3.5
+    carry per-expert MTP layers under a model-level ``"packed"`` flag."""
+
+    def test_forward_flag_independent(self):
+        model = _make_moe_leaf(num_experts=2, shared=False)()
+        default = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        packed = model.gen_aoa_statements(
+            _ctx(moe_expert_checkpoint_layout="packed"),
+            structured_name_prefix=_PFX,
+        )
+        self.assertEqual(default, packed)
+        self.assertTrue(all("permute" not in s for s in packed))
+
+    def test_inverse_flag_independent(self):
+        model = _make_moe_leaf(num_experts=2, shared=False)()
+        default = model.gen_inv_aoa_statements(
+            _ctx(), structured_name_prefix=_PFX
+        )
+        packed = model.gen_inv_aoa_statements(
+            _ctx(moe_expert_checkpoint_layout="packed"),
+            structured_name_prefix=_PFX,
+        )
+        self.assertEqual(default, packed)
+
+
+class TestMoELayerMixedLayoutCoexistence(unittest.TestCase):
+    """Qwen3.5-style mix under ONE model-level ``moe_expert_checkpoint_layout
+    == "packed"`` flag: a grouped backbone layer emits the packed permute while
+    a per-expert MTP layer emits per-expert recursion (flag ignored on the
+    per-expert branch). Both are generated with the same ``ctx``."""
+
+    def test_backbone_packed_mtp_per_expert(self):
+        ctx = _ctx(moe_expert_checkpoint_layout="packed")
+
+        backbone = _make_moe_leaf(num_experts=2, grouped=True)()
+        backbone_stmts = backbone.gen_aoa_statements(
+            ctx, structured_name_prefix=_PFX
+        )
+        # backbone -> packed permute, no per-expert fused_ffn
+        self.assertIn(
+            f"{_HF}grouped_gemm_experts.weight1 "
+            f"-> {_MD}grouped_gemm_experts.weight1, permute='[0,2,1]'",
+            backbone_stmts,
+        )
+        self.assertTrue(all("fused_ffn" not in s for s in backbone_stmts))
+
+        mtp = _make_moe_leaf(num_experts=2, grouped=False)()
+        mtp_stmts = mtp.gen_aoa_statements(ctx, structured_name_prefix=_MTP_PFX)
+        # MTP -> per-expert recursion, no packed permute
+        for eid in (0, 1):
+            self.assertIn(
+                f"{_MTP_HF}experts.{eid}.gate_proj.weight^T, "
+                f"{_MTP_HF}experts.{eid}.up_proj.weight^T "
+                f"-> {_MTP_MD}experts.{eid}.up_gate_proj.weight, fused_ffn",
+                mtp_stmts,
+            )
+        self.assertTrue(all("permute" not in s for s in mtp_stmts))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_moe_router_component.py
+++ b/tests/single_card_tests/aoa/test_aoa_moe_router_component.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: the MoE ``TopKRouter`` owns no fused layout. Its own
+# ``local_state_dict`` (this layer only, no sub-layers) is the sole enumeration
+# source, so every own Parameter / persistable buffer becomes a plain rename
+# (``weight`` / ``e_score_correction_bias`` ...) with no ``^T``, and a dtype
+# cast suffix appears only when the model rules match. This test pins that
+# coverage contract and the independent inverse direction.
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+
+import paddle
+
+from paddlefleet.models.gpt.aoa_generator import (
+    FleetAOAContext,
+)
+
+
+def _ctx(dtype_cast_rules=None):
+    return FleetAOAContext(
+        config=None,
+        checkpoint_name_prefix="hf",
+        pp_to_single_mapping={},
+        checkpoint_name_mapping={},
+        dtype_cast_rules=dtype_cast_rules or {},
+        model_name_prefix="model",
+        excluded_names=frozenset(),
+    )
+
+
+def _make_router_leaf():
+    """Binds the router AOA overrides onto a controllable stand-in.
+
+    The router enumerates only its own params/buffers, so the stand-in carries
+    a ``weight`` Parameter, an ``e_score_correction_bias`` Parameter, one
+    persistable buffer (must appear) and one non-persistable buffer (must be
+    absent).
+    """
+    from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+    class _RouterLeaf(paddle.nn.Layer):
+        gen_aoa_statements = TopKRouter.gen_aoa_statements
+        gen_inv_aoa_statements = TopKRouter.gen_inv_aoa_statements
+
+        def __init__(self):
+            super().__init__()
+            self.weight = self.create_parameter(shape=[2, 2])
+            self.e_score_correction_bias = self.create_parameter(shape=[2])
+            self.register_buffer(
+                "some_buf", paddle.zeros([2]), persistable=True
+            )
+            self.register_buffer(
+                "tmp_buf", paddle.zeros([2]), persistable=False
+            )
+
+    return _RouterLeaf
+
+
+_PFX = "model.layers.0.mlp.gate."
+_HF = "hf.layers.0.mlp.gate."
+_MD = "model.layers.0.mlp.gate."
+
+
+class TestRouterClassContract(unittest.TestCase):
+    def test_override_present(self):
+        from paddlefleet.transformer.moe.moe_router import TopKRouter
+
+        self.assertIn("gen_aoa_statements", TopKRouter.__dict__)
+        self.assertIn("gen_inv_aoa_statements", TopKRouter.__dict__)
+
+
+class TestRouterForward(unittest.TestCase):
+    def test_plain_rename_no_transpose(self):
+        model = _make_router_leaf()()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        # every own key is a plain rename (no ^T)
+        self.assertIn(f"{_HF}weight -> {_MD}weight", stmts)
+        self.assertIn(
+            f"{_HF}e_score_correction_bias -> {_MD}e_score_correction_bias",
+            stmts,
+        )
+        self.assertIn(f"{_HF}some_buf -> {_MD}some_buf", stmts)
+        self.assertFalse(any("^T" in s for s in stmts))
+        # non-persistable buffer never appears
+        self.assertFalse(any("tmp_buf" in s for s in stmts))
+        # exactly three producing statements
+        self.assertEqual(len(stmts), 3)
+
+
+class TestRouterInverse(unittest.TestCase):
+    def test_endpoints_swapped(self):
+        model = _make_router_leaf()()
+        stmts = model.gen_inv_aoa_statements(
+            _ctx(), structured_name_prefix=_PFX
+        )
+        self.assertIn(f"{_MD}weight -> {_HF}weight", stmts)
+        self.assertIn(
+            f"{_MD}e_score_correction_bias -> {_HF}e_score_correction_bias",
+            stmts,
+        )
+        self.assertIn(f"{_MD}some_buf -> {_HF}some_buf", stmts)
+        self.assertFalse(any("tmp_buf" in s for s in stmts))
+        self.assertEqual(len(stmts), 3)
+
+
+class TestRouterDtypeCast(unittest.TestCase):
+    def test_weight_cast_endpoints(self):
+        rules = {
+            "layers.0.mlp.gate.weight": {
+                "checkpoint_dtype": "bfloat16",
+                "model_dtype": "float32",
+            }
+        }
+        model = _make_router_leaf()()
+        fwd = model.gen_aoa_statements(_ctx(rules), structured_name_prefix=_PFX)
+        self.assertIn(
+            f"{_HF}weight -> {_MD}weight, "
+            "src_dtype='bfloat16', dst_dtype='float32'",
+            fwd,
+        )
+        inv = model.gen_inv_aoa_statements(
+            _ctx(rules), structured_name_prefix=_PFX
+        )
+        self.assertIn(
+            f"{_MD}weight -> {_HF}weight, "
+            "src_dtype='float32', dst_dtype='bfloat16'",
+            inv,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
+++ b/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
@@ -74,11 +74,13 @@ def _make_config(**overrides):
 def _layer_descs(num_mtp=1, **config_overrides):
     """Call get_layer_desc_list without building a real GPTModel.
 
-    The method only touches ``self.config`` and ``self.add_sequential_layer``,
-    so a stub carrying those two is enough and keeps this a single-card test.
+    The method only touches ``self.config``, ``self._model_name_prefix`` and
+    ``self.add_sequential_layer``, so a stub carrying those three is enough and
+    keeps this a single-card test.
     """
     fake_self = SimpleNamespace(
         config=_make_config(**config_overrides),
+        _model_name_prefix=lambda: "model",
         add_sequential_layer=lambda layers, desc, name_prefix="": layers.append(
             {"layer": desc, "name_prefix": name_prefix}
         ),


### PR DESCRIPTION
### PR Category

Distributed Strategy

### PR Types

New features

### Description

模块化 AOA 基础能力系列三（批4a+4b）：MLP 与 MoE 组件叶子。

> **依赖 #2023（stacked）。** 本 PR 分支基于 #2023 的分支，因上游无法承载 #2023 的分支作为 base，这里 base 只能设为 `develop`。**在 #2023 合入前，此处 diff 会一并包含 #2023 的 c1/c2 改动**；#2023 合入后 diff 会自动收敛为本 PR 唯一的新增 commit `6fe66265`。请优先 review #2023，再看本 PR 的增量。

本 PR 唯一新增 commit（`6fe66265`）内容：把组件级 AOA 语句发射器挂到 MLP 与 MoE 模块类上：

- `mlp.py`、`moe/moe_layer.py`、`moe/moe_router.py`、`moe/moe_expert.py`。
- 单测落在非受限目录 `tests/single_card_tests/aoa/`（`test_aoa_mlp_component.py`、`test_aoa_mlp_nongated_component.py`、`test_aoa_moe_layer_component.py`、`test_aoa_moe_router_component.py`）。

`aoa_modular` 保持 `False`（当前无任何模型翻 True）时，以上全部静态不可达；命名与 checkpoint 行为与改动前逐字节一致。

### 是否引起精度变化

否。

纯新增代码，仅在 `aoa_modular=True` 时进入；当前无模型开启，gate 关闭时静态不可达，不进入任何计算或 checkpoint 路径。
