### PR TITLE
[FlexCheckpoint] Modular AOA: attention and MLA/CSA/DSA leaves

### DIFF
--- a/src/paddlefleet/models/gpt/aoa_generator.py
+++ b/src/paddlefleet/models/gpt/aoa_generator.py
@@ -1,0 +1,278 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Whole-model modular AOA statement generation for boundary models.
+
+Pure functions backing the ``GPTModel`` boundary's modular AOA generation, plus
+the container entries a multi-tower model uses to drive several roots. The flow
+is:
+
+1. :func:`build_aoa_context` builds the read-only ``AOAContext`` once, using the
+   live model's ``_pp_to_single_mapping`` (same source as ``sharded_state_dict``,
+   so names come from the live module tree rather than a re-derived guess).
+2. :func:`collect_alias_plan` resolves tied / shared aliases and the pipeline
+   names to skip in one pass, **before** recursion (no post-hoc text dedup).
+   The skip set is pinned into ``ctx.excluded_names`` so every component
+   override honors it.
+3. :func:`gen_whole_model_aoa` / :func:`gen_whole_model_inv_aoa` hand each child
+   to the standard ``Layer.gen_aoa_statements`` / ``gen_inv_aoa_statements``
+   protocol -- that polymorphic call is the component dispatch point, so the
+   module walk is never re-implemented here. The two directions are generated
+   independently and never derived from one another.
+4. :func:`gen_multi_tower_aoa` / :func:`gen_multi_tower_inv_aoa` are the entry
+   points for a container that owns several roots (a vision tower beside a
+   language model). Every tower is dispatched on what its root is: a boundary
+   root goes through step 3, any other root through plain component recursion.
+   The container keeps globalization to itself so it runs once over the union
+   of all its towers.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    AOAContext,
+    validate_checkpoint_name_mapping,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# MTP checkpoint prefix protocol
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MTPCheckpointPrefixSpec:
+    """Checkpoint-side prefix protocol for MTP layers, resolved once per pass.
+
+    Producer-side state built at the whole-model entry from the model-declared
+    ``aoa_mtp_*`` attributes and threaded straight into
+    :func:`_resolve_mtp_scopes`. Deliberately *not* a field of the
+    component-facing :class:`AOAContext`: no component override reads it, so it
+    does not belong on the frozen recursion context forwarded to every
+    component.
+
+    Defaults cover the common case: MTP layers share the normal-layer
+    checkpoint numbering ``layers.$LAYER_ID`` and the inner transformer inherits
+    that same prefix. A boundary overrides via the three model attributes.
+    """
+
+    checkpoint_prefix: str = "layers.$LAYER_ID"
+    transformer_checkpoint_prefix: str = "layers.$LAYER_ID"
+    is_absolute: bool = False
+
+
+def resolve_mtp_checkpoint_prefix_spec(config) -> MTPCheckpointPrefixSpec:
+    """Normalizes the model-declared MTP checkpoint-prefix attributes.
+
+    Reads ``aoa_mtp_checkpoint_prefix`` /
+    ``aoa_mtp_transformer_checkpoint_prefix`` /
+    ``aoa_mtp_checkpoint_prefix_absolute`` off ``config`` with the defaulting an
+    unmigrated model relies on: the MTP-own prefix defaults to
+    ``layers.$LAYER_ID`` (same numbering as normal layers), the inner
+    transformer prefix inherits the MTP-own prefix, and no absolute-prefix
+    escape. Both prefixes route through :func:`_protocol_value`, so only an
+    absent / ``None`` attribute falls back; an explicitly declared value
+    (including an empty ``""`` for a top-level checkpoint) is taken verbatim.
+    """
+    checkpoint_prefix = _protocol_value(
+        config, "aoa_mtp_checkpoint_prefix", "layers.$LAYER_ID"
+    )
+    return MTPCheckpointPrefixSpec(
+        checkpoint_prefix=checkpoint_prefix,
+        transformer_checkpoint_prefix=_protocol_value(
+            config, "aoa_mtp_transformer_checkpoint_prefix", checkpoint_prefix
+        ),
+        is_absolute=bool(
+            getattr(config, "aoa_mtp_checkpoint_prefix_absolute", False)
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint protocol defaults and context construction
+# ---------------------------------------------------------------------------
+
+
+# Defaults for the model-declarable ``aoa_*`` checkpoint protocol. Each default
+# is named exactly once here and referenced by every consumer (the
+# :class:`FleetAOAContext` fields, :func:`build_aoa_context` and
+# :func:`_build_tower_ctx`), so no default literal is duplicated. The values
+# describe the ERNIE-series self-developed checkpoint; an external model
+# overrides only the attributes whose layout diverges.
+#
+# Only naming divergences belong in the mapping below: names the components
+# already emit identically (layernorms, ``model.norm``, the MTP layer's
+# ``enorm`` / ``hnorm`` / ``eh_proj``, and the CSA subtree) are deliberately
+# absent. The logical layer root also intentionally omits ``transformer_layer``
+# so the same entries cover ordinary layers and an MTP layer's inner
+# transformer.
+DEFAULT_CHECKPOINT_NAME_MAPPING = {
+    "embedding.embed_tokens.weight": "embed_tokens.weight",
+    "layers.$LAYER_ID.mlp.gate.weight": "layers.$LAYER_ID.block_sparse_moe.gate.weight",
+    "layers.$LAYER_ID.mlp.gate.weight_1": "layers.$LAYER_ID.block_sparse_moe.gate.weight_1",
+    "layers.$LAYER_ID.mlp.gate.routed_scaling_factor_param": "layers.$LAYER_ID.block_sparse_moe.gate.routed_scaling_factor_param",
+    "layers.$LAYER_ID.mlp.gate.e_score_correction_bias": "layers.$LAYER_ID.block_sparse_moe.e_score_correction_bias",
+    "layers.$LAYER_ID.mlp.fc1_latent_proj.weight": "layers.$LAYER_ID.block_sparse_moe.fc1_latent_proj.weight",
+    "layers.$LAYER_ID.mlp.fc2_latent_proj.weight": "layers.$LAYER_ID.block_sparse_moe.fc2_latent_proj.weight",
+    "layers.$LAYER_ID.mlp.experts.$EXPERT_ID.gate_proj.weight": "layers.$LAYER_ID.block_sparse_moe.experts.$EXPERT_ID.w1.weight",
+    "layers.$LAYER_ID.mlp.experts.$EXPERT_ID.up_proj.weight": "layers.$LAYER_ID.block_sparse_moe.experts.$EXPERT_ID.w3.weight",
+    "layers.$LAYER_ID.mlp.experts.$EXPERT_ID.down_proj.weight": "layers.$LAYER_ID.block_sparse_moe.experts.$EXPERT_ID.w2.weight",
+    "layers.$LAYER_ID.mlp.shared_experts.gate_proj.weight": "layers.$LAYER_ID.block_sparse_moe.shared_experts.w1.weight",
+    "layers.$LAYER_ID.mlp.shared_experts.up_proj.weight": "layers.$LAYER_ID.block_sparse_moe.shared_experts.w3.weight",
+    "layers.$LAYER_ID.mlp.shared_experts.down_proj.weight": "layers.$LAYER_ID.block_sparse_moe.shared_experts.w2.weight",
+    "layers.$LAYER_ID.norm.weight": "layers.$LAYER_ID.shared_head.norm.weight",
+}
+DEFAULT_CHECKPOINT_NAME_PREFIX = "model"
+DEFAULT_DTYPE_CAST_RULES = {}
+DEFAULT_GATE_CHECKPOINT_LAYOUT = "separate"
+DEFAULT_QKV_CHECKPOINT_PREFUSED = False
+DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT = "per_expert"
+DEFAULT_MLP_GATE_UP_FUSED = True
+DEFAULT_MAPPING_PROJ_CHECKPOINT_TRANSPOSED = False
+
+# Model-side single-name root, taken from the live model rather than declared on
+# the config; kept next to its checkpoint-side counterpart for readability.
+DEFAULT_MODEL_NAME_PREFIX = "model"
+
+
+@dataclass(frozen=True)
+class FleetAOAContext(AOAContext):
+    """Adds the checkpoint-layout declarations this library's components consume.
+
+    Paddle owns the recursion contract (names, dtype rules, exclusions); the
+    layouts below are paddlefleet's own protocol and grow with the models it
+    supports, so they live here rather than in the framework. Each is a
+    checkpoint-format fact that cannot be inferred from the live module, so the
+    model declares it; it only selects an emit branch and never overrides the
+    live structure.
+    """
+
+    gate_checkpoint_layout: str = DEFAULT_GATE_CHECKPOINT_LAYOUT
+    """Attention output gate placement for gated attention. ``"separate"``
+    (default) is the ERNIE-Lite layout with a standalone ``gate_proj`` tensor;
+    ``"interleaved"`` is a gate packed head-interleaved inside ``q_proj`` that
+    must be de-interleaved before fusing into ``qkv_proj``. Only consulted when
+    the live attention is gated."""
+
+    qkv_checkpoint_prefused: bool = DEFAULT_QKV_CHECKPOINT_PREFUSED
+    """``False`` (default) is the usual checkpoint with distinct ``q_proj`` /
+    ``k_proj`` / ``v_proj`` tensors; ``True`` is a single pre-fused ``qkv``
+    tensor that must be split before the ``fused_qkv`` re-fusion."""
+
+    moe_expert_checkpoint_layout: str = DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT
+    """``"per_expert"`` (default) for one projection tensor per expert,
+    ``"packed"`` for two 3D tensors packing every expert. Only consulted on the
+    grouped-GEMM branch, so one model may mix layouts across layers."""
+
+    mlp_gate_up_fused: bool = DEFAULT_MLP_GATE_UP_FUSED
+    """``True`` (default) is the gated MLP whose separate checkpoint
+    ``gate_proj`` / ``up_proj`` fuse into the model ``up_gate_proj``; ``False``
+    is a non-gated MLP handled by the generic Linear family."""
+
+    mapping_proj_checkpoint_transposed: bool = (
+        DEFAULT_MAPPING_PROJ_CHECKPOINT_TRANSPOSED
+    )
+    """Whether the checkpoint stores the mHC ``mapping_proj`` weight as
+    ``(out, in)`` (the torch layout, needing a ``^T``) instead of the live
+    ``(in, out)``. Orthogonal to the alpha layout; the accompanying leaf rename
+    is expressed by ``checkpoint_name_mapping``, which cannot carry a
+    transpose."""
+
+
+def _protocol_value(config, attr, default):
+    """Reads one model-declared ``aoa_*`` attribute with the single rule.
+
+    An attribute that is absent or explicitly ``None`` falls back to the
+    default; every other declared value is taken verbatim, including the falsy
+    ones a real model relies on (an empty ``""`` checkpoint prefix, a ``False``
+    ``mlp_gate_up_fused``). Keeping this the only reading path is what makes the
+    eight attributes behave uniformly.
+    """
+    value = getattr(config, attr, None)
+    return default if value is None else value
+
+
+def build_aoa_context(model, config) -> FleetAOAContext:
+    """Builds the read-only :class:`FleetAOAContext` for a whole-model pass.
+
+    Ensures ``_set_pipeline_name_mapping`` has run (idempotent; the same
+    side-effect ``state_dict`` / ``sharded_state_dict`` rely on), then resolves
+    every model-declared ``aoa_*`` attribute through :func:`_protocol_value`
+    against the module-level ``DEFAULT_*`` constants. The name mapping is the
+    one field with extra handling: it is copied so the context never aliases the
+    shared default, and validated as a name template.
+
+    Args:
+        model: The live ``GPTModel`` (or subclass) whose pipeline mapping backs
+            the single-name resolution and whose ``_model_name_prefix``
+            reports the authoritative model single-name root -- the same value
+            ``get_layer_desc_list`` uses to name its pipeline layers, so pipeline
+            naming and AOA name resolution never diverge.
+        config: The sub-structure config threaded into the context (whole-model
+            config for single-tower models, per-tower config for multi-tower).
+
+    Returns:
+        A frozen :class:`FleetAOAContext`.
+    """
+    if model._pipeline_name_mapping is None:
+        model._set_pipeline_name_mapping()
+    checkpoint_name_mapping = dict(
+        _protocol_value(
+            config,
+            "aoa_checkpoint_name_mapping",
+            DEFAULT_CHECKPOINT_NAME_MAPPING,
+        )
+    )
+    validate_checkpoint_name_mapping(checkpoint_name_mapping)
+    return FleetAOAContext(
+        config=config,
+        pp_to_single_mapping=model._pp_to_single_mapping or {},
+        model_name_prefix=model._model_name_prefix(),
+        checkpoint_name_mapping=checkpoint_name_mapping,
+        checkpoint_name_prefix=_protocol_value(
+            config,
+            "aoa_checkpoint_name_prefix",
+            DEFAULT_CHECKPOINT_NAME_PREFIX,
+        ),
+        dtype_cast_rules=_protocol_value(
+            config, "aoa_dtype_cast_rules", DEFAULT_DTYPE_CAST_RULES
+        ),
+        gate_checkpoint_layout=_protocol_value(
+            config,
+            "aoa_gate_checkpoint_layout",
+            DEFAULT_GATE_CHECKPOINT_LAYOUT,
+        ),
+        qkv_checkpoint_prefused=_protocol_value(
+            config,
+            "aoa_qkv_checkpoint_prefused",
+            DEFAULT_QKV_CHECKPOINT_PREFUSED,
+        ),
+        moe_expert_checkpoint_layout=_protocol_value(
+            config,
+            "aoa_moe_expert_checkpoint_layout",
+            DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT,
+        ),
+        mlp_gate_up_fused=_protocol_value(
+            config, "aoa_mlp_gate_up_fused", DEFAULT_MLP_GATE_UP_FUSED
+        ),
+        mapping_proj_checkpoint_transposed=_protocol_value(
+            config,
+            "aoa_mapping_proj_checkpoint_transposed",
+            DEFAULT_MAPPING_PROJ_CHECKPOINT_TRANSPOSED,
+        ),
+    )

--- a/src/paddlefleet/models/gpt/gpt_model.py
+++ b/src/paddlefleet/models/gpt/gpt_model.py
@@ -299,13 +299,23 @@ class GPTModel(PipelineLayer):
                 gpu_param = param.cuda()
                 gpu_param._share_buffer_to(param)
 
-    def get_layer_desc_list(self, spec, tie_word_embeddings):
-        layers = []
+    def _model_name_prefix(self) -> str:
+        """The model single-name root prefix (no trailing dot).
+
+        Authoritative for how this model roots its single-name space: used by
+        :meth:`get_layer_desc_list` to name pipeline layers and fed into
+        ``build_aoa_context``, so pipeline naming and AOA name resolution never
+        diverge (e.g. ``model.language_model`` for the qwen3_vl / qwen3_5
+        language tower instead of the ``model`` default).
+        """
         model_type = getattr(self.config, "model_type", "")
         if "qwen3_vl" in model_type or "qwen3_5" in model_type:
-            name_prefix = "model.language_model"
-        else:
-            name_prefix = "model"
+            return "model.language_model"
+        return "model"
+
+    def get_layer_desc_list(self, spec, tie_word_embeddings):
+        layers = []
+        name_prefix = self._model_name_prefix()
         if tie_word_embeddings:
             self.add_sequential_layer(
                 layers,
@@ -331,11 +341,32 @@ class GPTModel(PipelineLayer):
                 layers, LayerDesc(spec.embedding), name_prefix
             )
         i = 0
+        empty_index = 0
+        aoa_modular = getattr(
+            getattr(self, "config", None), "aoa_modular", False
+        )
+
+        def next_empty_layer_name():
+            """Name for the next EmptyLayer, advancing the right counter.
+
+            With ``aoa_modular`` empty layers live in their own
+            ``empty_layers.<i>`` namespace and do not consume a ``layers.<i>``
+            slot, so transformer layers start at ``layers.0``. Otherwise both
+            kinds share the ``i`` counter (the legacy ``+H`` offset).
+            """
+            nonlocal i, empty_index
+            if aoa_modular:
+                name = f"{name_prefix}.empty_layers.{empty_index}"
+                empty_index += 1
+            else:
+                name = f"{name_prefix}.layers.{i}"
+                i += 1
+            return name
+
         for head_empty_layer in spec.head_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(head_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(head_empty_layer), next_empty_layer_name()
             )
-            i += 1
 
         if spec.mhc_expand is not None:
             self.add_sequential_layer(
@@ -449,9 +480,8 @@ class GPTModel(PipelineLayer):
 
         for tail_empty_layer in spec.tail_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(tail_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(tail_empty_layer), next_empty_layer_name()
             )
-            i += 1
 
         if (
             self.config.gpt_model_use_experimental_version

--- a/src/paddlefleet/tensor_parallel/layers.py
+++ b/src/paddlefleet/tensor_parallel/layers.py
@@ -26,6 +26,13 @@ import paddle
 import paddle.distributed as dist
 import paddle.nn.functional as F
 from paddle.distributed.communication.reduce_scatter import _reduce_scatter_base
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    format_dtype_cast_attr,
+    format_inv_dtype_cast_attr,
+    resolve_dtype_cast_rule,
+    resolve_names,
+    should_skip,
+)
 from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
     build_sharded_state_dict,
 )
@@ -1283,6 +1290,96 @@ def linear_with_grad_accumulation_and_async_allreduce(
 linear_with_grad_accumulation_and_async_allreduce.warned = False
 
 
+def gen_linear_aoa_statements(
+    layer, ctx, *, structured_name_prefix="", aoa_name_scope=None
+):
+    """Checkpoint->model generator for the Linear family.
+
+    Weight carries a ``^T`` transpose; bias and any persistable buffer use
+    identity. A dtype cast suffix is appended when the model rules match the
+    single name. This is a plain module-level helper (not a base class) so
+    ``Linear`` / ``ColumnParallelLinear`` / ``RowParallelLinear`` share one
+    implementation without introducing a common ``LinearBase``. The transpose is
+    unconditional, so an owner whose embedded ``paddle.nn.Linear`` leaf may or
+    may not be transposed in the checkpoint (e.g.
+    ``HyperConnectionModule.mapping_proj``) emits that leaf inline instead of
+    calling this helper. The inverse direction has an independent helper and is
+    never derived from this one.
+    """
+    statements = []
+    local_state_dict = layer.state_dict(
+        structured_name_prefix="", include_sublayers=False
+    )
+    for name in local_state_dict:
+        if structured_name_prefix + name in ctx.excluded_names:
+            continue
+        checkpoint_name, single_name = resolve_names(
+            name,
+            ctx.checkpoint_name_prefix,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        cast = format_dtype_cast_attr(
+            resolve_dtype_cast_rule(
+                single_name,
+                ctx.dtype_cast_rules,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+        )
+        if name == "weight":
+            statements.append(f"{checkpoint_name}^T -> {single_name}{cast}")
+        else:
+            if should_skip(checkpoint_name, single_name, cast):
+                continue
+            statements.append(f"{checkpoint_name} -> {single_name}{cast}")
+    return statements
+
+
+def gen_linear_inv_aoa_statements(
+    layer, ctx, *, structured_name_prefix="", aoa_name_scope=None
+):
+    """Inverse (model -> checkpoint) generator for the Linear family.
+
+    Mirror of :func:`gen_linear_aoa_statements` for the opposite direction:
+    weight is transposed back (``^T`` stays on the source side), bias / buffers
+    use identity, and the dtype cast endpoints are swapped. Fully independent of
+    the checkpoint->model helper, never derived from its output text.
+    """
+    statements = []
+    local_state_dict = layer.state_dict(
+        structured_name_prefix="", include_sublayers=False
+    )
+    for name in local_state_dict:
+        if structured_name_prefix + name in ctx.excluded_names:
+            continue
+        checkpoint_name, single_name = resolve_names(
+            name,
+            ctx.checkpoint_name_prefix,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        cast = format_inv_dtype_cast_attr(
+            resolve_dtype_cast_rule(
+                single_name,
+                ctx.dtype_cast_rules,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+        )
+        if name == "weight":
+            statements.append(f"{single_name}^T -> {checkpoint_name}{cast}")
+        else:
+            if should_skip(checkpoint_name, single_name, cast):
+                continue
+            statements.append(f"{single_name} -> {checkpoint_name}{cast}")
+    return statements
+
+
 class Linear(paddle.nn.Layer):
     """Linear layer with no tensor parallelism (weight duplicated across TP ranks).
 
@@ -1593,6 +1690,37 @@ class Linear(paddle.nn.Layer):
         state_dict = self.state_dict(structured_name_prefix="")
         return build_sharded_state_dict(
             state_dict, None, structured_name_prefix
+        )
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model AOA for this Linear.
+
+        Weight is transposed (``^T``); bias / persistable buffers use identity;
+        a dtype cast suffix is appended when the model rules match.
+        """
+        return gen_linear_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) AOA for this Linear.
+
+        Independently generated, not derived from the checkpoint->model text:
+        weight is transposed back, bias / buffers use identity, dtype cast
+        endpoints are swapped.
+        """
+        return gen_linear_inv_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
         )
 
     def set_extra_state(self, state):
@@ -2123,6 +2251,37 @@ class ColumnParallelLinear(paddle.nn.Layer):
             state_dict, shard_rules, structured_name_prefix
         )
 
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model AOA for this Linear.
+
+        Weight is transposed (``^T``); bias / persistable buffers use identity;
+        a dtype cast suffix is appended when the model rules match.
+        """
+        return gen_linear_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) AOA for this Linear.
+
+        Independently generated, not derived from the checkpoint->model text:
+        weight is transposed back, bias / buffers use identity, dtype cast
+        endpoints are swapped.
+        """
+        return gen_linear_inv_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
     def set_extra_state(self, state):
         """Extra state is ignored"""
 
@@ -2439,6 +2598,37 @@ class RowParallelLinear(paddle.nn.Layer):
         shard_rules = None if self.world_size == 1 else {"weight": 0}
         return build_sharded_state_dict(
             state_dict, shard_rules, structured_name_prefix
+        )
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model AOA for this Linear.
+
+        Weight is transposed (``^T``); bias / persistable buffers use identity;
+        a dtype cast suffix is appended when the model rules match.
+        """
+        return gen_linear_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) AOA for this Linear.
+
+        Independently generated, not derived from the checkpoint->model text:
+        weight is transposed back, bias / buffers use identity, dtype cast
+        endpoints are swapped.
+        """
+        return gen_linear_inv_aoa_statements(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
         )
 
     def set_extra_state(self, state):

--- a/src/paddlefleet/transformer/attention.py
+++ b/src/paddlefleet/transformer/attention.py
@@ -30,6 +30,15 @@ import paddle
 from paddle import Tensor, nn
 from paddle.distributed.fleet.meta_parallel import LayerSpec, build_spec_layer
 from paddle.distributed.fleet.utils import recompute
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    format_dtype_cast_attr,
+    format_inv_dtype_cast_attr,
+    resolve_checkpoint_name_from_anchor,
+    resolve_dtype_cast_rule,
+    resolve_names,
+    resolve_single_name,
+    should_skip,
+)
 
 from paddlefleet import tensor_parallel
 from paddlefleet.context_parallel_utils import ContextParallelScatterOp
@@ -51,6 +60,10 @@ from paddlefleet.tensor_parallel import RecomputeWithoutOutput
 from paddlefleet.tensor_parallel.mappings import (
     gather_from_tensor_model_parallel_region,
     scatter_to_tensor_model_parallel_region,
+)
+from paddlefleet.transformer.gated_qkv_aoa import (
+    gen_gated_qkv_aoa,
+    gen_gated_qkv_inv_aoa,
 )
 from paddlefleet.transformer.layer import FleetLayer
 from paddlefleet.transformer.utils import (
@@ -1168,6 +1181,442 @@ class SelfAttention(Attention):
     def _backward_output_proj(self):
         """Update weights for output projection layer"""
         self.o_proj.backward_dw()
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model generator for standard
+        SelfAttention.
+
+        ``qkv_proj`` fuses checkpoint q/k/v (each transposed) via the
+        ``fused_qkv`` macro; every other direct child (``o_proj``, ``q_norm``,
+        ``k_norm``, ``core_attention`` ...) is recursed generically so Linear
+        leaves get their transpose and Norm/buffer leaves get identity. The qkv
+        head is dispatched by declared checkpoint layout (standard / gated /
+        pre-fused vision) in :meth:`_gen_qkv_head_aoa_statements`. Inverse is
+        implemented independently.
+        """
+        statements = self._gen_qkv_head_aoa_statements(
+            ctx, structured_name_prefix, aoa_name_scope
+        )
+        local_state_dict = self.state_dict(
+            structured_name_prefix="", include_sublayers=False
+        )
+        for name in local_state_dict:
+            if structured_name_prefix + name in ctx.excluded_names:
+                continue
+            source_name, target_name = resolve_names(
+                name,
+                ctx.checkpoint_name_prefix,
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            cast = format_dtype_cast_attr(
+                resolve_dtype_cast_rule(
+                    target_name,
+                    ctx.dtype_cast_rules,
+                    ctx.model_name_prefix,
+                )
+            )
+            if should_skip(source_name, target_name, cast):
+                continue
+            statements.append(f"{source_name} -> {target_name}{cast}")
+        for layer_name, sublayer in self._sub_layers.items():
+            if sublayer is None or layer_name == "qkv_proj":
+                continue
+            statements += sublayer.gen_aoa_statements(
+                ctx,
+                structured_name_prefix=(
+                    f"{structured_name_prefix}{layer_name}."
+                ),
+                aoa_name_scope=aoa_name_scope,
+            )
+        return statements
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Inverse (model -> checkpoint) generator for standard
+        SelfAttention.
+
+        Independently splits the fused ``qkv_proj`` back into checkpoint q/k/v
+        via ``fused_qkv``, then recurses every other direct child. The qkv head
+        is dispatched by declared checkpoint layout in
+        :meth:`_gen_inv_qkv_head_aoa_statements`. The inverse ``fused_qkv``
+        carries no ``^T`` (matches the validated existing generators in
+        ``aoa_config_base``/``qwen3_moe``/``glm4_moe``). Not derived from the
+        checkpoint->model text.
+        """
+        statements = self._gen_inv_qkv_head_aoa_statements(
+            ctx, structured_name_prefix, aoa_name_scope
+        )
+        local_state_dict = self.state_dict(
+            structured_name_prefix="", include_sublayers=False
+        )
+        for name in local_state_dict:
+            if structured_name_prefix + name in ctx.excluded_names:
+                continue
+            target_name, source_name = resolve_names(
+                name,
+                ctx.checkpoint_name_prefix,
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            cast = format_inv_dtype_cast_attr(
+                resolve_dtype_cast_rule(
+                    source_name,
+                    ctx.dtype_cast_rules,
+                    ctx.model_name_prefix,
+                )
+            )
+            if should_skip(source_name, target_name, cast):
+                continue
+            statements.append(f"{source_name} -> {target_name}{cast}")
+        for layer_name, sublayer in self._sub_layers.items():
+            if sublayer is None or layer_name == "qkv_proj":
+                continue
+            statements += sublayer.gen_inv_aoa_statements(
+                ctx,
+                structured_name_prefix=(
+                    f"{structured_name_prefix}{layer_name}."
+                ),
+                aoa_name_scope=aoa_name_scope,
+            )
+        return statements
+
+    def _gen_qkv_head_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Checkpoint->model qkv head (weight + optional bias), dispatched by
+        declared checkpoint layout.
+
+        - gated attention with the gate fused into ``qkv_proj`` (non-experimental
+          path) -> :func:`gen_gated_qkv_aoa` (``ctx.gate_checkpoint_layout``);
+        - a pre-fused vision checkpoint (``ctx.qkv_checkpoint_prefused``) ->
+          split the single fused ``qkv`` first;
+        - otherwise the standard ``fused_qkv`` over separate q/k/v keys.
+        """
+        if self.gated_attention and not getattr(
+            self.config, "gpt_model_use_experimental_version", False
+        ):
+            return gen_gated_qkv_aoa(
+                self,
+                ctx,
+                structured_name_prefix,
+                aoa_name_scope,
+                ctx.gate_checkpoint_layout,
+            )
+        if ctx.qkv_checkpoint_prefused:
+            return self._gen_prefused_qkv_head_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+        config = ctx.config
+        qkv_local_name = "qkv_proj.weight"
+        qkv_model_name = resolve_single_name(
+            qkv_local_name,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+
+        def _anchor(local):
+            return resolve_checkpoint_name_from_anchor(
+                qkv_model_name,
+                qkv_local_name,
+                local,
+                ctx.checkpoint_name_prefix,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+
+        q_checkpoint_name = _anchor("q_proj.weight")
+        k_checkpoint_name = _anchor("k_proj.weight")
+        v_checkpoint_name = _anchor("v_proj.weight")
+        statements = []
+        # ``excluded_names`` holds model names another statement already
+        # produces, so re-emitting one here would duplicate the target. A
+        # fusion is all-or-nothing: the whole statement goes or stays. Weight
+        # and bias are excluded independently.
+        if f"{structured_name_prefix}qkv_proj.weight" not in ctx.excluded_names:
+            statements.append(
+                f"{q_checkpoint_name}^T, {k_checkpoint_name}^T, "
+                f"{v_checkpoint_name}^T "
+                f"-> {qkv_model_name}, fused_qkv, "
+                f"num_heads={config.num_attention_heads}, "
+                f"num_key_value_groups={config.num_key_value_heads}"
+            )
+        if self.qkv_proj.bias is not None:
+            statements += self._gen_qkv_bias_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+        return statements
+
+    def _gen_prefused_qkv_head_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Checkpoint->model qkv head for a pre-fused vision checkpoint: split
+        the single fused ``qkv`` into q/k/v temporaries, then re-fuse (with
+        transpose) into the model ``qkv_proj``. No GQA in the vision tower, so
+        ``num_key_value_groups == num_heads == self.config.num_attention_heads``
+        (the tower-local vision config)."""
+        nh = self.config.num_attention_heads
+
+        def _names(suffix):
+            model_name = resolve_single_name(
+                f"qkv_proj.{suffix}",
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            checkpoint_name = resolve_checkpoint_name_from_anchor(
+                model_name,
+                f"qkv_proj.{suffix}",
+                f"qkv.{suffix}",
+                ctx.checkpoint_name_prefix,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            return model_name, checkpoint_name
+
+        qkv_model, qkv_ckpt = _names("weight")
+        statements = []
+        if f"{structured_name_prefix}qkv_proj.weight" not in ctx.excluded_names:
+            q_t = f"{qkv_ckpt}._vis_q"
+            k_t = f"{qkv_ckpt}._vis_k"
+            v_t = f"{qkv_ckpt}._vis_v"
+            statements += [
+                f"{qkv_ckpt} -> {q_t}, {k_t}, {v_t}, axis=0",
+                f"{q_t}^T, {k_t}^T, {v_t}^T -> {qkv_model}, fused_qkv, "
+                f"num_heads={nh}, num_key_value_groups={nh}",
+            ]
+        if self.qkv_proj.bias is not None and (
+            f"{structured_name_prefix}qkv_proj.bias" not in ctx.excluded_names
+        ):
+            bias_model, bias_ckpt = _names("bias")
+            qb = f"{bias_ckpt}._vis_q"
+            kb = f"{bias_ckpt}._vis_k"
+            vb = f"{bias_ckpt}._vis_v"
+            statements += [
+                f"{bias_ckpt} -> {qb}, {kb}, {vb}, axis=0",
+                f"{qb}, {kb}, {vb} -> {bias_model}, fused_qkv, "
+                f"num_heads={nh}, num_key_value_groups={nh}, axis=0",
+            ]
+        return statements
+
+    def _gen_qkv_bias_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Checkpoint->model helper: fuse checkpoint q/k/v 1-D bias into the
+        model fused bias (``axis=0``, no transpose). Anchored on the real
+        ``qkv_proj.bias``."""
+        config = ctx.config
+        bias_local_name = "qkv_proj.bias"
+        if structured_name_prefix + bias_local_name in ctx.excluded_names:
+            return []
+        bias_model_name = resolve_single_name(
+            bias_local_name,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        q_checkpoint_name = resolve_checkpoint_name_from_anchor(
+            bias_model_name,
+            bias_local_name,
+            "q_proj.bias",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        k_checkpoint_name = resolve_checkpoint_name_from_anchor(
+            bias_model_name,
+            bias_local_name,
+            "k_proj.bias",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        v_checkpoint_name = resolve_checkpoint_name_from_anchor(
+            bias_model_name,
+            bias_local_name,
+            "v_proj.bias",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        return [
+            f"{q_checkpoint_name}, {k_checkpoint_name}, "
+            f"{v_checkpoint_name} -> {bias_model_name}, "
+            f"fused_qkv, num_heads={config.num_attention_heads}, "
+            f"num_key_value_groups={config.num_key_value_heads}, axis=0"
+        ]
+
+    def _gen_inv_qkv_head_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Model->checkpoint qkv head (weight + optional bias), dispatched by
+        declared checkpoint layout. Mirrors
+        :meth:`_gen_qkv_head_aoa_statements` but implemented independently."""
+        if self.gated_attention and not getattr(
+            self.config, "gpt_model_use_experimental_version", False
+        ):
+            return gen_gated_qkv_inv_aoa(
+                self,
+                ctx,
+                structured_name_prefix,
+                aoa_name_scope,
+                ctx.gate_checkpoint_layout,
+            )
+        if ctx.qkv_checkpoint_prefused:
+            return self._gen_inv_prefused_qkv_head_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+        config = ctx.config
+        qkv_local_name = "qkv_proj.weight"
+        qkv_model_name = resolve_single_name(
+            qkv_local_name,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+
+        def _anchor(local):
+            return resolve_checkpoint_name_from_anchor(
+                qkv_model_name,
+                qkv_local_name,
+                local,
+                ctx.checkpoint_name_prefix,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+
+        q_checkpoint_name = _anchor("q_proj.weight")
+        k_checkpoint_name = _anchor("k_proj.weight")
+        v_checkpoint_name = _anchor("v_proj.weight")
+        statements = []
+        if f"{structured_name_prefix}qkv_proj.weight" not in ctx.excluded_names:
+            statements.append(
+                f"{qkv_model_name} -> {q_checkpoint_name}, "
+                f"{k_checkpoint_name}, {v_checkpoint_name}, "
+                f"fused_qkv, num_heads={config.num_attention_heads}, "
+                f"num_key_value_groups={config.num_key_value_heads}"
+            )
+        if self.qkv_proj.bias is not None:
+            statements += self._gen_inv_qkv_bias_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+        return statements
+
+    def _gen_inv_prefused_qkv_head_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Model->checkpoint qkv head for a pre-fused vision checkpoint: split
+        the model ``qkv_proj`` into q/k/v (no transpose) and merge them (with
+        transpose) into the checkpoint fused ``qkv``. Independent inverse."""
+        nh = self.config.num_attention_heads
+
+        def _names(suffix):
+            model_name = resolve_single_name(
+                f"qkv_proj.{suffix}",
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            checkpoint_name = resolve_checkpoint_name_from_anchor(
+                model_name,
+                f"qkv_proj.{suffix}",
+                f"qkv.{suffix}",
+                ctx.checkpoint_name_prefix,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            return model_name, checkpoint_name
+
+        qkv_model, qkv_ckpt = _names("weight")
+        statements = []
+        if f"{structured_name_prefix}qkv_proj.weight" not in ctx.excluded_names:
+            q_t = f"{qkv_ckpt}._vis_q"
+            k_t = f"{qkv_ckpt}._vis_k"
+            v_t = f"{qkv_ckpt}._vis_v"
+            statements += [
+                f"{qkv_model} -> {q_t}, {k_t}, {v_t}, fused_qkv, "
+                f"num_heads={nh}, num_key_value_groups={nh}",
+                f"{q_t}^T, {k_t}^T, {v_t}^T -> {qkv_ckpt}, axis=0",
+            ]
+        if self.qkv_proj.bias is not None and (
+            f"{structured_name_prefix}qkv_proj.bias" not in ctx.excluded_names
+        ):
+            bias_model, bias_ckpt = _names("bias")
+            qb = f"{bias_ckpt}._vis_q"
+            kb = f"{bias_ckpt}._vis_k"
+            vb = f"{bias_ckpt}._vis_v"
+            statements += [
+                f"{bias_model} -> {qb}, {kb}, {vb}, fused_qkv, "
+                f"num_heads={nh}, num_key_value_groups={nh}, axis=0",
+                f"{qb}, {kb}, {vb} -> {bias_ckpt}, axis=0",
+            ]
+        return statements
+
+    def _gen_inv_qkv_bias_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Inverse-only helper: split the model fused 1-D bias back into
+        checkpoint q/k/v bias (``axis=0``, no transpose)."""
+        config = ctx.config
+        bias_local_name = "qkv_proj.bias"
+        if structured_name_prefix + bias_local_name in ctx.excluded_names:
+            return []
+        bias_model_name = resolve_single_name(
+            bias_local_name,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        q_checkpoint_name = resolve_checkpoint_name_from_anchor(
+            bias_model_name,
+            bias_local_name,
+            "q_proj.bias",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        k_checkpoint_name = resolve_checkpoint_name_from_anchor(
+            bias_model_name,
+            bias_local_name,
+            "k_proj.bias",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        v_checkpoint_name = resolve_checkpoint_name_from_anchor(
+            bias_model_name,
+            bias_local_name,
+            "v_proj.bias",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        return [
+            f"{bias_model_name} -> {q_checkpoint_name}, "
+            f"{k_checkpoint_name}, {v_checkpoint_name}, "
+            f"fused_qkv, num_heads={config.num_attention_heads}, "
+            f"num_key_value_groups={config.num_key_value_heads}, axis=0"
+        ]
 
 
 class SelfAttentionVHA(Attention):

--- a/src/paddlefleet/transformer/csa_attention.py
+++ b/src/paddlefleet/transformer/csa_attention.py
@@ -54,6 +54,10 @@ from paddlefleet.transformer.dsa_attention import (
     fused_qk_topk_naive,
     rotate_activation,
 )
+from paddlefleet.transformer.init_from_scratch_aoa import (
+    gen_init_from_scratch_aoa,
+    resolve_init_from_scratch,
+)
 
 if TYPE_CHECKING:
     from paddlefleet.process_groups_config import ProcessGroupCollection
@@ -2108,6 +2112,32 @@ class CSAIndexer(nn.Layer):
                 {"heads": self.index_n_heads},
             ),
         }
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint -> model, with the phase-1 add branch.
+
+        Phase 1 runs with ``csa_dense_mode=true`` and builds no Indexer, so this
+        subtree (including its nested ``compressor``) can be absent from the
+        checkpoint being resumed. ``indexer_init_from_scratch`` says whether it
+        is; see ``init_from_scratch_aoa.gen_init_from_scratch_aoa``. The inverse
+        direction is intentionally not overridden.
+        """
+        if not resolve_init_from_scratch(
+            self.config, "a CSA Indexer", "csa_dense_mode=false"
+        ):
+            return super().gen_aoa_statements(
+                ctx,
+                structured_name_prefix=structured_name_prefix,
+                aoa_name_scope=aoa_name_scope,
+            )
+        return gen_init_from_scratch_aoa(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
 
     def forward_before_topk(
         self,

--- a/src/paddlefleet/transformer/dsa_attention.py
+++ b/src/paddlefleet/transformer/dsa_attention.py
@@ -50,6 +50,10 @@ from paddlefleet.tensor_parallel.mappings import (
 from paddlefleet.transformer.cp_utils import all_gather_cp
 from paddlefleet.transformer.dw_overlap import deferrable_linear
 from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.init_from_scratch_aoa import (
+    gen_init_from_scratch_aoa,
+    resolve_init_from_scratch,
+)
 from paddlefleet.transformer.layer import FleetLayer
 
 try:
@@ -432,6 +436,33 @@ class DSAIndexer(paddle.nn.Layer):
         return {
             "wq_b.weight": (ortho_per_head, {"heads": self.n_heads}),
         }
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint -> model, with the phase-1 add branch.
+
+        Latent MQA keeps the MHA parameters byte-identical, so this indexer is
+        the whole parameter delta of ``hybrid_mla_attention="mqa_dsa"`` over a
+        phase-1 ``"mha"`` checkpoint. ``indexer_init_from_scratch`` says whether
+        that checkpoint has it; see
+        ``init_from_scratch_aoa.gen_init_from_scratch_aoa``. The inverse
+        direction is intentionally not overridden.
+        """
+        if not resolve_init_from_scratch(
+            self.config, "a DSA Indexer", 'hybrid_mla_attention="mqa_dsa"'
+        ):
+            return super().gen_aoa_statements(
+                ctx,
+                structured_name_prefix=structured_name_prefix,
+                aoa_name_scope=aoa_name_scope,
+            )
+        return gen_init_from_scratch_aoa(
+            self,
+            ctx,
+            structured_name_prefix=structured_name_prefix,
+            aoa_name_scope=aoa_name_scope,
+        )
 
     def _apply_rope(
         self, x: Tensor, freqs: Tensor, mscale: float = 1.0

--- a/src/paddlefleet/transformer/gated_qkv_aoa.py
+++ b/src/paddlefleet/transformer/gated_qkv_aoa.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Gated-attention qkv AOA helper (checkpoint <-> model).
+
+Some attention towers fuse an output gate into ``qkv_proj`` alongside q/k/v in a
+per-KV-group ``[Q, Gate, K, V]`` layout that the generic ``fused_qkv`` macro
+cannot express. The model side is identical across such towers; only the
+checkpoint-side gate placement differs, declared via
+``ctx.gate_checkpoint_layout``:
+
+* ``"separate"`` -- the gate is its own checkpoint tensor ``gate_proj`` (the
+  ERNIE-Lite layout). Q and Gate are split from two distinct checkpoint keys.
+* ``"interleaved"`` -- the gate is head-interleaved inside the ``q_proj``
+  checkpoint tensor (``[Q_h0, Gate_h0, Q_h1, Gate_h1, ...]``, the Qwen3.5
+  layout). There is no separate ``gate_proj`` key, so the single ``q_proj`` is
+  split into interleaved Q/Gate chunks.
+
+Only the source split/merge on the checkpoint side differs between the two
+layouts; the model per-group regroup and transpose are identical. ``head_dim``
+may differ from the gate/value head dim, so each per-head slice is sub-chunked
+at their GCD before regrouping. The inverse is implemented independently, never
+derived from the forward text (the shared pure name-builder is
+direction-agnostic).
+"""
+
+from __future__ import annotations
+
+import math
+
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    resolve_checkpoint_name_from_anchor,
+    resolve_single_name,
+)
+
+GATE_CHECKPOINT_LAYOUTS = ("separate", "interleaved")
+
+
+def _check_layout(layout):
+    """Rejects an unknown gate layout instead of defaulting silently.
+
+    Both emit paths branch on ``layout == "interleaved"`` with the separate
+    layout as the else-branch, so a typo would otherwise produce plausible but
+    wrong statements that only surface as a shape mismatch at load time.
+    """
+    if layout not in GATE_CHECKPOINT_LAYOUTS:
+        raise ValueError(
+            f"unknown gate_checkpoint_layout {layout!r}; expected one of "
+            f"{GATE_CHECKPOINT_LAYOUTS}"
+        )
+
+
+def _temp_names(base, num_heads, num_kv_groups, head_dim, v_head_dim, gated):
+    """Pure name-builder: per-head Q/Gate and per-group K/V temp names.
+
+    Returns ``(q_list, gate_list, k_list, v_list, fused, qg_interleaved)``.
+    ``fused`` is the model per-group concatenation order
+    ``for g: [Q_g, Gate_g, K_g, V_g]``. ``qg_interleaved`` is the checkpoint
+    ``q_proj`` order for the interleaved layout: for each ``(group, head)`` the
+    head's Q chunks followed by its Gate chunks. Both reference the same temp
+    names, only reordered.
+    """
+    gcd = math.gcd(head_dim, v_head_dim)
+    hd_chunks = head_dim // gcd
+    vhd_chunks = v_head_dim // gcd
+    heads_per_group = num_heads // num_kv_groups
+    q_list, gate_list, k_list, v_list, fused, qg_interleaved = (
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+    )
+    for g in range(num_kv_groups):
+        q_g, gate_g = [], []
+        for h in range(heads_per_group):
+            q_h = [f"{base}._q_g{g}_h{h}_c{c}" for c in range(hd_chunks)]
+            gate_h = (
+                [f"{base}._gate_g{g}_h{h}_c{c}" for c in range(vhd_chunks)]
+                if gated
+                else []
+            )
+            q_g += q_h
+            gate_g += gate_h
+            qg_interleaved += q_h + gate_h
+        k_g = [f"{base}._k_g{g}_c{c}" for c in range(hd_chunks)]
+        v_g = [f"{base}._v_g{g}_c{c}" for c in range(vhd_chunks)]
+        q_list += q_g
+        gate_list += gate_g
+        k_list += k_g
+        v_list += v_g
+        fused += q_g + gate_g + k_g + v_g
+    return q_list, gate_list, k_list, v_list, fused, qg_interleaved
+
+
+def _resolve_names(
+    attn, ctx, structured_name_prefix, aoa_name_scope, layout, bias
+):
+    """Resolve the model ``qkv_proj`` single name and the checkpoint source
+    names via anchor resolution. ``gate_ckpt`` is ``None`` for the interleaved
+    layout (gate rides inside ``q_proj``)."""
+    suffix = "bias" if bias else "weight"
+    qkv_local = f"qkv_proj.{suffix}"
+    qkv_model = resolve_single_name(
+        qkv_local,
+        structured_name_prefix,
+        ctx.pp_to_single_mapping,
+        model_name_prefix=ctx.model_name_prefix,
+    )
+
+    def ckpt(local):
+        return resolve_checkpoint_name_from_anchor(
+            qkv_model,
+            qkv_local,
+            local,
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+
+    gate_ckpt = ckpt(f"gate_proj.{suffix}") if layout == "separate" else None
+    return (
+        qkv_model,
+        ckpt(f"q_proj.{suffix}"),
+        gate_ckpt,
+        ckpt(f"k_proj.{suffix}"),
+        ckpt(f"v_proj.{suffix}"),
+    )
+
+
+def _is_excluded(ctx, structured_name_prefix, bias):
+    """Whether this direction's ``qkv_proj`` parameter is already produced by
+    another statement (a shared-layer alias), in which case re-emitting it
+    would duplicate the target. A fusion is all-or-nothing, so the whole group
+    of statements goes or stays; weight and bias are excluded independently.
+    """
+    suffix = "bias" if bias else "weight"
+    key = f"{structured_name_prefix}qkv_proj.{suffix}"
+    return key in ctx.excluded_names
+
+
+def _gen_qkv_statements(
+    attn, ctx, structured_name_prefix, aoa_name_scope, layout, *, bias
+):
+    """Checkpoint -> model qkv statements for one of weight / bias."""
+    if _is_excluded(ctx, structured_name_prefix, bias):
+        return []
+    qkv_model, q_ckpt, gate_ckpt, k_ckpt, v_ckpt = _resolve_names(
+        attn, ctx, structured_name_prefix, aoa_name_scope, layout, bias
+    )
+    gated = attn.gated_attention
+    (
+        q_names,
+        gate_names,
+        k_names,
+        v_names,
+        fused_names,
+        qg_interleaved,
+    ) = _temp_names(
+        qkv_model,
+        num_heads=attn.num_attention_heads,
+        num_kv_groups=attn.num_key_value_heads,
+        head_dim=attn.head_dim,
+        v_head_dim=attn.v_head_dim,
+        gated=gated,
+    )
+    if layout == "interleaved":
+        # Single q_proj carries Q+Gate head-interleaved; one split produces
+        # both Q and Gate temps in checkpoint order.
+        stmts = [f"{q_ckpt} -> {','.join(qg_interleaved)}, axis=0"]
+    else:
+        stmts = [f"{q_ckpt} -> {','.join(q_names)}, axis=0"]
+        if gated:
+            stmts.append(f"{gate_ckpt} -> {','.join(gate_names)}, axis=0")
+    stmts.append(f"{k_ckpt} -> {','.join(k_names)}, axis=0")
+    stmts.append(f"{v_ckpt} -> {','.join(v_names)}, axis=0")
+    if bias:
+        stmts.append(f"{','.join(fused_names)} -> {qkv_model}, axis=0")
+    else:
+        fused_tmp = f"{qkv_model}.qkv_fused_tmp"
+        stmts.append(f"{','.join(fused_names)} -> {fused_tmp}, axis=0")
+        stmts.append(f"{fused_tmp}^T -> {qkv_model}")
+    return stmts
+
+
+def _gen_inv_qkv_statements(
+    attn, ctx, structured_name_prefix, aoa_name_scope, layout, *, bias
+):
+    """Model -> checkpoint qkv statements for one of weight / bias."""
+    if _is_excluded(ctx, structured_name_prefix, bias):
+        return []
+    qkv_model, q_ckpt, gate_ckpt, k_ckpt, v_ckpt = _resolve_names(
+        attn, ctx, structured_name_prefix, aoa_name_scope, layout, bias
+    )
+    gated = attn.gated_attention
+    (
+        q_names,
+        gate_names,
+        k_names,
+        v_names,
+        fused_names,
+        qg_interleaved,
+    ) = _temp_names(
+        qkv_model,
+        num_heads=attn.num_attention_heads,
+        num_kv_groups=attn.num_key_value_heads,
+        head_dim=attn.head_dim,
+        v_head_dim=attn.v_head_dim,
+        gated=gated,
+    )
+    if bias:
+        stmts = [f"{qkv_model} -> {','.join(fused_names)}, axis=0"]
+    else:
+        fused_tmp = f"{qkv_model}.qkv_fused_tmp"
+        stmts = [f"{qkv_model}^T -> {fused_tmp}"]
+        stmts.append(f"{fused_tmp} -> {','.join(fused_names)}, axis=0")
+    if layout == "interleaved":
+        stmts.append(f"{','.join(qg_interleaved)} -> {q_ckpt}, axis=0")
+    else:
+        stmts.append(f"{','.join(q_names)} -> {q_ckpt}, axis=0")
+        if gated:
+            stmts.append(f"{','.join(gate_names)} -> {gate_ckpt}, axis=0")
+    stmts.append(f"{','.join(k_names)} -> {k_ckpt}, axis=0")
+    stmts.append(f"{','.join(v_names)} -> {v_ckpt}, axis=0")
+    return stmts
+
+
+def gen_gated_qkv_aoa(
+    attn, ctx, structured_name_prefix, aoa_name_scope, layout
+):
+    """Forward qkv head statements (weight + optional bias) for gated attention.
+
+    Replaces the standard ``fused_qkv`` head of the base ``SelfAttention``.
+    """
+    _check_layout(layout)
+    stmts = _gen_qkv_statements(
+        attn, ctx, structured_name_prefix, aoa_name_scope, layout, bias=False
+    )
+    if attn.qkv_proj.bias is not None:
+        stmts += _gen_qkv_statements(
+            attn, ctx, structured_name_prefix, aoa_name_scope, layout, bias=True
+        )
+    return stmts
+
+
+def gen_gated_qkv_inv_aoa(
+    attn, ctx, structured_name_prefix, aoa_name_scope, layout
+):
+    """Inverse qkv head statements (weight + optional bias) for gated attention.
+
+    Independently mirrors :func:`gen_gated_qkv_aoa`.
+    """
+    _check_layout(layout)
+    stmts = _gen_inv_qkv_statements(
+        attn, ctx, structured_name_prefix, aoa_name_scope, layout, bias=False
+    )
+    if attn.qkv_proj.bias is not None:
+        stmts += _gen_inv_qkv_statements(
+            attn, ctx, structured_name_prefix, aoa_name_scope, layout, bias=True
+        )
+    return stmts

--- a/src/paddlefleet/transformer/init_from_scratch_aoa.py
+++ b/src/paddlefleet/transformer/init_from_scratch_aoa.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""AOA "add" helper: a whole subtree that the checkpoint does not contain.
+
+Multi-phase training grows the model between phases. A phase-1 checkpoint holds
+no Indexer at all (``csa_dense_mode=true`` / ``hybrid_mla_attention="mha"``
+builds none), yet phase 2 must load that checkpoint into a model that has one.
+AOA expresses this with the source-less statement ``_ -> <model name>``: the key
+is declared to have no checkpoint source, so it keeps what the freshly built
+module initialised while every other tensor loads normally. Omitting the
+statement instead would not work -- an uncovered key falls back to identity
+naming and aborts with ``... should be assigned before!``.
+
+:func:`gen_init_from_scratch_aoa` emits that statement for every tensor of a
+subtree, and :func:`resolve_init_from_scratch` reads the switch that selects the
+branch, refusing to guess when it is unset.
+
+Checkpoint -> model only. The inverse direction is unconditional: whatever the
+model owns is written out, so a component using this helper must not override
+``gen_inv_aoa_statements``.
+"""
+
+from __future__ import annotations
+
+from paddle.distributed.flex_checkpoint.aoa.generation import resolve_names
+
+
+def resolve_init_from_scratch(config, what, gated_by):
+    """Read the mandatory ``indexer_init_from_scratch`` switch off ``config``.
+
+    Leaving it unset is an error rather than a default: it says which checkpoint
+    the run starts from, which is a deliberate decision. Guessing it wrong is
+    silent -- ``False`` against a checkpoint that lacks the tensors aborts with
+    ``... should be assigned before!``, while ``True`` against one that has them
+    throws away everything trained so far.
+
+    Args:
+        config: The ``TransformerConfig`` of the component.
+        what: What the model builds, for the error message (e.g. ``"a DSA
+            Indexer"``).
+        gated_by: The config that makes the model build it, for the error
+            message (e.g. ``'hybrid_mla_attention="mqa_dsa"'``).
+
+    Returns:
+        The switch value.
+
+    Raises:
+        ValueError: When ``indexer_init_from_scratch`` is ``None``.
+    """
+    field = "indexer_init_from_scratch"
+    value = getattr(config, field, None)
+    if value is None:
+        raise ValueError(
+            f"{field} must be set explicitly when loading a checkpoint into a "
+            f"model that creates {what} ({gated_by}). It selects which "
+            "checkpoint you start from:\n"
+            f"  {field}: true   # phase-1 checkpoint: it does not have these "
+            "tensors, initialize them randomly\n"
+            f"  {field}: false  # checkpoint already contains them: load them "
+            "(phase 2 restart, or phase 3 from phase 2, or phase 3 restart)"
+        )
+    return value
+
+
+def gen_init_from_scratch_aoa(
+    layer, ctx, *, structured_name_prefix="", aoa_name_scope=None
+):
+    """``_ -> <model name>`` for every tensor of ``layer`` and its sub-layers.
+
+    Walks own parameters / persistable buffers and then recurses, the same
+    traversal ``Layer.gen_aoa_statements`` and ``Layer.sharded_state_dict`` use,
+    so the emitted keys are exactly the ones the engine has to assign. The
+    recursion deliberately does not dispatch to sub-layer overrides: a
+    source-less statement has no checkpoint side, and the model side of every
+    override resolves the same way, so the plain walk is both sufficient and
+    immune to their layout rewrites.
+
+    No ``should_skip`` (an add is never redundant) and no dtype cast (there is
+    no source to cast from). ``ctx.excluded_names`` is honoured, so a tensor
+    another component claims stays claimed.
+
+    Args:
+        layer: Root of the subtree that the checkpoint does not contain.
+        ctx: Read-only ``AOAContext`` for the generation pass.
+        structured_name_prefix: Live module path prefix of ``layer``, ending in
+            ``.`` when non-empty, as in ``sharded_state_dict``.
+        aoa_name_scope: Optional checkpoint-side scope, passed down unchanged.
+
+    Returns:
+        One statement per tensor in the subtree.
+    """
+    statements = []
+    own_state_dict = layer.state_dict(
+        structured_name_prefix="", include_sublayers=False
+    )
+    for name in own_state_dict:
+        if structured_name_prefix + name in ctx.excluded_names:
+            continue
+        _, single_name = resolve_names(
+            name,
+            ctx.checkpoint_name_prefix,
+            structured_name_prefix,
+            ctx.pp_to_single_mapping,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        statements.append(f"_ -> {single_name}")
+    for layer_name, sublayer in layer._sub_layers.items():
+        if sublayer is not None:
+            statements += gen_init_from_scratch_aoa(
+                sublayer,
+                ctx,
+                structured_name_prefix=f"{structured_name_prefix}{layer_name}.",
+                aoa_name_scope=aoa_name_scope,
+            )
+    return statements

--- a/src/paddlefleet/transformer/multi_latent_attention.py
+++ b/src/paddlefleet/transformer/multi_latent_attention.py
@@ -22,6 +22,15 @@ import paddle
 from paddle import Tensor
 from paddle.distributed.fleet.meta_parallel import LayerSpec, build_spec_layer
 from paddle.distributed.fleet.utils import recompute
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    format_dtype_cast_attr,
+    format_inv_dtype_cast_attr,
+    resolve_checkpoint_name_from_anchor,
+    resolve_dtype_cast_rule,
+    resolve_names,
+    resolve_single_name,
+    should_skip,
+)
 
 from paddlefleet.context_parallel_utils import (
     ContextParallelAllGatherOp,
@@ -1611,6 +1620,320 @@ class MLASelfAttention(MultiLatentAttention):
                 {"heads": num_heads},
             )
         return specs
+
+    # Local names of the two standalone absorption parameters that replace
+    # ``kv_b_proj`` under ``mqa_split_kv_b_proj``. The generic own-parameter
+    # walk must skip both: they are the two ends of one chain over the single
+    # checkpoint ``kv_b_proj.weight`` key, so an extra identity statement for
+    # either one would add a second producer for the same target as soon as a
+    # ``checkpoint_name_mapping`` makes its source differ from its target.
+    _SPLIT_KV_B_LOCAL_NAMES = ("k_b_proj", "v_b_proj")
+
+    def _split_kv_b_head_blocks(self):
+        """``(heads, n_k, n_v)``: row-block geometry of one head's slice.
+
+        The checkpoint keeps ``kv_b_proj.weight`` as the transpose of the Fleet
+        weight, i.e. ``[heads * (qk_nope_head_dim + v_head_dim),
+        kv_lora_rank]``, with head-major rows: per head the ``qk_nope`` K rows
+        first, then the ``v_head`` V rows. An AOA split only produces *equal*
+        blocks, so the granularity is ``gcd(qk_nope, v_head)`` and one head
+        spans ``n_k + n_v`` of those blocks.
+
+        Read off the same attributes ``__init__`` sized ``k_b_proj`` /
+        ``v_b_proj`` with, so the statements cannot drift from the parameters
+        they describe. TP is forced to 1 in this mode, hence the per-partition
+        head count is the full head count.
+        """
+        chunk = math.gcd(self.qk_nope_head_dim, self.v_head_dim)
+        return (
+            self.num_attention_heads_per_partition,
+            self.qk_nope_head_dim // chunk,
+            self.v_head_dim // chunk,
+        )
+
+    def _split_kv_b_names(self, ctx, structured_name_prefix, aoa_name_scope):
+        """``(k_model, v_model, kv_checkpoint)`` names for the split chain.
+
+        ``kv_b_proj`` exists only on the checkpoint side here (``__init__``
+        sets ``self.kv_b_proj = None``), so its name cannot come from
+        ``resolve_names``: there is no entry for it in
+        ``ctx.pp_to_single_mapping``. It is anchored on the real ``k_b_proj``
+        parameter instead, the same idiom ``SelfAttention`` uses to name its
+        checkpoint-only q/k/v keys.
+        """
+
+        def _model(local):
+            return resolve_single_name(
+                local,
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+
+        k_model = _model("k_b_proj")
+        v_model = _model("v_b_proj")
+        kv_checkpoint = resolve_checkpoint_name_from_anchor(
+            k_model,
+            "k_b_proj",
+            "kv_b_proj.weight",
+            ctx.checkpoint_name_prefix,
+            ctx.checkpoint_name_mapping,
+            aoa_name_scope=aoa_name_scope,
+            model_name_prefix=ctx.model_name_prefix,
+        )
+        return k_model, v_model, kv_checkpoint
+
+    def _split_kv_b_excluded(self, ctx, structured_name_prefix):
+        """Whether the whole split chain is excluded from the recursion.
+
+        ``k_b_proj`` and ``v_b_proj`` are two ends of *one* chain over a single
+        checkpoint key, so they can only be excluded together. Honoring a
+        partial exclusion would leave the other half with no source on load, or
+        the checkpoint key half-built on save -- exactly the silent corruption
+        this override exists to prevent -- so it fails loudly instead.
+        """
+        excluded = [
+            local
+            for local in self._SPLIT_KV_B_LOCAL_NAMES
+            if structured_name_prefix + local in ctx.excluded_names
+        ]
+        if excluded and len(excluded) != len(self._SPLIT_KV_B_LOCAL_NAMES):
+            raise NotImplementedError(
+                "k_b_proj / v_b_proj form a single AOA chain over one "
+                "checkpoint key and cannot be excluded independently; "
+                f"excluded_names covers only {excluded} under "
+                f"'{structured_name_prefix}'."
+            )
+        return bool(excluded)
+
+    def _gen_split_kv_b_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Checkpoint->model chain for the split ``kv_b_proj``.
+
+        Splits the checkpoint ``kv_b_proj.weight`` into
+        ``heads * (n_k + n_v)`` equal row blocks, then per head concatenates
+        the K blocks back to ``[qk_nope, kv_lora]`` and transposes to the
+        stored ``[kv_lora, qk_nope]``, and concatenates the V blocks to
+        ``[v_head, kv_lora]``, which is already the stored orientation. The
+        per-head results are concatenated on axis 0 into the folded 2-D
+        parameters.
+
+        Nothing is emitted for ``kv_b_proj`` itself: it is not built in this
+        mode, so there is no model tensor to fill.
+
+        Every temporary is read exactly once. ``get_var_mapping_chain_macro``
+        records a variable's chain with a plain assignment, so a temporary
+        consumed by two statements silently loses the first chain and leaves
+        that chain's destination uninitialised.
+        """
+        heads, n_k, n_v = self._split_kv_b_head_blocks()
+        per_head = n_k + n_v
+        k_model, v_model, kv_checkpoint = self._split_kv_b_names(
+            ctx, structured_name_prefix, aoa_name_scope
+        )
+        tmp = f"{k_model}._kvb"
+        rows = [
+            f"{tmp}_r{h}_{j}" for h in range(heads) for j in range(per_head)
+        ]
+        statements = [f"{kv_checkpoint} -> {','.join(rows)}, axis=0"]
+        k_parts = []
+        v_parts = []
+        for h in range(heads):
+            head_rows = rows[h * per_head : (h + 1) * per_head]
+            k_flat = f"{tmp}_k{h}"
+            k_part = f"{tmp}_kt{h}"
+            k_src = ",".join(head_rows[:n_k])
+            statements.append(f"{k_src} -> {k_flat}, axis=0")
+            statements.append(f"{k_flat}^T -> {k_part}")
+            k_parts.append(k_part)
+            v_part = f"{tmp}_v{h}"
+            v_src = ",".join(head_rows[n_k:])
+            statements.append(f"{v_src} -> {v_part}, axis=0")
+            v_parts.append(v_part)
+
+        statements.append(f"{','.join(k_parts)} -> {k_model}, axis=0")
+        statements.append(f"{','.join(v_parts)} -> {v_model}, axis=0")
+        return statements
+
+    def _gen_inv_split_kv_b_aoa_statements(
+        self, ctx, structured_name_prefix, aoa_name_scope
+    ):
+        """Model->checkpoint chain for the split ``kv_b_proj``.
+
+        Rebuilds the Fleet-oriented ``[kv_lora, heads * (qk_nope + v_head)]``
+        matrix -- ``k_b_proj`` split per head on axis 0 already yields
+        ``[kv_lora, qk_nope]``, ``v_b_proj^T`` split per head on axis 1 yields
+        ``[kv_lora, v_head]`` -- concatenates K then V per head to reproduce
+        the head-major column order, and transposes once into the checkpoint
+        key. Written as an independent inverse, not derived from the
+        checkpoint->model text.
+        """
+        heads, _, _ = self._split_kv_b_head_blocks()
+        k_model, v_model, kv_checkpoint = self._split_kv_b_names(
+            ctx, structured_name_prefix, aoa_name_scope
+        )
+        for model_name in (k_model, v_model):
+            # Formatted rather than raw so a rule whose two dtypes are equal --
+            # a no-op cast -- does not trip the guard.
+            if format_inv_dtype_cast_attr(
+                resolve_dtype_cast_rule(
+                    model_name, ctx.dtype_cast_rules, ctx.model_name_prefix
+                )
+            ):
+                # This direction merges two model tensors into one checkpoint
+                # key, so there is no single-input single-output statement --
+                # the only shape ``format_inv_dtype_cast_attr`` documents -- to
+                # carry the cast suffix, and picking one of the two rules for
+                # the merged key would silently ignore the other.
+                raise NotImplementedError(
+                    "aoa_dtype_cast_rules matches "
+                    f"'{model_name}', but the split kv_b_proj inverse merges "
+                    "k_b_proj and v_b_proj into a single checkpoint key; "
+                    "casting on that key is not supported."
+                )
+        tmp = f"{k_model}._inv_kvb"
+        k_parts = [f"{tmp}_k{h}" for h in range(heads)]
+        statements = [f"{k_model} -> {','.join(k_parts)}, axis=0"]
+        v_t = f"{tmp}_vt"
+        statements.append(f"{v_model}^T -> {v_t}")
+        v_parts = [f"{tmp}_v{h}" for h in range(heads)]
+        statements.append(f"{v_t} -> {','.join(v_parts)}, axis=1")
+        head_parts = []
+        for h in range(heads):
+            part = f"{tmp}_h{h}"
+            pair = ",".join((k_parts[h], v_parts[h]))
+            statements.append(f"{pair} -> {part}, axis=1")
+            head_parts.append(part)
+        rebuilt = f"{tmp}_kv"
+        statements.append(f"{','.join(head_parts)} -> {rebuilt}, axis=1")
+        statements.append(f"{rebuilt}^T -> {kv_checkpoint}")
+        return statements
+
+    def gen_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Checkpoint->model generator for MLA.
+
+        Only ``mqa_split_kv_b_proj`` needs a component override. Without it
+        every MLA projection is a TP-linear sublayer whose own generator
+        supplies the transpose, so the generic recursion is already correct and
+        is delegated to unchanged. With it, ``kv_b_proj`` is not built and its
+        checkpoint tensor has to be split into the two standalone absorption
+        parameters, which no generic per-leaf rule can express: left to the
+        default walk, ``k_b_proj`` / ``v_b_proj`` resolve to identity
+        statements that ``should_skip`` drops, and the whole projection ends up
+        with no source at all.
+        """
+        if not self.mqa_latent_split_kv_b:
+            return super().gen_aoa_statements(
+                ctx,
+                structured_name_prefix=structured_name_prefix,
+                aoa_name_scope=aoa_name_scope,
+            )
+        statements = []
+        if not self._split_kv_b_excluded(ctx, structured_name_prefix):
+            statements = self._gen_split_kv_b_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+        local_state_dict = self.state_dict(
+            structured_name_prefix="", include_sublayers=False
+        )
+        for name in local_state_dict:
+            if name in self._SPLIT_KV_B_LOCAL_NAMES:
+                continue
+            if structured_name_prefix + name in ctx.excluded_names:
+                continue
+            source_name, target_name = resolve_names(
+                name,
+                ctx.checkpoint_name_prefix,
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            cast = format_dtype_cast_attr(
+                resolve_dtype_cast_rule(
+                    target_name,
+                    ctx.dtype_cast_rules,
+                    ctx.model_name_prefix,
+                )
+            )
+            if should_skip(source_name, target_name, cast):
+                continue
+            statements.append(f"{source_name} -> {target_name}{cast}")
+        for layer_name, sublayer in self._sub_layers.items():
+            if sublayer is None:
+                continue
+            statements += sublayer.gen_aoa_statements(
+                ctx,
+                structured_name_prefix=(
+                    f"{structured_name_prefix}{layer_name}."
+                ),
+                aoa_name_scope=aoa_name_scope,
+            )
+        return statements
+
+    def gen_inv_aoa_statements(
+        self, ctx, *, structured_name_prefix="", aoa_name_scope=None
+    ):
+        """Model->checkpoint generator for MLA.
+
+        Mirror of :meth:`gen_aoa_statements`: delegates to the generic
+        recursion unless ``mqa_split_kv_b_proj`` is on, in which case the two
+        absorption parameters are merged back into the single checkpoint
+        ``kv_b_proj.weight`` key and skipped by the own-parameter walk.
+        """
+        if not self.mqa_latent_split_kv_b:
+            return super().gen_inv_aoa_statements(
+                ctx,
+                structured_name_prefix=structured_name_prefix,
+                aoa_name_scope=aoa_name_scope,
+            )
+        statements = []
+        if not self._split_kv_b_excluded(ctx, structured_name_prefix):
+            statements = self._gen_inv_split_kv_b_aoa_statements(
+                ctx, structured_name_prefix, aoa_name_scope
+            )
+        local_state_dict = self.state_dict(
+            structured_name_prefix="", include_sublayers=False
+        )
+        for name in local_state_dict:
+            if name in self._SPLIT_KV_B_LOCAL_NAMES:
+                continue
+            if structured_name_prefix + name in ctx.excluded_names:
+                continue
+            target_name, source_name = resolve_names(
+                name,
+                ctx.checkpoint_name_prefix,
+                structured_name_prefix,
+                ctx.pp_to_single_mapping,
+                ctx.checkpoint_name_mapping,
+                aoa_name_scope=aoa_name_scope,
+                model_name_prefix=ctx.model_name_prefix,
+            )
+            cast = format_inv_dtype_cast_attr(
+                resolve_dtype_cast_rule(
+                    source_name,
+                    ctx.dtype_cast_rules,
+                    ctx.model_name_prefix,
+                )
+            )
+            if should_skip(source_name, target_name, cast):
+                continue
+            statements.append(f"{source_name} -> {target_name}{cast}")
+        for layer_name, sublayer in self._sub_layers.items():
+            if sublayer is None:
+                continue
+            statements += sublayer.gen_inv_aoa_statements(
+                ctx,
+                structured_name_prefix=(
+                    f"{structured_name_prefix}{layer_name}."
+                ),
+                aoa_name_scope=aoa_name_scope,
+            )
+        return statements
 
     def _is_cudagraph_active(self) -> bool:
         """Check if CUDA Graph capture or replay is currently active.

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -21,7 +21,7 @@ import functools
 import logging
 import math
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 import paddle.nn.functional as F
 
@@ -1950,6 +1950,40 @@ class TransformerConfig(ModelParallelConfig):
     deepep_buffer_configs: dict | None = None
     """DeepEP buffer configuration."""
 
+    ####################
+    # AOA generator migration marker (code-level, not a config item)
+    ####################
+
+    aoa_modular: ClassVar[bool] = False
+    """Whether this model has been migrated to modular AOA.
+
+    Deliberately a ``ClassVar``, so it is not a dataclass field -- it records a
+    property of the model's *code*, not a choice the user makes per run. A
+    provider subclass flips it to ``True`` once its components carry their own
+    AOA markers and its hand-written generator is gone (see
+    ``Ernie5V2Provider``). Because ``register_attributes`` would otherwise turn
+    an ``aoa_modular`` key in a yaml / ``config.json`` into an instance
+    attribute that shadows this ``ClassVar``, ``_process_attribute`` rejects
+    that key outright, so it can only ever be set in a class body.
+
+    One marker drives two coupled behaviours, which is why they cannot be
+    separate switches:
+
+    * whole-model AOA generation: ``True`` -> module-tree recursion
+      (``gen_whole_model_aoa``), ``False`` -> the per-model hand-written
+      generator attached on the model instance (``model._gen_aoa_config``).
+    * empty-layer naming: ``True`` -> ``EmptyLayer`` instances get their own
+      ``empty_layers.<i>`` namespace and transformer layers are numbered
+      ``layers.0 .. layers.{num_hidden_layers - 1}`` regardless of
+      ``num_empty_layers_add_in_head=H``; ``False`` -> both kinds share one
+      ``layers.<i>`` counter, so the first transformer layer is ``layers.H``.
+
+    The modular generator is written against decoupled numbering and every
+    legacy generator against the shared counter, so mixing the two would
+    silently corrupt checkpoint keys. Keeping a single marker makes that
+    mixed state inexpressible.
+    """
+
     # Field name mapping rules: HuggingFace config.json name -> TransformerConfig name
     transform_rules = {
         # DSA field mapping
@@ -2080,6 +2114,12 @@ class TransformerConfig(ModelParallelConfig):
                 f"{self.renamed_config_keys_when_set[key]} Update the config "
                 f"that still sets {key}={value!r}; it would otherwise be "
                 f"silently ignored."
+            )
+        elif key == "aoa_modular":
+            raise ValueError(
+                "aoa_modular is a code-level modular-AOA migration marker "
+                "(a ClassVar flipped in a provider class body), not a config "
+                "field; it must never be set from yaml / config.json."
             )
         else:
             setattr(self, key, value)

--- a/src/paddlefleet/transformer/transformer_encoder.py
+++ b/src/paddlefleet/transformer/transformer_encoder.py
@@ -167,11 +167,31 @@ class TransformerEncoder(PipelineLayer):
 
     def get_encoder_layer_desc_list(self, layers, spec, name_prefix):
         i = 0
+        empty_index = 0
+
+        def next_empty_layer_name():
+            """Name for the next EmptyLayer, advancing the right counter.
+
+            With ``aoa_modular`` empty layers live in their own
+            ``empty_layers.<i>`` namespace and do not consume a ``layers.<i>``
+            slot, so transformer layers start at ``layers.0``. Otherwise both
+            kinds share the ``i`` counter. Kept identical to the language
+            tower's rule in ``GPTModel.get_layer_desc_list`` so the two towers
+            never name layers differently.
+            """
+            nonlocal i, empty_index
+            if getattr(getattr(self, "config", None), "aoa_modular", False):
+                name = f"{name_prefix}.empty_layers.{empty_index}"
+            else:
+                name = f"{name_prefix}.layers.{i}"
+                i += 1
+            empty_index += 1
+            return name
+
         for head_empty_layer in spec.head_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(head_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(head_empty_layer), next_empty_layer_name()
             )
-            i += 1
         for transformer_layer_spec in spec.transformer_layers:
             self.add_sequential_layer(
                 layers,
@@ -181,9 +201,8 @@ class TransformerEncoder(PipelineLayer):
             i += 1
         for tail_empty_layer in spec.tail_empty_layers:
             self.add_sequential_layer(
-                layers, LayerDesc(tail_empty_layer), f"{name_prefix}.layers.{i}"
+                layers, LayerDesc(tail_empty_layer), next_empty_layer_name()
             )
-            i += 1
 
     def overlapped_forward_backward(
         self,

--- a/tests/single_card_tests/aoa/test_aoa_attention_prefused_qkv_component.py
+++ b/tests/single_card_tests/aoa/test_aoa_attention_prefused_qkv_component.py
@@ -1,0 +1,189 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: the base ``SelfAttention`` PRE-FUSED qkv checkpoint layout, selected by
+# the AOA flag ``ctx.qkv_checkpoint_prefused`` (declared per-model, e.g. the
+# Qwen3-VL vision tower's ``aoa_qkv_checkpoint_prefused = True``).
+# The default (``False``) layout fuses separate checkpoint q/k/v keys into the
+# model ``qkv_proj`` via ``fused_qkv``. The pre-fused layout instead splits a
+# single checkpoint ``qkv`` tensor into AOA-internal q/k/v temporaries and then
+# re-fuses per head (vision has no GQA, so
+# ``num_heads == num_key_value_groups == config.num_attention_heads``).
+#
+# The head helpers ``_gen_(inv_)prefused_qkv_head_aoa_statements`` read
+# ``self.config.num_attention_heads`` and ``self.qkv_proj.bias``, so we bind them
+# onto a light probe carrying just those two attributes and golden-test the
+# emitted statement list. We also assert the flag-routing contract on the real
+# ``SelfAttention`` class.
+import os
+import sys
+import types
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+
+from paddlefleet.models.gpt.aoa_generator import (
+    FleetAOAContext,
+)
+
+
+def _ctx(pp_to_single_mapping):
+    return FleetAOAContext(
+        config=None,
+        checkpoint_name_prefix="hf",
+        pp_to_single_mapping=pp_to_single_mapping,
+        checkpoint_name_mapping={},
+        dtype_cast_rules={},
+        model_name_prefix="model",
+        excluded_names=frozenset(),
+        qkv_checkpoint_prefused=True,
+    )
+
+
+_PFX = "layers.0.self_attn."
+_PP = {
+    _PFX + "qkv_proj.weight": "model.layers.0.self_attn.qkv_proj.weight",
+    _PFX + "qkv_proj.bias": "model.layers.0.self_attn.qkv_proj.bias",
+}
+_QKV_MODEL_W = "model.layers.0.self_attn.qkv_proj.weight"
+_QKV_MODEL_B = "model.layers.0.self_attn.qkv_proj.bias"
+_QKV_CKPT_W = "hf.layers.0.self_attn.qkv.weight"
+_QKV_CKPT_B = "hf.layers.0.self_attn.qkv.bias"
+_NH = 4
+
+
+def _make_probe(bias):
+    """A light stand-in carrying the two live attributes the base pre-fused head
+    helpers read (``config.num_attention_heads`` and ``qkv_proj.bias``); the
+    helpers are borrowed off the real ``SelfAttention`` class."""
+    from paddlefleet.transformer.attention import SelfAttention
+
+    class _Probe:
+        _gen_prefused_qkv_head_aoa_statements = (
+            SelfAttention._gen_prefused_qkv_head_aoa_statements
+        )
+        _gen_inv_prefused_qkv_head_aoa_statements = (
+            SelfAttention._gen_inv_prefused_qkv_head_aoa_statements
+        )
+
+        def __init__(self):
+            self.config = types.SimpleNamespace(num_attention_heads=_NH)
+            self.qkv_proj = types.SimpleNamespace(
+                bias=object() if bias else None
+            )
+
+    return _Probe()
+
+
+class TestPrefusedForward(unittest.TestCase):
+    """Forward (checkpoint -> model): equal-split the single fused ``qkv`` into
+    q/k/v temporaries, then re-fuse (with transpose) into the model single. No
+    GQA -> ``num_heads == num_key_value_groups``."""
+
+    def setUp(self):
+        self.ctx = _ctx(_PP)
+
+    def test_weight_golden(self):
+        stmts = _make_probe(bias=False)._gen_prefused_qkv_head_aoa_statements(
+            self.ctx, _PFX, None
+        )
+        q_t = f"{_QKV_CKPT_W}._vis_q"
+        k_t = f"{_QKV_CKPT_W}._vis_k"
+        v_t = f"{_QKV_CKPT_W}._vis_v"
+        expected = [
+            f"{_QKV_CKPT_W} -> {q_t}, {k_t}, {v_t}, axis=0",
+            f"{q_t}^T, {k_t}^T, {v_t}^T -> {_QKV_MODEL_W}, fused_qkv, "
+            f"num_heads={_NH}, num_key_value_groups={_NH}",
+        ]
+        self.assertEqual(stmts, expected)
+
+    def test_bias_appended_axis0_no_transpose(self):
+        stmts = _make_probe(bias=True)._gen_prefused_qkv_head_aoa_statements(
+            self.ctx, _PFX, None
+        )
+        qb = f"{_QKV_CKPT_B}._vis_q"
+        kb = f"{_QKV_CKPT_B}._vis_k"
+        vb = f"{_QKV_CKPT_B}._vis_v"
+        self.assertEqual(len(stmts), 4)
+        self.assertEqual(stmts[2], f"{_QKV_CKPT_B} -> {qb}, {kb}, {vb}, axis=0")
+        self.assertEqual(
+            stmts[3],
+            f"{qb}, {kb}, {vb} -> {_QKV_MODEL_B}, fused_qkv, "
+            f"num_heads={_NH}, num_key_value_groups={_NH}, axis=0",
+        )
+        self.assertNotIn("^T", stmts[3])
+
+
+class TestPrefusedInverse(unittest.TestCase):
+    """Inverse (model -> checkpoint): split the model single into q/k/v
+    (fused_qkv) then merge (with transpose) back into the fused checkpoint.
+    Independently generated."""
+
+    def setUp(self):
+        self.ctx = _ctx(_PP)
+
+    def test_weight_golden(self):
+        stmts = _make_probe(
+            bias=False
+        )._gen_inv_prefused_qkv_head_aoa_statements(self.ctx, _PFX, None)
+        q_t = f"{_QKV_CKPT_W}._vis_q"
+        k_t = f"{_QKV_CKPT_W}._vis_k"
+        v_t = f"{_QKV_CKPT_W}._vis_v"
+        expected = [
+            f"{_QKV_MODEL_W} -> {q_t}, {k_t}, {v_t}, fused_qkv, "
+            f"num_heads={_NH}, num_key_value_groups={_NH}",
+            f"{q_t}^T, {k_t}^T, {v_t}^T -> {_QKV_CKPT_W}, axis=0",
+        ]
+        self.assertEqual(stmts, expected)
+
+
+class TestFlagRoutingContract(unittest.TestCase):
+    """The base ``SelfAttention`` owns the pre-fused head helpers and its qkv
+    head dispatcher routes to them only when ``ctx.qkv_checkpoint_prefused`` is
+    set (no AOA-only subclass involved)."""
+
+    def test_base_has_prefused_helpers(self):
+        from paddlefleet.transformer.attention import SelfAttention
+
+        self.assertIn(
+            "_gen_prefused_qkv_head_aoa_statements", SelfAttention.__dict__
+        )
+        self.assertIn(
+            "_gen_inv_prefused_qkv_head_aoa_statements",
+            SelfAttention.__dict__,
+        )
+
+    def test_dispatcher_branches_on_flag(self):
+        import inspect
+
+        from paddlefleet.transformer.attention import SelfAttention
+
+        fwd = inspect.getsource(SelfAttention._gen_qkv_head_aoa_statements)
+        inv = inspect.getsource(SelfAttention._gen_inv_qkv_head_aoa_statements)
+        self.assertIn("ctx.qkv_checkpoint_prefused", fwd)
+        self.assertIn("_gen_prefused_qkv_head_aoa_statements", fwd)
+        self.assertIn("ctx.qkv_checkpoint_prefused", inv)
+        self.assertIn("_gen_inv_prefused_qkv_head_aoa_statements", inv)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_config_protocol.py
+++ b/tests/single_card_tests/aoa/test_aoa_config_protocol.py
@@ -1,0 +1,289 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: pins the whole-model config-field protocol normalization -- the single
+# place that resolves the model-declared AOA name / dtype / layout attributes
+# (``build_aoa_context`` via ``_protocol_value``) and the MTP checkpoint-prefix
+# attributes (``MTPCheckpointPrefixSpec`` via
+# ``resolve_mtp_checkpoint_prefix_spec``). An unmigrated model (without an
+# explicit mapping) inherits the shared ERNIE mapping; an external model
+# overrides it via that attribute. Also carries a source-level lint pinning
+# the direction-independence contract (no ``direction`` / ``reverse`` param, a
+# ``_fwd_`` / ``_inv_`` helper split with no cross-direction calls and no
+# ``aoa_config_reverse`` call).
+import dataclasses
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+from paddle.distributed.flex_checkpoint.aoa.generation import AOAContext
+
+from paddlefleet.models.gpt.aoa_generator import (
+    DEFAULT_CHECKPOINT_NAME_MAPPING,
+    DEFAULT_CHECKPOINT_NAME_PREFIX,
+    DEFAULT_GATE_CHECKPOINT_LAYOUT,
+    DEFAULT_MLP_GATE_UP_FUSED,
+    DEFAULT_MODEL_NAME_PREFIX,
+    DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT,
+    DEFAULT_QKV_CHECKPOINT_PREFUSED,
+    FleetAOAContext,
+    MTPCheckpointPrefixSpec,
+    build_aoa_context,
+    resolve_mtp_checkpoint_prefix_spec,
+)
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+class _Cfg:
+    """Bare config stand-in; only the attributes a test sets are present."""
+
+
+class _FakeModel:
+    """Duck-types the attributes ``build_aoa_context`` reads.
+
+    ``_pipeline_name_mapping`` is pre-populated (non-None) so the idempotent
+    ``_set_pipeline_name_mapping`` side effect is skipped in the happy path.
+    ``_model_name_prefix()`` stands in for the live model's single-name root,
+    which is where the context takes it from; the value is held in a separately
+    named attribute so it does not shadow the method.
+    """
+
+    def __init__(
+        self,
+        pp_to_single_mapping=None,
+        model_name_prefix=DEFAULT_MODEL_NAME_PREFIX,
+    ):
+        self._pipeline_name_mapping = {}
+        self._pp_to_single_mapping = pp_to_single_mapping or {}
+        self._model_name_prefix_value = model_name_prefix
+
+    def _set_pipeline_name_mapping(self):
+        self._pipeline_name_mapping = {}
+
+    def _model_name_prefix(self):
+        return self._model_name_prefix_value
+
+
+class TestBuildAOAContextDefaults(unittest.TestCase):
+    def test_unmigrated_config_uses_ernie_defaults(self):
+        model = _FakeModel(pp_to_single_mapping={"s": "s"})
+        ctx = build_aoa_context(model, _Cfg())
+        self.assertIsInstance(ctx, AOAContext)
+        self.assertIsInstance(ctx, FleetAOAContext)
+        self.assertEqual(
+            ctx.checkpoint_name_prefix, DEFAULT_CHECKPOINT_NAME_PREFIX
+        )
+        self.assertEqual(
+            dict(ctx.checkpoint_name_mapping), DEFAULT_CHECKPOINT_NAME_MAPPING
+        )
+        self.assertEqual(dict(ctx.dtype_cast_rules), {})
+        self.assertEqual(ctx.model_name_prefix, DEFAULT_MODEL_NAME_PREFIX)
+        self.assertEqual(dict(ctx.pp_to_single_mapping), {"s": "s"})
+
+    def test_layout_defaults(self):
+        ctx = build_aoa_context(_FakeModel(), _Cfg())
+        self.assertEqual(
+            ctx.gate_checkpoint_layout, DEFAULT_GATE_CHECKPOINT_LAYOUT
+        )
+        self.assertEqual(
+            ctx.qkv_checkpoint_prefused, DEFAULT_QKV_CHECKPOINT_PREFUSED
+        )
+        self.assertEqual(
+            ctx.moe_expert_checkpoint_layout,
+            DEFAULT_MOE_EXPERT_CHECKPOINT_LAYOUT,
+        )
+        self.assertEqual(ctx.mlp_gate_up_fused, DEFAULT_MLP_GATE_UP_FUSED)
+        self.assertFalse(ctx.mapping_proj_checkpoint_transposed)
+
+    def test_mapping_is_copied_not_aliased(self):
+        ctx = build_aoa_context(_FakeModel(), _Cfg())
+        self.assertIsNot(
+            ctx.checkpoint_name_mapping, DEFAULT_CHECKPOINT_NAME_MAPPING
+        )
+
+    def test_explicit_empty_checkpoint_mapping_overrides_default(self):
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_mapping = {}
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(dict(ctx.checkpoint_name_mapping), {})
+
+    def test_explicit_empty_checkpoint_prefix_is_preserved(self):
+        # A checkpoint rooted at the top level (DeepSeek V4) declares "" and
+        # must not silently fall back to the Ernie-series default.
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_prefix = ""
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(ctx.checkpoint_name_prefix, "")
+
+    def test_explicit_none_falls_back_to_default(self):
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_prefix = None
+        cfg.aoa_dtype_cast_rules = None
+        cfg.aoa_qkv_checkpoint_prefused = None
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(
+            ctx.checkpoint_name_prefix, DEFAULT_CHECKPOINT_NAME_PREFIX
+        )
+        self.assertEqual(dict(ctx.dtype_cast_rules), {})
+        self.assertEqual(
+            ctx.qkv_checkpoint_prefused, DEFAULT_QKV_CHECKPOINT_PREFUSED
+        )
+
+
+class TestBuildAOAContextOverrides(unittest.TestCase):
+    def test_name_and_dtype_overrides_propagate(self):
+        cfg = _Cfg()
+        cfg.aoa_checkpoint_name_prefix = "hf"
+        cfg.aoa_checkpoint_name_mapping = {"a.weight": "b.weight"}
+        cfg.aoa_dtype_cast_rules = {
+            "x": {"checkpoint_dtype": "bfloat16", "model_dtype": "float32"}
+        }
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(ctx.checkpoint_name_prefix, "hf")
+        self.assertEqual(
+            dict(ctx.checkpoint_name_mapping), {"a.weight": "b.weight"}
+        )
+        self.assertEqual(
+            dict(ctx.dtype_cast_rules),
+            {"x": {"checkpoint_dtype": "bfloat16", "model_dtype": "float32"}},
+        )
+
+    def test_layout_overrides_propagate(self):
+        cfg = _Cfg()
+        cfg.aoa_gate_checkpoint_layout = "interleaved"
+        cfg.aoa_qkv_checkpoint_prefused = True
+        cfg.aoa_moe_expert_checkpoint_layout = "packed"
+        cfg.aoa_mapping_proj_checkpoint_transposed = True
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertEqual(ctx.gate_checkpoint_layout, "interleaved")
+        self.assertTrue(ctx.qkv_checkpoint_prefused)
+        self.assertEqual(ctx.moe_expert_checkpoint_layout, "packed")
+        self.assertTrue(ctx.mapping_proj_checkpoint_transposed)
+
+    def test_falsy_mlp_gate_up_fused_is_preserved(self):
+        # Qwen3-VL declares False; a truthiness-based default would swallow it.
+        cfg = _Cfg()
+        cfg.aoa_mlp_gate_up_fused = False
+        ctx = build_aoa_context(_FakeModel(), cfg)
+        self.assertFalse(ctx.mlp_gate_up_fused)
+
+    def test_model_name_prefix_comes_from_the_live_model(self):
+        # The model single-name root comes from the live model, not the config:
+        # it must stay the same value that names the pipeline layers.
+        ctx = build_aoa_context(_FakeModel(model_name_prefix="root"), _Cfg())
+        self.assertEqual(ctx.model_name_prefix, "root")
+
+    def test_context_is_frozen(self):
+        ctx = build_aoa_context(_FakeModel(), _Cfg())
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            ctx.checkpoint_name_prefix = "mut"
+
+    def test_none_pipeline_mapping_triggers_side_effect(self):
+        model = _FakeModel()
+        model._pipeline_name_mapping = None
+        ctx = build_aoa_context(model, _Cfg())
+        self.assertIsNotNone(model._pipeline_name_mapping)
+        self.assertIsInstance(ctx, AOAContext)
+
+
+class TestMTPCheckpointPrefixSpec(unittest.TestCase):
+    def test_defaults(self):
+        spec = resolve_mtp_checkpoint_prefix_spec(_Cfg())
+        self.assertEqual(spec.checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertFalse(spec.is_absolute)
+
+    def test_transformer_inherits_own_prefix(self):
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix = "mtp.$LAYER_ID"
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertEqual(spec.checkpoint_prefix, "mtp.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "mtp.$LAYER_ID")
+
+    def test_transformer_prefix_override_independent(self):
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix = "mtp.$LAYER_ID"
+        cfg.aoa_mtp_transformer_checkpoint_prefix = "mtp.$LAYER_ID.tf"
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertEqual(spec.checkpoint_prefix, "mtp.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "mtp.$LAYER_ID.tf")
+
+    def test_absolute_flag(self):
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix_absolute = True
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertTrue(spec.is_absolute)
+
+    def test_bare_spec_defaults(self):
+        spec = MTPCheckpointPrefixSpec()
+        self.assertEqual(spec.checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "layers.$LAYER_ID")
+        self.assertFalse(spec.is_absolute)
+
+    def test_explicit_empty_mtp_prefix_is_preserved(self):
+        # A top-level MTP checkpoint declares "" and must not silently fall
+        # back to the layers.$LAYER_ID default; the inner transformer prefix
+        # then inherits that same "".
+        cfg = _Cfg()
+        cfg.aoa_mtp_checkpoint_prefix = ""
+        spec = resolve_mtp_checkpoint_prefix_spec(cfg)
+        self.assertEqual(spec.checkpoint_prefix, "")
+        self.assertEqual(spec.transformer_checkpoint_prefix, "")
+
+
+class TestAoaModularNotConfigInjectable(unittest.TestCase):
+    """Pins that ``aoa_modular`` is a code-level marker, not a config field.
+
+    The marker is a ``ClassVar`` a migrated provider flips in its class body;
+    it must never be reachable from a yaml / ``config.json``. Two independent
+    surfaces enforce this and this test pins both: the ``ClassVar`` keeps it
+    out of the dataclass fields (so it is neither constructor-settable nor
+    instance-shadowed), and ``_process_attribute`` rejects the key outright on
+    the ``from_config`` load path.
+    """
+
+    def test_classvar_default_is_false(self):
+        self.assertFalse(TransformerConfig.aoa_modular)
+
+    def test_aoa_modular_is_not_a_dataclass_field(self):
+        field_names = {f.name for f in dataclasses.fields(TransformerConfig)}
+        self.assertNotIn("aoa_modular", field_names)
+
+    def test_from_config_rejects_aoa_modular_key(self):
+        # Rejected by the key itself, independent of the value carried.
+        for value in (True, False):
+            with self.assertRaises(ValueError):
+                TransformerConfig.from_config(
+                    SimpleNamespace(aoa_modular=value)
+                )
+
+    def test_reject_is_narrow(self):
+        # An unrelated attribute still flows through the normal setattr path.
+        inst = object.__new__(TransformerConfig)
+        inst._process_attribute("some_unrelated_attr", 123)
+        self.assertEqual(inst.some_unrelated_attr, 123)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_csa_dsa_components.py
+++ b/tests/single_card_tests/aoa/test_aoa_csa_dsa_components.py
@@ -1,0 +1,439 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: CSA / DSA attention components. Their leaves are Linear (``^T`` handled
+# by the Linear component), Norm (identity) and float32 direct params ``ape`` /
+# ``attn_sink`` (identity), all covered by the base ``Layer`` recursion over the
+# live module tree, so the layout needs no override. The two Indexer classes
+# override forward only, and only to pick the ``indexer_init_from_scratch``
+# branch (a checkpoint from an earlier training phase has no Indexer at all);
+# the loading layout inside the branch is still the base recursion. The other
+# model-specific twist is GLM5 DSA, whose checkpoint drops the
+# ``core_attention`` path segment; that is expressed purely as a per-leaf
+# ``aoa_checkpoint_name_mapping`` and resolved by the same base recursion.
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+from types import SimpleNamespace
+
+import paddle
+from paddle.distributed.flex_checkpoint.aoa.generation import (
+    validate_checkpoint_name_mapping,
+)
+
+from paddlefleet.models.gpt.aoa_generator import FleetAOAContext
+from paddlefleet.transformer.csa_attention import (
+    CompressedSparseAttention,
+    Compressor,
+    CSAIndexer,
+)
+from paddlefleet.transformer.dsa_attention import DSAIndexer
+
+
+class _Leaf(paddle.nn.Layer):
+    """A single-``weight`` leaf (Linear/Norm stand-in for name resolution)."""
+
+    def __init__(self, with_bias=False):
+        super().__init__()
+        self.weight = self.create_parameter(shape=[2])
+        if with_bias:
+            self.bias = self.create_parameter(shape=[2])
+
+
+class _Node(paddle.nn.Layer):
+    """Container registering direct params and child sub-layers by name.
+
+    ``params`` model float32 direct params (CSA ``ape`` / ``attn_sink``); the
+    keyword children model nested sub-layers. Both register through
+    ``Layer.__setattr__`` exactly like a real module tree.
+    """
+
+    def __init__(self, params=(), **children):
+        super().__init__()
+        for pname in params:
+            setattr(self, pname, self.create_parameter(shape=[2]))
+        for name, child in children.items():
+            setattr(self, name, child)
+
+
+# GLM5 DSA canonical declaration: the checkpoint keeps the DSA
+# indexer directly under ``self_attn`` (no ``core_attention`` segment), so five
+# per-leaf model->checkpoint entries drop it. ``_match_template`` has no
+# wildcard, hence one entry per leaf. Keys are model-root-relative, values are
+# checkpoint-root-relative; ``$LAYER_ID`` matches a decimal segment.
+GLM5_DSA_NAME_MAPPING = {
+    "layers.$LAYER_ID.self_attn.core_attention.indexer.wq_b.weight": (
+        "layers.$LAYER_ID.self_attn.indexer.wq_b.weight"
+    ),
+    "layers.$LAYER_ID.self_attn.core_attention.indexer.wk.weight": (
+        "layers.$LAYER_ID.self_attn.indexer.wk.weight"
+    ),
+    "layers.$LAYER_ID.self_attn.core_attention.indexer.weights_proj.weight": (
+        "layers.$LAYER_ID.self_attn.indexer.weights_proj.weight"
+    ),
+    "layers.$LAYER_ID.self_attn.core_attention.indexer.k_norm.weight": (
+        "layers.$LAYER_ID.self_attn.indexer.k_norm.weight"
+    ),
+    "layers.$LAYER_ID.self_attn.core_attention.indexer.k_norm.bias": (
+        "layers.$LAYER_ID.self_attn.indexer.k_norm.bias"
+    ),
+}
+
+
+def _ctx(*, pp_to_single_mapping, checkpoint_name_mapping=None):
+    """A directly-constructed frozen context (no live GPTModel needed)."""
+    return FleetAOAContext(
+        config=None,
+        checkpoint_name_prefix="hf",
+        pp_to_single_mapping=pp_to_single_mapping,
+        checkpoint_name_mapping=checkpoint_name_mapping or {},
+        dtype_cast_rules={},
+        model_name_prefix="model",
+        excluded_names=frozenset(),
+    )
+
+
+def _identity_pp_mapping(structured_names):
+    """Structured live name -> single name, single == ``model.<structured>``."""
+    return {name: f"model.{name}" for name in structured_names}
+
+
+def _leaf_of(statement, side):
+    """Returns the ``side`` (``0`` source / ``1`` target) endpoint of a stmt."""
+    return statement.split(" -> ")[side]
+
+
+class TestNoComponentOverride(unittest.TestCase):
+    """No CSA/DSA class may re-implement the module walk.
+
+    A stray override would silently diverge from the Linear ``^T`` / identity
+    contract, bypassing the shared component layer. The two Indexers are the
+    single exception, and forward only: they choose between loading and the
+    ``_ ->`` add branch, and delegate the layout either way. Guarding on
+    ``__dict__`` (not ``getattr``) pins the *class itself*, ignoring the
+    inherited ``Layer`` method.
+    """
+
+    def test_only_the_indexers_override_and_forward_only(self):
+        for cls in (Compressor, CompressedSparseAttention):
+            self.assertNotIn(
+                "gen_aoa_statements",
+                cls.__dict__,
+                f"{cls.__name__} unexpectedly overrides gen_aoa_statements",
+            )
+        for cls in (CSAIndexer, DSAIndexer):
+            self.assertIn(
+                "gen_aoa_statements",
+                cls.__dict__,
+                f"{cls.__name__} lost its init_from_scratch branch",
+            )
+
+    def test_no_class_overrides_the_inverse(self):
+        # Saving is unconditional: whatever the model owns is written out.
+        for cls in (
+            Compressor,
+            CSAIndexer,
+            CompressedSparseAttention,
+            DSAIndexer,
+        ):
+            self.assertNotIn(
+                "gen_inv_aoa_statements",
+                cls.__dict__,
+                f"{cls.__name__} overrides gen_inv_aoa_statements",
+            )
+
+
+def _csa_core_attention_subtree():
+    """A CompressedSparseAttention-shaped subtree (ERNIE-Lite / DSV4 style).
+
+    ``attn_sink`` is a direct float32 param on the CSA module; ``compressor``
+    holds a direct ``ape`` param plus a Linear (``linear_wkv``) and a Norm.
+    """
+    compressor = _Node(
+        params=["ape"],
+        linear_wkv=_Leaf(),
+        norm=_Leaf(),
+    )
+    return _Node(params=["attn_sink"], compressor=compressor)
+
+
+_CSA_PREFIX = "layers.0.self_attn.core_attention."
+_CSA_STRUCTURED = [
+    _CSA_PREFIX + "attn_sink",
+    _CSA_PREFIX + "compressor.ape",
+    _CSA_PREFIX + "compressor.linear_wkv.weight",
+    _CSA_PREFIX + "compressor.norm.weight",
+]
+
+
+class TestCsaIdentityPath(unittest.TestCase):
+    """ERNIE-Lite / DSV4 CSA: checkpoint relative path == model relative path.
+
+    With an empty ``checkpoint_name_mapping`` the base recursion produces pure
+    identity names (only the checkpoint prefix differs), so ``core_attention``
+    survives on both sides. This is why these models declare nothing.
+    """
+
+    def setUp(self):
+        self.model = _csa_core_attention_subtree()
+        self.ctx = _ctx(
+            pp_to_single_mapping=_identity_pp_mapping(_CSA_STRUCTURED)
+        )
+
+    def test_forward_is_identity_and_keeps_core_attention(self):
+        stmts = self.model.gen_aoa_statements(
+            self.ctx, structured_name_prefix=_CSA_PREFIX
+        )
+        self.assertEqual(len(stmts), len(_CSA_STRUCTURED))
+        for s in stmts:
+            src, dst = _leaf_of(s, 0), _leaf_of(s, 1)
+            self.assertIn(".core_attention.", src)
+            self.assertEqual(src, "hf." + dst[len("model.") :])
+
+    def test_inverse_is_identity_and_keeps_core_attention(self):
+        stmts = self.model.gen_inv_aoa_statements(
+            self.ctx, structured_name_prefix=_CSA_PREFIX
+        )
+        self.assertEqual(len(stmts), len(_CSA_STRUCTURED))
+        for s in stmts:
+            src, dst = _leaf_of(s, 0), _leaf_of(s, 1)
+            self.assertIn(".core_attention.", dst)
+            self.assertEqual(dst, "hf." + src[len("model.") :])
+
+
+def _dsa_indexer_subtree():
+    """A DSAIndexer-shaped subtree: three Linears + a LayerNorm (weight+bias)."""
+    return _Node(
+        wq_b=_Leaf(),
+        wk=_Leaf(),
+        weights_proj=_Leaf(),
+        k_norm=_Leaf(with_bias=True),
+    )
+
+
+_DSA_PREFIX = "layers.0.self_attn.core_attention.indexer."
+_DSA_STRUCTURED = [
+    _DSA_PREFIX + "wq_b.weight",
+    _DSA_PREFIX + "wk.weight",
+    _DSA_PREFIX + "weights_proj.weight",
+    _DSA_PREFIX + "k_norm.weight",
+    _DSA_PREFIX + "k_norm.bias",
+]
+
+
+class TestGlm5DsaCoreAttentionDropped(unittest.TestCase):
+    """GLM5 DSA: the checkpoint drops ``core_attention`` on the indexer.
+
+    The five-entry ``GLM5_DSA_NAME_MAPPING`` rewrites the checkpoint side only;
+    the live single name (right of forward / left of inverse) keeps
+    ``core_attention``. Both directions resolve the same pair through the base
+    recursion -- no component override, no post-hoc text edit.
+    """
+
+    def setUp(self):
+        self.model = _dsa_indexer_subtree()
+        self.ctx = _ctx(
+            pp_to_single_mapping=_identity_pp_mapping(_DSA_STRUCTURED),
+            checkpoint_name_mapping=GLM5_DSA_NAME_MAPPING,
+        )
+
+    def test_frozen_mapping_is_wellformed(self):
+        # The five-entry mapping is what a GLM5 config would carry verbatim;
+        # it must pass the same validation the model __init__ runs.
+        validate_checkpoint_name_mapping(GLM5_DSA_NAME_MAPPING)
+
+    def test_forward_checkpoint_side_drops_core_attention(self):
+        stmts = self.model.gen_aoa_statements(
+            self.ctx, structured_name_prefix=_DSA_PREFIX
+        )
+        self.assertEqual(len(stmts), len(_DSA_STRUCTURED))
+        for s in stmts:
+            checkpoint, single = _leaf_of(s, 0), _leaf_of(s, 1)
+            self.assertNotIn("core_attention", checkpoint)
+            self.assertIn(".self_attn.indexer.", checkpoint)
+            # The live single name is untouched: it still has core_attention.
+            self.assertIn(".self_attn.core_attention.indexer.", single)
+        self.assertIn(
+            "hf.layers.0.self_attn.indexer.wq_b.weight -> "
+            "model.layers.0.self_attn.core_attention.indexer.wq_b.weight",
+            stmts,
+        )
+        self.assertIn(
+            "hf.layers.0.self_attn.indexer.k_norm.bias -> "
+            "model.layers.0.self_attn.core_attention.indexer.k_norm.bias",
+            stmts,
+        )
+
+    def test_inverse_checkpoint_side_drops_core_attention(self):
+        stmts = self.model.gen_inv_aoa_statements(
+            self.ctx, structured_name_prefix=_DSA_PREFIX
+        )
+        self.assertEqual(len(stmts), len(_DSA_STRUCTURED))
+        for s in stmts:
+            single, checkpoint = _leaf_of(s, 0), _leaf_of(s, 1)
+            self.assertNotIn("core_attention", checkpoint)
+            self.assertIn(".self_attn.core_attention.indexer.", single)
+        self.assertIn(
+            "model.layers.0.self_attn.core_attention.indexer.wq_b.weight -> "
+            "hf.layers.0.self_attn.indexer.wq_b.weight",
+            stmts,
+        )
+
+    def test_forward_and_inverse_are_endpoint_swaps(self):
+        fwd = self.model.gen_aoa_statements(
+            self.ctx, structured_name_prefix=_DSA_PREFIX
+        )
+        inv = self.model.gen_inv_aoa_statements(
+            self.ctx, structured_name_prefix=_DSA_PREFIX
+        )
+        reversed_fwd = [" -> ".join(reversed(s.split(" -> "))) for s in fwd]
+        self.assertEqual(sorted(inv), sorted(reversed_fwd))
+
+
+class _FakeDsaIndexer(DSAIndexer):
+    """Real ``gen_aoa_statements``, real child names, no heavy ``__init__``.
+
+    Subclassing keeps the zero-arg ``super()`` inside the override bound to the
+    real MRO, so the loading branch really is the base recursion.
+    """
+
+    def __init__(self, init_from_scratch):
+        paddle.nn.Layer.__init__(self)
+        self.config = SimpleNamespace(
+            indexer_init_from_scratch=init_from_scratch
+        )
+        self.wq_b = _Leaf()
+        self.wk = _Leaf()
+        self.weights_proj = _Leaf()
+        self.k_norm = _Leaf(with_bias=True)
+
+
+class _FakeCsaIndexer(CSAIndexer):
+    """Same trick for CSA, whose subtree nests a Compressor."""
+
+    def __init__(self, init_from_scratch):
+        paddle.nn.Layer.__init__(self)
+        self.config = SimpleNamespace(
+            indexer_init_from_scratch=init_from_scratch
+        )
+        self.linear_wq_b = _Leaf()
+        self.linear_weights_proj = _Leaf()
+        self.compressor = _Node(
+            params=["ape"],
+            linear_wkv=_Leaf(),
+            linear_wgate=_Leaf(),
+            norm=_Leaf(),
+        )
+
+
+_CSA_INDEXER_STRUCTURED = [
+    _DSA_PREFIX + "linear_wq_b.weight",
+    _DSA_PREFIX + "linear_weights_proj.weight",
+    _DSA_PREFIX + "compressor.ape",
+    _DSA_PREFIX + "compressor.linear_wkv.weight",
+    _DSA_PREFIX + "compressor.linear_wgate.weight",
+    _DSA_PREFIX + "compressor.norm.weight",
+]
+
+
+class TestIndexerInitFromScratch(unittest.TestCase):
+    """The phase-1 add branch: a checkpoint that has no Indexer at all.
+
+    Growing the model between training phases means the Indexer subtree has no
+    checkpoint source. AOA says that with ``_ -> <model name>``; omitting the
+    statement instead falls back to identity naming and aborts. Both flavours
+    read the same ``indexer_init_from_scratch`` switch.
+    """
+
+    def _cases(self):
+        return (
+            (_FakeDsaIndexer, _DSA_STRUCTURED),
+            (_FakeCsaIndexer, _CSA_INDEXER_STRUCTURED),
+        )
+
+    def test_unset_switch_is_rejected(self):
+        for cls, structured in self._cases():
+            ctx = _ctx(pp_to_single_mapping=_identity_pp_mapping(structured))
+            with self.assertRaises(ValueError) as cm:
+                cls(None).gen_aoa_statements(
+                    ctx, structured_name_prefix=_DSA_PREFIX
+                )
+            self.assertIn("indexer_init_from_scratch", str(cm.exception))
+
+    def test_true_adds_the_whole_subtree_and_reads_nothing(self):
+        for cls, structured in self._cases():
+            ctx = _ctx(pp_to_single_mapping=_identity_pp_mapping(structured))
+            stmts = cls(True).gen_aoa_statements(
+                ctx, structured_name_prefix=_DSA_PREFIX
+            )
+            self.assertEqual(
+                sorted(stmts),
+                sorted(f"_ -> model.{name}" for name in structured),
+            )
+
+    def test_false_loads_through_the_base_recursion(self):
+        for cls, structured in self._cases():
+            ctx = _ctx(pp_to_single_mapping=_identity_pp_mapping(structured))
+            stmts = cls(False).gen_aoa_statements(
+                ctx, structured_name_prefix=_DSA_PREFIX
+            )
+            self.assertEqual(len(stmts), len(structured))
+            for s in stmts:
+                src, dst = _leaf_of(s, 0), _leaf_of(s, 1)
+                self.assertNotEqual(src, "_")
+                self.assertEqual(src, "hf." + dst[len("model.") :])
+
+    def test_targets_are_the_same_keys_either_way(self):
+        # The add branch must claim exactly the keys loading would have
+        # assigned, or the engine is left with an unassigned tensor.
+        for cls, structured in self._cases():
+            ctx = _ctx(pp_to_single_mapping=_identity_pp_mapping(structured))
+            adds = cls(True).gen_aoa_statements(
+                ctx, structured_name_prefix=_DSA_PREFIX
+            )
+            loads = cls(False).gen_aoa_statements(
+                ctx, structured_name_prefix=_DSA_PREFIX
+            )
+            self.assertEqual(
+                sorted(_leaf_of(s, 1) for s in adds),
+                sorted(_leaf_of(s, 1) for s in loads),
+            )
+
+    def test_saving_ignores_the_switch(self):
+        for cls, structured in self._cases():
+            ctx = _ctx(pp_to_single_mapping=_identity_pp_mapping(structured))
+            saves = [
+                cls(flag).gen_inv_aoa_statements(
+                    ctx, structured_name_prefix=_DSA_PREFIX
+                )
+                for flag in (True, False)
+            ]
+            self.assertEqual(sorted(saves[0]), sorted(saves[1]))
+            self.assertEqual(len(saves[0]), len(structured))
+            for s in saves[0]:
+                self.assertNotIn("_ ->", s)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_dsv4_mla_zero_override.py
+++ b/tests/single_card_tests/aoa/test_aoa_dsv4_mla_zero_override.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: DeepSeek-V4 MLA is a ZERO-OVERRIDE case for its ordinary layout, NOT
+# an adapter subclass. An earlier design pass assumed a ``NonTransposeLinear``
+# adapter would be needed for ``linear_o_group_proj``, but that projection is a
+# bare ``create_parameter`` -> the generic Layer recursion emits an identity
+# statement (no ``^T``), which is exactly correct. The sibling ``o_proj`` is a
+# plain Linear covered by the generic Linear family. So on the ordinary layout
+# the whole MLA stack (``MultiLatentAttention`` / ``MLASelfAttention`` /
+# ``MQASelfAttention``) adds NO component AOA behaviour: the generic
+# ``paddle.nn.Layer.gen_(inv_)aoa_statements`` recursion is what runs, and the
+# checkpoint<->model name / dtype divergences are model-level concerns handled
+# during per-model migration.
+#
+# The one exception is ``mqa_split_kv_b_proj``, where ``MLASelfAttention`` does
+# not build ``kv_b_proj`` at all and holds two standalone absorption parameters
+# instead. That needs a real chain over one checkpoint key, so
+# ``MLASelfAttention`` defines both generators -- but they must delegate to the
+# generic recursion whenever the mode is off (see
+# ``test_ai_aoa_mla_split_kv_b_component.py`` for the chain itself).
+#
+# This test locks in the narrowed contract: no MLA class other than
+# ``MLASelfAttention`` may define AOA generators, and ``MLASelfAttention``'s
+# ``super()`` must still land on the generic recursion, so a future edit that
+# resurrects the abandoned adapter path fails loudly.
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+
+
+class TestMLAZeroOverride(unittest.TestCase):
+    """Only ``MLASelfAttention`` may define AOA generators (for the split
+    ``kv_b_proj`` mode); the ordinary layout rides the generic Layer recursion
+    (identity for the bare ``linear_o_group_proj`` param, ``^T`` for the
+    ``o_proj`` Linear child)."""
+
+    def _zero_override_classes(self):
+        from paddlefleet.transformer.multi_latent_attention import (
+            MQASelfAttention,
+            MultiLatentAttention,
+        )
+
+        # MQASelfAttention subclasses MLASelfAttention and inherits its split
+        # handling unchanged, so it must not add generators of its own.
+        return (MultiLatentAttention, MQASelfAttention)
+
+    def _mla_self_attention(self):
+        from paddlefleet.transformer.multi_latent_attention import (
+            MLASelfAttention,
+        )
+
+        return MLASelfAttention
+
+    def test_no_forward_override(self):
+        for cls in self._zero_override_classes():
+            self.assertNotIn(
+                "gen_aoa_statements",
+                cls.__dict__,
+                f"{cls.__name__} must stay zero-override "
+                f"(the generic Layer recursion is already correct)",
+            )
+
+    def test_no_inverse_override(self):
+        for cls in self._zero_override_classes():
+            self.assertNotIn(
+                "gen_inv_aoa_statements",
+                cls.__dict__,
+                f"{cls.__name__} must stay zero-override "
+                f"(the generic Layer recursion is already correct)",
+            )
+
+    def test_mqa_inherits_mla_generators(self):
+        from paddlefleet.transformer.multi_latent_attention import (
+            MQASelfAttention,
+        )
+
+        mla = self._mla_self_attention()
+        self.assertIs(
+            MQASelfAttention.gen_aoa_statements, mla.gen_aoa_statements
+        )
+        self.assertIs(
+            MQASelfAttention.gen_inv_aoa_statements, mla.gen_inv_aoa_statements
+        )
+
+    def test_generic_recursion_reachable(self):
+        # ``MultiLatentAttention`` sits ABOVE ``MLASelfAttention``, so its
+        # inherited generators resolve straight to the generic paddle.nn.Layer
+        # recursion, confirming the zero-override path is what actually runs.
+        # ``MQASelfAttention`` sits below and therefore inherits
+        # ``MLASelfAttention``'s split-mode generators instead (pinned by
+        # ``test_mqa_inherits_mla_generators``); those reach the same generic
+        # recursion through ``super()`` (pinned by
+        # ``test_mla_super_lands_on_generic_recursion``).
+        import paddle
+
+        from paddlefleet.transformer.multi_latent_attention import (
+            MultiLatentAttention,
+        )
+
+        self.assertIs(
+            MultiLatentAttention.gen_aoa_statements,
+            paddle.nn.Layer.gen_aoa_statements,
+        )
+        self.assertIs(
+            MultiLatentAttention.gen_inv_aoa_statements,
+            paddle.nn.Layer.gen_inv_aoa_statements,
+        )
+
+    def test_mla_super_lands_on_generic_recursion(self):
+        # MLASelfAttention's non-split branch is a bare ``super()`` call, so the
+        # first ancestor defining each generator has to be paddle.nn.Layer for
+        # the ordinary layout to keep its current (correct) behaviour.
+        import paddle
+
+        mla = self._mla_self_attention()
+        for method_name in ("gen_aoa_statements", "gen_inv_aoa_statements"):
+            self.assertIn(method_name, mla.__dict__)
+            owner = next(
+                cls for cls in mla.__mro__[1:] if method_name in cls.__dict__
+            )
+            self.assertIs(owner, paddle.nn.Layer)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_gated_qkv_component.py
+++ b/tests/single_card_tests/aoa/test_aoa_gated_qkv_component.py
@@ -1,0 +1,273 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: the shared gated-attention qkv AOA helper ``gated_qkv_aoa``, which the
+# base ``SelfAttention`` qkv head dispatcher routes to when
+# ``self.gated_attention`` and the (non-experimental) gate is fused into
+# ``qkv_proj``. The model side is a per-KV-group ``[Q, Gate, K, V]`` layout that
+# ``fused_qkv`` cannot express (gate section between Q and K;
+# ``head_dim != v_head_dim`` needs GCD sub-chunking). Only the checkpoint-side
+# gate placement differs, declared via ``ctx.gate_checkpoint_layout``:
+#   * "separate"    -- gate is its own ``gate_proj`` checkpoint key (ERNIE-Lite);
+#   * "interleaved" -- gate is head-interleaved inside the ``q_proj`` checkpoint
+#                      tensor (Qwen3.5), with no separate gate key.
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import math
+import unittest
+
+import paddle  # noqa: F401  (kept for CI parity with sibling tests)
+
+from paddlefleet.models.gpt.aoa_generator import (
+    FleetAOAContext,
+)
+from paddlefleet.transformer.gated_qkv_aoa import (
+    _temp_names,
+    gen_gated_qkv_aoa,
+    gen_gated_qkv_inv_aoa,
+)
+
+
+def _ctx(pp_to_single_mapping, layout):
+    return FleetAOAContext(
+        config=None,
+        checkpoint_name_prefix="hf",
+        pp_to_single_mapping=pp_to_single_mapping,
+        checkpoint_name_mapping={},
+        dtype_cast_rules={},
+        model_name_prefix="model",
+        excluded_names=frozenset(),
+        gate_checkpoint_layout=layout,
+    )
+
+
+_PFX = "layers.0.self_attn."
+_PP = {
+    _PFX + "qkv_proj.weight": "model.layers.0.self_attn.qkv_proj.weight",
+    _PFX + "qkv_proj.bias": "model.layers.0.self_attn.qkv_proj.bias",
+}
+_W = "model.layers.0.self_attn.qkv_proj.weight"
+_BIAS = "model.layers.0.self_attn.qkv_proj.bias"
+
+
+def _checkpoint(local):
+    return f"hf.layers.0.self_attn.{local}"
+
+
+class _FakeQkv:
+    def __init__(self, bias):
+        self.bias = object() if bias else None
+
+
+class _FakeAttn:
+    """A light stand-in carrying the live dims the generators read off the
+    attention module (head counts / head dims / ``gated_attention``) plus
+    ``attn.qkv_proj.bias``."""
+
+    def __init__(self, gated=True, hd=4, vhd=2, nh=4, nkv=2, bias=False):
+        self.num_attention_heads = nh
+        self.num_key_value_heads = nkv
+        self.head_dim = hd
+        self.v_head_dim = vhd
+        self.gated_attention = gated
+        self.qkv_proj = _FakeQkv(bias)
+
+
+class TestTempNames(unittest.TestCase):
+    """The pure name-builder: counts, no-duplication completeness, the per-group
+    ``[Q, Gate, K, V]`` fused ordering, and the per-(group,head) interleaved
+    ``q_proj`` ordering."""
+
+    def _dims(self, hd, vhd, nh, nkv):
+        gcd = math.gcd(hd, vhd)
+        return hd // gcd, vhd // gcd, nh // nkv
+
+    def test_counts_and_completeness_gated(self):
+        q, g, k, v, fused, qg = _temp_names(_W, 4, 2, 4, 2, True)
+        hd_c, vhd_c, _ = self._dims(4, 2, 4, 2)
+        self.assertEqual(len(q), 4 * hd_c)
+        self.assertEqual(len(g), 4 * vhd_c)
+        self.assertEqual(len(k), 2 * hd_c)
+        self.assertEqual(len(v), 2 * vhd_c)
+        allnames = q + g + k + v
+        self.assertEqual(len(allnames), len(set(allnames)))
+        self.assertEqual(sorted(fused), sorted(allnames))
+        # qg is the interleaved q+gate universe (no k/v).
+        self.assertEqual(sorted(qg), sorted(q + g))
+
+    def test_non_gated_has_no_gate_section(self):
+        q, g, k, v, fused, qg = _temp_names(_W, 4, 2, 4, 2, False)
+        self.assertEqual(g, [])
+        self.assertEqual(sorted(fused), sorted(q + k + v))
+        self.assertEqual(sorted(qg), sorted(q))
+
+    def test_fused_is_per_group_q_gate_k_v(self):
+        q, g, k, v, fused, _ = _temp_names(_W, 4, 2, 4, 2, True)
+        hd_c, vhd_c, hpg = self._dims(4, 2, 4, 2)
+        q_per, g_per, k_per, v_per = (
+            hpg * hd_c,
+            hpg * vhd_c,
+            hd_c,
+            vhd_c,
+        )
+        block = q_per + g_per + k_per + v_per
+        for gi in range(2):
+            seg = fused[gi * block : (gi + 1) * block]
+            self.assertEqual(seg[:q_per], q[gi * q_per : (gi + 1) * q_per])
+            self.assertEqual(
+                seg[q_per : q_per + g_per], g[gi * g_per : (gi + 1) * g_per]
+            )
+            self.assertEqual(
+                seg[q_per + g_per : q_per + g_per + k_per],
+                k[gi * k_per : (gi + 1) * k_per],
+            )
+            self.assertEqual(
+                seg[q_per + g_per + k_per :], v[gi * v_per : (gi + 1) * v_per]
+            )
+
+    def test_head_dim_neq_v_head_dim_chunks(self):
+        q, g, k, v, fused, _ = _temp_names(_W, 1, 1, 6, 4, True)
+        # nh=1 nkv=1 hd=6 vhd=4 -> gcd 2 -> 3 vs 2 chunks per head.
+        self.assertEqual(len(q), 1 * 3)
+        self.assertEqual(len(g), 1 * 2)
+        self.assertEqual(len(k), 1 * 3)
+        self.assertEqual(len(v), 1 * 2)
+
+
+class TestSeparateForward(unittest.TestCase):
+    """Separate layout (ERNIE-Lite): checkpoint q/gate/k/v are four distinct
+    keys; forward splits each, regroups into the fused per-group layout, then
+    transposes (weights) into the model single."""
+
+    def setUp(self):
+        self.ctx = _ctx(_PP, "separate")
+
+    def test_weight_and_bias_golden(self):
+        attn = _FakeAttn(gated=True, hd=4, vhd=2, nh=4, nkv=2, bias=True)
+        q, g, k, v, fused, _ = _temp_names(_W, 4, 2, 4, 2, True)
+        qb, gb, kb, vb, fusedb, _ = _temp_names(_BIAS, 4, 2, 4, 2, True)
+        stmts = gen_gated_qkv_aoa(attn, self.ctx, _PFX, None, "separate")
+        expected = [
+            f"{_checkpoint('q_proj.weight')} -> {','.join(q)}, axis=0",
+            f"{_checkpoint('gate_proj.weight')} -> {','.join(g)}, axis=0",
+            f"{_checkpoint('k_proj.weight')} -> {','.join(k)}, axis=0",
+            f"{_checkpoint('v_proj.weight')} -> {','.join(v)}, axis=0",
+            f"{','.join(fused)} -> {_W}.qkv_fused_tmp, axis=0",
+            f"{_W}.qkv_fused_tmp^T -> {_W}",
+            f"{_checkpoint('q_proj.bias')} -> {','.join(qb)}, axis=0",
+            f"{_checkpoint('gate_proj.bias')} -> {','.join(gb)}, axis=0",
+            f"{_checkpoint('k_proj.bias')} -> {','.join(kb)}, axis=0",
+            f"{_checkpoint('v_proj.bias')} -> {','.join(vb)}, axis=0",
+            f"{','.join(fusedb)} -> {_BIAS}, axis=0",
+        ]
+        self.assertEqual(stmts, expected)
+
+    def test_non_gated_omits_gate(self):
+        attn = _FakeAttn(gated=False, hd=4, vhd=2, nh=4, nkv=2, bias=False)
+        stmts = gen_gated_qkv_aoa(attn, self.ctx, _PFX, None, "separate")
+        self.assertFalse(any("gate_proj" in s for s in stmts))
+
+
+class TestInterleavedForward(unittest.TestCase):
+    """Interleaved layout (Qwen3.5): gate rides head-interleaved inside the
+    single ``q_proj`` checkpoint tensor; there is NO separate ``gate_proj`` key,
+    so one split off ``q_proj`` produces both Q and Gate temps."""
+
+    def setUp(self):
+        self.ctx = _ctx(_PP, "interleaved")
+
+    def test_weight_golden_single_q_split(self):
+        attn = _FakeAttn(gated=True, hd=4, vhd=2, nh=4, nkv=2, bias=False)
+        _, _, k, v, fused, qg = _temp_names(_W, 4, 2, 4, 2, True)
+        stmts = gen_gated_qkv_aoa(attn, self.ctx, _PFX, None, "interleaved")
+        expected = [
+            f"{_checkpoint('q_proj.weight')} -> {','.join(qg)}, axis=0",
+            f"{_checkpoint('k_proj.weight')} -> {','.join(k)}, axis=0",
+            f"{_checkpoint('v_proj.weight')} -> {','.join(v)}, axis=0",
+            f"{','.join(fused)} -> {_W}.qkv_fused_tmp, axis=0",
+            f"{_W}.qkv_fused_tmp^T -> {_W}",
+        ]
+        self.assertEqual(stmts, expected)
+
+    def test_no_separate_gate_key(self):
+        attn = _FakeAttn(gated=True, hd=4, vhd=2, nh=4, nkv=2, bias=False)
+        stmts = gen_gated_qkv_aoa(attn, self.ctx, _PFX, None, "interleaved")
+        self.assertFalse(any("gate_proj" in s for s in stmts))
+
+
+class TestInverse(unittest.TestCase):
+    """Inverse (independently generated): transpose the fused single (weights),
+    split along the per-group layout, then regroup each checkpoint tensor.
+    Separate -> four keys; interleaved -> merge Q+Gate back into ``q_proj``."""
+
+    def test_separate_weight_golden(self):
+        ctx = _ctx(_PP, "separate")
+        attn = _FakeAttn(gated=True, hd=4, vhd=2, nh=4, nkv=2, bias=False)
+        q, g, k, v, fused, _ = _temp_names(_W, 4, 2, 4, 2, True)
+        stmts = gen_gated_qkv_inv_aoa(attn, ctx, _PFX, None, "separate")
+        expected = [
+            f"{_W}^T -> {_W}.qkv_fused_tmp",
+            f"{_W}.qkv_fused_tmp -> {','.join(fused)}, axis=0",
+            f"{','.join(q)} -> {_checkpoint('q_proj.weight')}, axis=0",
+            f"{','.join(g)} -> {_checkpoint('gate_proj.weight')}, axis=0",
+            f"{','.join(k)} -> {_checkpoint('k_proj.weight')}, axis=0",
+            f"{','.join(v)} -> {_checkpoint('v_proj.weight')}, axis=0",
+        ]
+        self.assertEqual(stmts, expected)
+
+    def test_interleaved_weight_golden(self):
+        ctx = _ctx(_PP, "interleaved")
+        attn = _FakeAttn(gated=True, hd=4, vhd=2, nh=4, nkv=2, bias=False)
+        _, _, k, v, fused, qg = _temp_names(_W, 4, 2, 4, 2, True)
+        stmts = gen_gated_qkv_inv_aoa(attn, ctx, _PFX, None, "interleaved")
+        expected = [
+            f"{_W}^T -> {_W}.qkv_fused_tmp",
+            f"{_W}.qkv_fused_tmp -> {','.join(fused)}, axis=0",
+            f"{','.join(qg)} -> {_checkpoint('q_proj.weight')}, axis=0",
+            f"{','.join(k)} -> {_checkpoint('k_proj.weight')}, axis=0",
+            f"{','.join(v)} -> {_checkpoint('v_proj.weight')}, axis=0",
+        ]
+        self.assertEqual(stmts, expected)
+
+
+class TestFlagRoutingContract(unittest.TestCase):
+    """The base ``SelfAttention`` qkv head dispatcher routes gated attention to
+    the shared helper (no AOA-only subclass involved)."""
+
+    def test_dispatcher_uses_gated_helper(self):
+        import inspect
+
+        from paddlefleet.transformer.attention import SelfAttention
+
+        fwd = inspect.getsource(SelfAttention._gen_qkv_head_aoa_statements)
+        inv = inspect.getsource(SelfAttention._gen_inv_qkv_head_aoa_statements)
+        self.assertIn("gated_attention", fwd)
+        self.assertIn("gen_gated_qkv_aoa", fwd)
+        self.assertIn("gate_checkpoint_layout", fwd)
+        self.assertIn("gated_attention", inv)
+        self.assertIn("gen_gated_qkv_inv_aoa", inv)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_linear_component.py
+++ b/tests/single_card_tests/aoa/test_aoa_linear_component.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: the Linear family (``Linear`` / ``ColumnParallelLinear`` /
+# ``RowParallelLinear``) share a single module-level helper
+# ``gen_linear_aoa_statements`` / ``gen_linear_inv_aoa_statements``. This test
+# pins the coverage contract: ``weight`` carries ``^T``; bias / buffers use
+# identity only when their resolved names differ or a dtype cast is required;
+# and excluded aliases are omitted in both directions.
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+
+import paddle
+
+from paddlefleet.models.gpt.aoa_generator import (
+    FleetAOAContext,
+)
+
+
+def _ctx(
+    dtype_cast_rules=None,
+    *,
+    checkpoint_name_prefix="hf",
+    model_name_prefix="model",
+    excluded_names=frozenset(),
+):
+    return FleetAOAContext(
+        config=None,
+        checkpoint_name_prefix=checkpoint_name_prefix,
+        pp_to_single_mapping={},
+        checkpoint_name_mapping={},
+        dtype_cast_rules=dtype_cast_rules or {},
+        model_name_prefix=model_name_prefix,
+        excluded_names=excluded_names,
+    )
+
+
+def _make_linear_leaf(bias=False, buffer=False):
+    """Binds the Linear family AOA helpers onto a controllable stand-in.
+
+    The real ``Linear`` needs a live TP process group to construct, so we bind
+    the two override methods (which just forward to the module-level helpers)
+    onto a lightweight ``paddle.nn.Layer`` carrying real params / buffers.
+    """
+    from paddlefleet.tensor_parallel.layers import Linear
+
+    class _LinearLeaf(paddle.nn.Layer):
+        gen_aoa_statements = Linear.gen_aoa_statements
+        gen_inv_aoa_statements = Linear.gen_inv_aoa_statements
+
+        def __init__(self):
+            super().__init__()
+            self.weight = self.create_parameter(shape=[2, 2])
+            if bias:
+                self.bias = self.create_parameter(shape=[2])
+            if buffer:
+                # A persistable buffer must appear in state_dict and therefore
+                # get an identity statement (no orphan target).
+                self.register_buffer(
+                    "some_buf", paddle.zeros([2]), persistable=True
+                )
+                # A non-persistable buffer must NOT appear (no statement).
+                self.register_buffer(
+                    "tmp_buf", paddle.zeros([2]), persistable=False
+                )
+
+    return _LinearLeaf
+
+
+_PFX = "model.layers.0.mlp.down_proj."
+_W_CK = "hf.layers.0.mlp.down_proj.weight"
+_W_MD = "model.layers.0.mlp.down_proj.weight"
+
+
+class TestLinearClassContract(unittest.TestCase):
+    def test_three_linear_classes_override(self):
+        from paddlefleet.tensor_parallel.layers import (
+            ColumnParallelLinear,
+            Linear,
+            RowParallelLinear,
+        )
+
+        for cls in (Linear, ColumnParallelLinear, RowParallelLinear):
+            self.assertIn("gen_aoa_statements", cls.__dict__)
+            self.assertIn("gen_inv_aoa_statements", cls.__dict__)
+
+
+class TestLinearForward(unittest.TestCase):
+    def test_weight_transposed_bias_and_buffer_identity(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        # weight is transposed
+        self.assertIn(f"{_W_CK}^T -> {_W_MD}", stmts)
+        # bias is identity (no ^T)
+        self.assertIn(
+            "hf.layers.0.mlp.down_proj.bias -> "
+            "model.layers.0.mlp.down_proj.bias",
+            stmts,
+        )
+        # persistable buffer is identity, non-persistable buffer is absent
+        self.assertIn(
+            "hf.layers.0.mlp.down_proj.some_buf -> "
+            "model.layers.0.mlp.down_proj.some_buf",
+            stmts,
+        )
+        self.assertFalse(any("tmp_buf" in s for s in stmts))
+
+    def test_no_orphan_targets(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        # Every own state_dict key (weight/bias/some_buf) has exactly one
+        # producing statement; tmp_buf (non-persistable) has none.
+        self.assertEqual(len(stmts), 3)
+
+    def test_bias_absent_when_not_present(self):
+        model = _make_linear_leaf(bias=False, buffer=False)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        self.assertEqual(stmts, [f"{_W_CK}^T -> {_W_MD}"])
+
+    def test_same_name_identity_is_omitted(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        ctx = _ctx(checkpoint_name_prefix="model", model_name_prefix="model")
+        stmts = model.gen_aoa_statements(ctx, structured_name_prefix=_PFX)
+        self.assertEqual(stmts, [f"{_W_MD}^T -> {_W_MD}"])
+
+    def test_excluded_weight_is_omitted_in_forward_and_inverse(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        ctx = _ctx(excluded_names=frozenset({_PFX + "weight"}))
+
+        forward = model.gen_aoa_statements(ctx, structured_name_prefix=_PFX)
+        inverse = model.gen_inv_aoa_statements(ctx, structured_name_prefix=_PFX)
+
+        self.assertNotIn(f"{_W_CK}^T -> {_W_MD}", forward)
+        self.assertNotIn(f"{_W_MD}^T -> {_W_CK}", inverse)
+
+
+class TestLinearInverse(unittest.TestCase):
+    def test_weight_transposed_back_endpoints_swapped(self):
+        model = _make_linear_leaf(bias=True, buffer=True)()
+        stmts = model.gen_inv_aoa_statements(
+            _ctx(), structured_name_prefix=_PFX
+        )
+        self.assertIn(f"{_W_MD}^T -> {_W_CK}", stmts)
+        self.assertIn(
+            "model.layers.0.mlp.down_proj.bias -> "
+            "hf.layers.0.mlp.down_proj.bias",
+            stmts,
+        )
+        self.assertIn(
+            "model.layers.0.mlp.down_proj.some_buf -> "
+            "hf.layers.0.mlp.down_proj.some_buf",
+            stmts,
+        )
+        self.assertEqual(len(stmts), 3)
+
+
+class TestLinearDtypeCast(unittest.TestCase):
+    def test_forward_and_inverse_cast_endpoints(self):
+        rules = {
+            "layers.0.mlp.down_proj.weight": {
+                "checkpoint_dtype": "bfloat16",
+                "model_dtype": "float32",
+            }
+        }
+        model = _make_linear_leaf(bias=False)()
+        fwd = model.gen_aoa_statements(_ctx(rules), structured_name_prefix=_PFX)
+        self.assertEqual(
+            fwd,
+            [
+                f"{_W_CK}^T -> {_W_MD}, "
+                "src_dtype='bfloat16', dst_dtype='float32'"
+            ],
+        )
+        inv = model.gen_inv_aoa_statements(
+            _ctx(rules), structured_name_prefix=_PFX
+        )
+        self.assertEqual(
+            inv,
+            [
+                f"{_W_MD}^T -> {_W_CK}, "
+                "src_dtype='float32', dst_dtype='bfloat16'"
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_mla_split_kv_b_component.py
+++ b/tests/single_card_tests/aoa/test_aoa_mla_split_kv_b_component.py
@@ -1,0 +1,439 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: ``MLASelfAttention``'s only component AOA override, the
+# ``mqa_split_kv_b_proj`` mode. There ``kv_b_proj`` is not built at all and two
+# standalone absorption parameters hold its elements instead: ``k_b_proj``
+# folded from [heads, kv_lora, qk_nope] and ``v_b_proj`` folded from
+# [heads, v_head, kv_lora]. The checkpoint still carries one
+# ``kv_b_proj.weight`` key, transposed relative to the Fleet weight and
+# head-major in its rows, so both directions are a single chain over that key:
+# split into equal row blocks (granularity ``gcd(qk_nope, v_head)``), regroup
+# per head, transpose the K half only. Left to the generic recursion this
+# projection gets NO statements at all -- ``k_b_proj`` / ``v_b_proj`` resolve to
+# identities that ``should_skip`` drops -- which loads uninitialised memory and
+# saves two checkpoint keys no consumer understands.
+#
+# The non-split path is a bare ``super()`` delegation and is pinned structurally
+# in ``test_ai_aoa_dsv4_mla_zero_override.py``; a fake that merely borrows the
+# methods cannot exercise it, because zero-arg ``super()`` resolves against
+# ``MLASelfAttention``.
+#
+# This test pins the block geometry, both directions' exact statements, the
+# read-exactly-once property every temporary must have, the checkpoint-only
+# naming of the absent ``kv_b_proj``, that the two absorption params are skipped
+# by the own-parameter walk while other own params and sublayers are not, and
+# the two loud failures (partial exclusion, inverse dtype cast).
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+
+import paddle
+
+from paddlefleet.models.gpt.aoa_generator import (
+    FleetAOAContext,
+)
+
+_PREFIX = "model.layers.0.self_attn."
+_K = _PREFIX + "k_b_proj"
+_V = _PREFIX + "v_b_proj"
+_KV_CKPT = "hf.layers.0.self_attn.kv_b_proj.weight"
+
+
+def _ctx(
+    checkpoint_name_mapping=None,
+    dtype_cast_rules=None,
+    excluded_names=(),
+):
+    return FleetAOAContext(
+        config=None,
+        checkpoint_name_prefix="hf",
+        pp_to_single_mapping={},
+        checkpoint_name_mapping=checkpoint_name_mapping or {},
+        dtype_cast_rules=dtype_cast_rules or {},
+        model_name_prefix="model",
+        excluded_names=frozenset(excluded_names),
+    )
+
+
+def _make_split_mla(qk_nope=4, v_head=4, heads=2, kv_lora=3, extra_param=True):
+    """Stand-in for a live ``MLASelfAttention`` in split mode.
+
+    The generators read the geometry off exactly the attributes ``__init__``
+    sizes the two parameters with, so the fake carries those same attributes
+    and creates parameters of the same folded shapes; a marker that hard-coded
+    the block counts would pin nothing. ``kv_b_proj`` is deliberately absent,
+    which is what the real ``__init__`` does in this mode. Everything else a
+    real MLA owns (rope, core attention, a full TransformerConfig) is
+    irrelevant to plan generation.
+    """
+    from paddlefleet.tensor_parallel.layers import Linear
+    from paddlefleet.transformer.multi_latent_attention import MLASelfAttention
+
+    class _LinearLeaf(paddle.nn.Layer):
+        gen_aoa_statements = Linear.gen_aoa_statements
+        gen_inv_aoa_statements = Linear.gen_inv_aoa_statements
+
+        def __init__(self):
+            super().__init__()
+            self.weight = self.create_parameter(shape=[2, 2])
+            self.bias = None
+
+    class _SplitMLA(paddle.nn.Layer):
+        gen_aoa_statements = MLASelfAttention.gen_aoa_statements
+        gen_inv_aoa_statements = MLASelfAttention.gen_inv_aoa_statements
+        _SPLIT_KV_B_LOCAL_NAMES = MLASelfAttention._SPLIT_KV_B_LOCAL_NAMES
+        _split_kv_b_head_blocks = MLASelfAttention._split_kv_b_head_blocks
+        _split_kv_b_names = MLASelfAttention._split_kv_b_names
+        _split_kv_b_excluded = MLASelfAttention._split_kv_b_excluded
+        _gen_split_kv_b_aoa_statements = (
+            MLASelfAttention._gen_split_kv_b_aoa_statements
+        )
+        _gen_inv_split_kv_b_aoa_statements = (
+            MLASelfAttention._gen_inv_split_kv_b_aoa_statements
+        )
+
+        def __init__(self):
+            super().__init__()
+            self.mqa_latent_split_kv_b = True
+            self.qk_nope_head_dim = qk_nope
+            self.v_head_dim = v_head
+            self.num_attention_heads_per_partition = heads
+            self.k_b_proj = self.create_parameter(
+                shape=[heads * kv_lora, qk_nope]
+            )
+            self.v_b_proj = self.create_parameter(
+                shape=[heads * v_head, kv_lora]
+            )
+            if extra_param:
+                # A plain own parameter, to prove the skip list is narrow.
+                self.softmax_scale_param = self.create_parameter(shape=[1])
+            self.o_proj = _LinearLeaf()
+
+    return _SplitMLA()
+
+
+def _parse(statement):
+    """``(sources, targets)`` of one statement, transposes/attrs stripped."""
+    lhs, rhs = statement.split(" -> ", 1)
+    sources = [s.strip().removesuffix("^T") for s in lhs.split(",")]
+    # Attributes (``axis=``, ``src_dtype=`` ...) follow the target list.
+    targets = [t.strip() for t in rhs.split(",") if t.strip() and "=" not in t]
+    return sources, targets
+
+
+def _temp_usage(statements, roots):
+    """``(produced, consumed)`` counters for names under ``roots``."""
+    produced = {}
+    consumed = {}
+    for statement in statements:
+        sources, targets = _parse(statement)
+        for name in sources:
+            if any(name.startswith(root) for root in roots):
+                consumed[name] = consumed.get(name, 0) + 1
+        for name in targets:
+            if any(name.startswith(root) for root in roots):
+                produced[name] = produced.get(name, 0) + 1
+    return produced, consumed
+
+
+class TestSplitKVBGeometry(unittest.TestCase):
+    """The row-block granularity is ``gcd(qk_nope, v_head)``, so a head spans
+    ``n_k + n_v`` equal blocks."""
+
+    def test_equal_head_dims_give_one_block_each(self):
+        layer = _make_split_mla(qk_nope=4, v_head=4, heads=2)
+        self.assertEqual(layer._split_kv_b_head_blocks(), (2, 1, 1))
+
+    def test_unequal_head_dims_use_gcd(self):
+        layer = _make_split_mla(qk_nope=4, v_head=2, heads=3)
+        self.assertEqual(layer._split_kv_b_head_blocks(), (3, 2, 1))
+
+    def test_coprime_head_dims_split_to_rows(self):
+        layer = _make_split_mla(qk_nope=3, v_head=2, heads=1)
+        self.assertEqual(layer._split_kv_b_head_blocks(), (1, 3, 2))
+
+
+class TestSplitKVBForward(unittest.TestCase):
+    """Checkpoint -> model chain."""
+
+    def test_exact_statements(self):
+        layer = _make_split_mla(qk_nope=4, v_head=4, heads=2)
+        tmp = _K + "._kvb"
+        self.assertEqual(
+            layer._gen_split_kv_b_aoa_statements(_ctx(), _PREFIX, None),
+            [
+                f"{_KV_CKPT} -> "
+                f"{tmp}_r0_0,{tmp}_r0_1,{tmp}_r1_0,{tmp}_r1_1, axis=0",
+                f"{tmp}_r0_0 -> {tmp}_k0, axis=0",
+                f"{tmp}_k0^T -> {tmp}_kt0",
+                f"{tmp}_r0_1 -> {tmp}_v0, axis=0",
+                f"{tmp}_r1_0 -> {tmp}_k1, axis=0",
+                f"{tmp}_k1^T -> {tmp}_kt1",
+                f"{tmp}_r1_1 -> {tmp}_v1, axis=0",
+                f"{tmp}_kt0,{tmp}_kt1 -> {_K}, axis=0",
+                f"{tmp}_v0,{tmp}_v1 -> {_V}, axis=0",
+            ],
+        )
+
+    def test_unequal_dims_group_blocks_per_head(self):
+        # qk_nope=4, v_head=2 -> chunk 2, so a head is 2 K blocks + 1 V block.
+        layer = _make_split_mla(qk_nope=4, v_head=2, heads=1)
+        tmp = _K + "._kvb"
+        self.assertEqual(
+            layer._gen_split_kv_b_aoa_statements(_ctx(), _PREFIX, None),
+            [
+                f"{_KV_CKPT} -> {tmp}_r0_0,{tmp}_r0_1,{tmp}_r0_2, axis=0",
+                f"{tmp}_r0_0,{tmp}_r0_1 -> {tmp}_k0, axis=0",
+                f"{tmp}_k0^T -> {tmp}_kt0",
+                f"{tmp}_r0_2 -> {tmp}_v0, axis=0",
+                f"{tmp}_kt0 -> {_K}, axis=0",
+                f"{tmp}_v0 -> {_V}, axis=0",
+            ],
+        )
+
+    def test_every_temporary_read_exactly_once(self):
+        # ``get_var_mapping_chain_macro`` overwrites a variable's chain with a
+        # plain assignment, so a temporary consumed twice silently drops the
+        # first chain and leaves its destination uninitialised.
+        layer = _make_split_mla(qk_nope=6, v_head=4, heads=3)
+        statements = layer._gen_split_kv_b_aoa_statements(_ctx(), _PREFIX, None)
+        produced, consumed = _temp_usage(statements, (_K + "._kvb",))
+        self.assertEqual(sorted(produced), sorted(consumed))
+        self.assertEqual(set(produced.values()), {1})
+        self.assertEqual(set(consumed.values()), {1})
+
+    def test_absent_kv_b_proj_is_never_a_model_target(self):
+        # ``kv_b_proj`` is not built in this mode, so unlike the hand-written
+        # generator (which predates that optimisation) nothing may be written
+        # to it, and no dead-weight ``_ ->`` filler is emitted.
+        layer = _make_split_mla()
+        statements = layer._gen_split_kv_b_aoa_statements(_ctx(), _PREFIX, None)
+        self.assertEqual([s for s in statements if s.startswith("_ ->")], [])
+        for statement in statements:
+            _, targets = _parse(statement)
+            for target in targets:
+                self.assertNotIn("kv_b_proj", target)
+
+    def test_checkpoint_name_mapping_applies_to_the_fused_key(self):
+        layer = _make_split_mla()
+        ctx = _ctx(
+            checkpoint_name_mapping={
+                "layers.$LAYER_ID.self_attn.kv_b_proj.weight": (
+                    "blocks.$LAYER_ID.attn.kv_b.w"
+                )
+            }
+        )
+        statements = layer._gen_split_kv_b_aoa_statements(ctx, _PREFIX, None)
+        self.assertTrue(
+            statements[0].startswith("hf.blocks.0.attn.kv_b.w -> "),
+            statements[0],
+        )
+
+
+class TestSplitKVBInverse(unittest.TestCase):
+    """Model -> checkpoint chain."""
+
+    def test_exact_statements(self):
+        layer = _make_split_mla(qk_nope=4, v_head=4, heads=2)
+        tmp = _K + "._inv_kvb"
+        self.assertEqual(
+            layer._gen_inv_split_kv_b_aoa_statements(_ctx(), _PREFIX, None),
+            [
+                f"{_K} -> {tmp}_k0,{tmp}_k1, axis=0",
+                f"{_V}^T -> {tmp}_vt",
+                f"{tmp}_vt -> {tmp}_v0,{tmp}_v1, axis=1",
+                f"{tmp}_k0,{tmp}_v0 -> {tmp}_h0, axis=1",
+                f"{tmp}_k1,{tmp}_v1 -> {tmp}_h1, axis=1",
+                f"{tmp}_h0,{tmp}_h1 -> {tmp}_kv, axis=1",
+                f"{tmp}_kv^T -> {_KV_CKPT}",
+            ],
+        )
+
+    def test_head_major_column_order_is_k_then_v(self):
+        # The checkpoint rows are, per head, the K rows followed by the V rows;
+        # after the single closing transpose that is the per-head column order,
+        # so the per-head concat must put K first.
+        layer = _make_split_mla(qk_nope=4, v_head=4, heads=2)
+        tmp = _K + "._inv_kvb"
+        statements = layer._gen_inv_split_kv_b_aoa_statements(
+            _ctx(), _PREFIX, None
+        )
+        for h in range(2):
+            self.assertIn(
+                f"{tmp}_k{h},{tmp}_v{h} -> {tmp}_h{h}, axis=1", statements
+            )
+
+    def test_block_count_does_not_leak_into_the_inverse(self):
+        # The inverse rebuilds whole heads, so unequal head dims change nothing
+        # about its shape: one split per parameter, one concat per head.
+        layer = _make_split_mla(qk_nope=6, v_head=2, heads=2)
+        statements = layer._gen_inv_split_kv_b_aoa_statements(
+            _ctx(), _PREFIX, None
+        )
+        self.assertEqual(len(statements), 7)
+
+    def test_every_temporary_read_exactly_once(self):
+        layer = _make_split_mla(qk_nope=6, v_head=4, heads=3)
+        statements = layer._gen_inv_split_kv_b_aoa_statements(
+            _ctx(), _PREFIX, None
+        )
+        produced, consumed = _temp_usage(statements, (_K + "._inv_kvb",))
+        self.assertEqual(sorted(produced), sorted(consumed))
+        self.assertEqual(set(produced.values()), {1})
+        self.assertEqual(set(consumed.values()), {1})
+
+    def test_absent_kv_b_proj_is_never_a_model_source(self):
+        layer = _make_split_mla()
+        statements = layer._gen_inv_split_kv_b_aoa_statements(
+            _ctx(), _PREFIX, None
+        )
+        self.assertEqual([s for s in statements if s.endswith(" -> _")], [])
+        for statement in statements:
+            sources, _ = _parse(statement)
+            for source in sources:
+                self.assertNotIn(".kv_b_proj", source)
+
+
+class TestSplitKVBComposition(unittest.TestCase):
+    """The two absorption params are handled by the chain and skipped by the
+    generic own-parameter walk; nothing else changes."""
+
+    def test_forward_skips_absorption_params_and_keeps_the_rest(self):
+        layer = _make_split_mla()
+        statements = layer.gen_aoa_statements(
+            _ctx(), structured_name_prefix=_PREFIX
+        )
+        chain = layer._gen_split_kv_b_aoa_statements(_ctx(), _PREFIX, None)
+        self.assertEqual(statements[: len(chain)], chain)
+        # No identity statement competing with the chain for either parameter.
+        self.assertEqual(
+            [s for s in statements[len(chain) :] if "_b_proj" in s], []
+        )
+        # The sibling Linear child is still recursed (it needs its transpose).
+        self.assertIn(
+            f"hf.layers.0.self_attn.o_proj.weight^T -> {_PREFIX}o_proj.weight",
+            statements,
+        )
+
+    def test_renamed_absorption_params_still_get_no_identity(self):
+        # With a mapping in play source != target, so ``should_skip`` would no
+        # longer hide a stray identity: the explicit skip list is what keeps
+        # the chain the single producer.
+        layer = _make_split_mla()
+        ctx = _ctx(
+            checkpoint_name_mapping={
+                "layers.$LAYER_ID.self_attn.k_b_proj": "renamed.k",
+                "layers.$LAYER_ID.self_attn.v_b_proj": "renamed.v",
+            }
+        )
+        statements = layer.gen_aoa_statements(
+            ctx, structured_name_prefix=_PREFIX
+        )
+        self.assertEqual([s for s in statements if "renamed." in s], [])
+
+    def test_inverse_skips_absorption_params_and_keeps_the_rest(self):
+        layer = _make_split_mla()
+        statements = layer.gen_inv_aoa_statements(
+            _ctx(), structured_name_prefix=_PREFIX
+        )
+        chain = layer._gen_inv_split_kv_b_aoa_statements(_ctx(), _PREFIX, None)
+        self.assertEqual(statements[: len(chain)], chain)
+        self.assertEqual(
+            [s for s in statements[len(chain) :] if "_b_proj" in s], []
+        )
+        self.assertIn(
+            f"{_PREFIX}o_proj.weight^T -> hf.layers.0.self_attn.o_proj.weight",
+            statements,
+        )
+
+    def test_excluding_both_params_drops_the_whole_chain(self):
+        layer = _make_split_mla()
+        ctx = _ctx(excluded_names=(_PREFIX + "k_b_proj", _PREFIX + "v_b_proj"))
+        for statements in (
+            layer.gen_aoa_statements(ctx, structured_name_prefix=_PREFIX),
+            layer.gen_inv_aoa_statements(ctx, structured_name_prefix=_PREFIX),
+        ):
+            self.assertEqual([s for s in statements if "_b_proj" in s], [])
+            self.assertEqual([s for s in statements if "kv_b_proj" in s], [])
+
+    def test_partial_exclusion_fails_loudly(self):
+        # Honoring half of one chain would leave the other half sourceless on
+        # load / the checkpoint key half-built on save.
+        layer = _make_split_mla()
+        for excluded in ("k_b_proj", "v_b_proj"):
+            ctx = _ctx(excluded_names=(_PREFIX + excluded,))
+            with self.assertRaises(NotImplementedError):
+                layer.gen_aoa_statements(ctx, structured_name_prefix=_PREFIX)
+            with self.assertRaises(NotImplementedError):
+                layer.gen_inv_aoa_statements(
+                    ctx, structured_name_prefix=_PREFIX
+                )
+
+
+class TestSplitKVBDtypeCast(unittest.TestCase):
+    """Neither direction carries a cast: both end in a concat, and a cast
+    suffix only rides a one-to-one statement. Save rejects a matching rule;
+    load ignores it."""
+
+    _RULE = {"checkpoint_dtype": "float32", "model_dtype": "bfloat16"}
+    _NOOP = {"checkpoint_dtype": "bfloat16", "model_dtype": "bfloat16"}
+
+    def test_forward_ignores_a_cast_rule(self):
+        layer = _make_split_mla(qk_nope=4, v_head=4, heads=2)
+        ctx = _ctx(
+            dtype_cast_rules={"layers.$LAYER_ID.self_attn.k_b_proj": self._RULE}
+        )
+        statements = layer._gen_split_kv_b_aoa_statements(ctx, _PREFIX, None)
+        self.assertEqual(
+            statements,
+            layer._gen_split_kv_b_aoa_statements(_ctx(), _PREFIX, None),
+        )
+        self.assertEqual([s for s in statements if "dtype" in s], [])
+
+    def test_inverse_rejects_a_cast(self):
+        layer = _make_split_mla()
+        for local in ("k_b_proj", "v_b_proj"):
+            ctx = _ctx(
+                dtype_cast_rules={
+                    f"layers.$LAYER_ID.self_attn.{local}": self._RULE
+                }
+            )
+            with self.assertRaises(NotImplementedError):
+                layer._gen_inv_split_kv_b_aoa_statements(ctx, _PREFIX, None)
+
+    def test_inverse_accepts_a_noop_cast_rule(self):
+        # Equal dtypes format to an empty suffix, so there is nothing to drop.
+        layer = _make_split_mla()
+        ctx = _ctx(
+            dtype_cast_rules={"layers.$LAYER_ID.self_attn.k_b_proj": self._NOOP}
+        )
+        self.assertEqual(
+            len(layer._gen_inv_split_kv_b_aoa_statements(ctx, _PREFIX, None)),
+            7,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/aoa/test_aoa_self_attention_component.py
+++ b/tests/single_card_tests/aoa/test_aoa_self_attention_component.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Scope: standard ``SelfAttention`` fuses the checkpoint q/k/v projections
+# (each transposed) into the model ``qkv_proj`` via the ``fused_qkv`` macro,
+# adds an optional fused ``axis=0`` bias, then recurses every other direct
+# child generically (``o_proj`` -> Linear ``^T``) and emits an identity
+# statement for each own persistable buffer. This test pins that coverage
+# contract and the independent inverse split.
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.dirname(
+        os.path.dirname(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        )
+    ),
+)
+
+import unittest
+
+import paddle
+
+from paddlefleet.models.gpt.aoa_generator import (
+    FleetAOAContext,
+)
+
+
+class _Config:
+    num_attention_heads = 8
+    num_key_value_heads = 2
+
+
+def _ctx(dtype_cast_rules=None):
+    return FleetAOAContext(
+        config=_Config(),
+        checkpoint_name_prefix="hf",
+        pp_to_single_mapping={},
+        checkpoint_name_mapping={},
+        dtype_cast_rules=dtype_cast_rules or {},
+        model_name_prefix="model",
+        excluded_names=frozenset(),
+    )
+
+
+def _make_linear_leaf(bias=False):
+    from paddlefleet.tensor_parallel.layers import Linear
+
+    class _LinearLeaf(paddle.nn.Layer):
+        gen_aoa_statements = Linear.gen_aoa_statements
+        gen_inv_aoa_statements = Linear.gen_inv_aoa_statements
+
+        def __init__(self):
+            super().__init__()
+            self.weight = self.create_parameter(shape=[2, 2])
+            self.bias = self.create_parameter(shape=[2]) if bias else None
+
+    return _LinearLeaf
+
+
+def _make_attn_leaf(qkv_bias=False, buffer=False):
+    """Binds the SelfAttention AOA overrides onto a controllable stand-in.
+
+    The real ``SelfAttention`` needs a live TP process group, so we bind the
+    two entry points, the qkv-head hooks they dispatch into, and the fused
+    qkv-bias helpers those hooks delegate their bias tail to. The stand-in
+    carries a ``qkv_proj`` leaf (whose ``.bias`` gates the fused-bias
+    statement), an ``o_proj`` Linear leaf that is recursed generically, and an
+    optional own persistable buffer. ``gated_attention = False`` selects the
+    standard qkv branch (the gated layout has its own component test).
+    """
+    from paddlefleet.transformer.attention import SelfAttention
+
+    linear_with_bias = _make_linear_leaf(bias=qkv_bias)
+    linear_plain = _make_linear_leaf(bias=False)
+
+    class _AttnLeaf(paddle.nn.Layer):
+        gen_aoa_statements = SelfAttention.gen_aoa_statements
+        gen_inv_aoa_statements = SelfAttention.gen_inv_aoa_statements
+        _gen_qkv_head_aoa_statements = (
+            SelfAttention._gen_qkv_head_aoa_statements
+        )
+        _gen_inv_qkv_head_aoa_statements = (
+            SelfAttention._gen_inv_qkv_head_aoa_statements
+        )
+        _gen_qkv_bias_aoa_statements = (
+            SelfAttention._gen_qkv_bias_aoa_statements
+        )
+        _gen_inv_qkv_bias_aoa_statements = (
+            SelfAttention._gen_inv_qkv_bias_aoa_statements
+        )
+        gated_attention = False
+
+        def __init__(self):
+            super().__init__()
+            self.qkv_proj = linear_with_bias()
+            self.o_proj = linear_plain()
+            if buffer:
+                self.register_buffer(
+                    "some_buf", paddle.zeros([2]), persistable=True
+                )
+                self.register_buffer(
+                    "tmp_buf", paddle.zeros([2]), persistable=False
+                )
+
+    return _AttnLeaf
+
+
+_PFX = "model.layers.0.self_attn."
+_HF = "hf.layers.0.self_attn."
+_MD = "model.layers.0.self_attn."
+
+
+class TestSelfAttentionClassContract(unittest.TestCase):
+    def test_override_present(self):
+        from paddlefleet.transformer.attention import SelfAttention
+
+        for name in (
+            "gen_aoa_statements",
+            "gen_inv_aoa_statements",
+            "_gen_qkv_head_aoa_statements",
+            "_gen_inv_qkv_head_aoa_statements",
+            "_gen_qkv_bias_aoa_statements",
+            "_gen_inv_qkv_bias_aoa_statements",
+        ):
+            self.assertIn(name, SelfAttention.__dict__)
+
+
+class TestSelfAttentionForward(unittest.TestCase):
+    def test_fused_qkv_weight_and_child_recursion(self):
+        model = _make_attn_leaf(qkv_bias=False, buffer=True)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        # fused qkv weight: three transposed checkpoint inputs, one model output
+        self.assertIn(
+            f"{_HF}q_proj.weight^T, {_HF}k_proj.weight^T, "
+            f"{_HF}v_proj.weight^T "
+            f"-> {_MD}qkv_proj.weight, fused_qkv, "
+            f"num_heads=8, num_key_value_groups=2",
+            stmts,
+        )
+        # o_proj recursed generically -> Linear transpose
+        self.assertIn(f"{_HF}o_proj.weight^T -> {_MD}o_proj.weight", stmts)
+        # own persistable buffer -> identity; non-persistable absent
+        self.assertIn(f"{_HF}some_buf -> {_MD}some_buf", stmts)
+        self.assertFalse(any("tmp_buf" in s for s in stmts))
+
+    def test_fused_qkv_bias_present_when_qkv_has_bias(self):
+        model = _make_attn_leaf(qkv_bias=True, buffer=False)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        self.assertIn(
+            f"{_HF}q_proj.bias, {_HF}k_proj.bias, {_HF}v_proj.bias "
+            f"-> {_MD}qkv_proj.bias, fused_qkv, "
+            f"num_heads=8, num_key_value_groups=2, axis=0",
+            stmts,
+        )
+
+    def test_no_qkv_bias_statement_when_absent(self):
+        model = _make_attn_leaf(qkv_bias=False, buffer=False)()
+        stmts = model.gen_aoa_statements(_ctx(), structured_name_prefix=_PFX)
+        self.assertFalse(any("qkv_proj.bias" in s for s in stmts))
+        # exactly two statements: fused qkv weight + o_proj weight
+        self.assertEqual(len(stmts), 2)
+
+
+class TestSelfAttentionInverse(unittest.TestCase):
+    def test_fused_qkv_split_and_child_recursion(self):
+        model = _make_attn_leaf(qkv_bias=True, buffer=True)()
+        stmts = model.gen_inv_aoa_statements(
+            _ctx(), structured_name_prefix=_PFX
+        )
+        # inverse fused qkv split carries NO ^T
+        self.assertIn(
+            f"{_MD}qkv_proj.weight -> {_HF}q_proj.weight, "
+            f"{_HF}k_proj.weight, {_HF}v_proj.weight, "
+            f"fused_qkv, num_heads=8, num_key_value_groups=2",
+            stmts,
+        )
+        # inverse fused bias split
+        self.assertIn(
+            f"{_MD}qkv_proj.bias -> {_HF}q_proj.bias, "
+            f"{_HF}k_proj.bias, {_HF}v_proj.bias, "
+            f"fused_qkv, num_heads=8, num_key_value_groups=2, axis=0",
+            stmts,
+        )
+        # o_proj recursed -> Linear inverse transpose (endpoints swapped)
+        self.assertIn(f"{_MD}o_proj.weight^T -> {_HF}o_proj.weight", stmts)
+        # own persistable buffer identity (model -> checkpoint)
+        self.assertIn(f"{_MD}some_buf -> {_HF}some_buf", stmts)
+
+
+class TestSelfAttentionDtypeCast(unittest.TestCase):
+    def test_own_buffer_cast_endpoints(self):
+        rules = {
+            "layers.0.self_attn.some_buf": {
+                "checkpoint_dtype": "bfloat16",
+                "model_dtype": "float32",
+            }
+        }
+        model = _make_attn_leaf(qkv_bias=False, buffer=True)()
+        fwd = model.gen_aoa_statements(_ctx(rules), structured_name_prefix=_PFX)
+        self.assertIn(
+            f"{_HF}some_buf -> {_MD}some_buf, "
+            "src_dtype='bfloat16', dst_dtype='float32'",
+            fwd,
+        )
+        inv = model.gen_inv_aoa_statements(
+            _ctx(rules), structured_name_prefix=_PFX
+        )
+        self.assertIn(
+            f"{_MD}some_buf -> {_HF}some_buf, "
+            "src_dtype='float32', dst_dtype='bfloat16'",
+            inv,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
+++ b/tests/single_card_tests/transformer/test_magic_send_shared_last_layer_desc.py
@@ -74,11 +74,13 @@ def _make_config(**overrides):
 def _layer_descs(num_mtp=1, **config_overrides):
     """Call get_layer_desc_list without building a real GPTModel.
 
-    The method only touches ``self.config`` and ``self.add_sequential_layer``,
-    so a stub carrying those two is enough and keeps this a single-card test.
+    The method only touches ``self.config``, ``self._model_name_prefix`` and
+    ``self.add_sequential_layer``, so a stub carrying those three is enough and
+    keeps this a single-card test.
     """
     fake_self = SimpleNamespace(
         config=_make_config(**config_overrides),
+        _model_name_prefix=lambda: "model",
         add_sequential_layer=lambda layers, desc, name_prefix="": layers.append(
             {"layer": desc, "name_prefix": name_prefix}
         ),


### PR DESCRIPTION
### PR Category

Distributed Strategy

### PR Types

New features

### Description

模块化 AOA 基础能力系列四（批5+批6）：注意力与 MLA/CSA/DSA 组件叶子。

> **依赖 #2023（stacked）。** 本 PR 分支基于 #2023 的分支，因上游无法承载 #2023 的分支作为 base，这里 base 只能设为 `develop`。**在 #2023 合入前，此处 diff 会一并包含 #2023 的 c1/c2 改动**；#2023 合入后 diff 会自动收敛为本 PR 唯一的新增 commit `6d168219`。请优先 review #2023，再看本 PR 的增量。

本 PR 唯一新增 commit（`6d168219`）内容：把组件级 AOA 语句发射器挂到自注意力族与潜/稀疏注意力变体上：

- 自注意力族：`attention.py` + `gated_qkv_aoa.py` 辅助模块。
- 潜/稀疏变体：`multi_latent_attention.py`、`csa_attention.py`、`dsa_attention.py` + `init_from_scratch_aoa.py` 辅助模块。
- 单测落在非受限目录 `tests/single_card_tests/aoa/`（`test_aoa_self_attention_component.py`、`test_aoa_attention_prefused_qkv_component.py`、`test_aoa_gated_qkv_component.py`、`test_aoa_mla_split_kv_b_component.py`、`test_aoa_csa_dsa_components.py`、`test_aoa_dsv4_mla_zero_override.py`）。

`aoa_modular` 保持 `False`（当前无任何模型翻 True）时，以上全部静态不可达；命名与 checkpoint 行为与改动前逐字节一致。

### 是否引起精度变化

否。

纯新增代码，仅在 `aoa_modular=True` 时进入；当前无模型开启，gate 关闭时静态不可达，不进入任何计算或 checkpoint 路径。
