### PR TITLE
[DSA] Fix two stale negative controls in the MQA+DSA single-card tests

### DIFF
--- a/src/paddlefleet/fusions/mqa_sparse_attn.py
+++ b/src/paddlefleet/fusions/mqa_sparse_attn.py
@@ -282,16 +282,14 @@ class _MQASparseAttention(paddle.autograd.PyLayer):
             #
             # The forward output was formed with the sink competing in the softmax
             # denominator: p_k = exp(l_k - lse_full), lse_full = logaddexp(lse_kv,
-            # sink). But the forward kernel returns a KV-only ``lse`` (the sink is
-            # excluded), and the cuDNN DSA backward's ``d_qk != d_v`` branch (the
-            # absorbed-MQA Dk=576 / Dv=512 layout used here) consumes the passed LSE
-            # verbatim -- it does NOT fold the sink into the denominator itself.
-            # Feeding it the KV-only LSE therefore overestimates every p_k for a
-            # finite sink and corrupts dq (confirmed: packed finite-sink dQ cos
-            # 0.976 vs the dense reference). Fix: for a finite (learnable) sink on
-            # this Dk!=Dv path, pass a sink-inclusive LSE and neutralize the sink
-            # argument (a -1e30 sink can no longer double-count in the kernel), so
-            # p_k matches the forward exactly.
+            # sink), while the forward kernel returns a KV-only ``lse``. The sink
+            # therefore has to reach the backward exactly once: pass a
+            # sink-inclusive LSE *and* neutralize the sink argument, because the
+            # vendored cuDNN DSA backward folds ``attn_sink`` into the LSE itself
+            # (``_interface_sm100.py``) and would otherwise count it twice.
+            # Measured on SM100, dq rel-err vs an fp32 autograd reference at
+            # sink=3.0: this pairing 3.7e-3, double-counted 0.30, sink missing
+            # from the backward entirely 1.96.
             #
             # Sinkless keeps the KV-only ``lse`` and the -1e30 ``sink`` untouched
             # (logaddexp(lse, -1e30) == lse), so that path is bit-for-bit unchanged.
@@ -299,13 +297,12 @@ class _MQASparseAttention(paddle.autograd.PyLayer):
             # KV-only ``lse`` (it re-derives lse_full from it).
             lse_bwd = lse
             sink_bwd = sink
-            # This correction is load-bearing and silent: dropping it leaves the
-            # forward output bit-identical (it only touches the backward), while
-            # ``dq`` gets ~75x and ``dkv`` ~120x worse against an autograd
-            # reference. Do not use forward agreement to conclude the backward is
-            # fine. See ``tests/.../test_block_sparse_dsa_gradcheck.py::
+            # Load-bearing and silent: getting the sink count wrong here leaves the
+            # forward output bit-identical (this only touches the backward). Do not
+            # use forward agreement to conclude the backward is fine. See
+            # ``tests/.../test_block_sparse_dsa_gradcheck.py::
             # test_finite_sink_lse_fix_matters``, which re-drives the raw kernels
-            # with the uncorrected KV-only LSE to pin the gap.
+            # with a sink-free backward to pin the gap.
             if ctx.learnable_sink and dk != d_v:
                 lse_bwd = paddle.logaddexp(
                     lse.astype("float32"),

--- a/tests/single_card_tests/transformer/test_block_sparse_dsa_gradcheck.py
+++ b/tests/single_card_tests/transformer/test_block_sparse_dsa_gradcheck.py
@@ -224,14 +224,22 @@ def _kernel_grads(
     return dq, dkv, dsink
 
 
-def _kernel_dq_with_kv_only_lse(q_np, kv_np, ti_np, dO_np, sink_mag):
-    """dQ from the raw kernels with the **uncorrected** KV-only LSE.
+def _kernel_dq_with_sinkless_bwd(q_np, kv_np, ti_np, dO_np, sink_mag):
+    """dQ from the raw kernels with the sink absent from the *backward*.
 
-    ``mqa_sparse_attn`` always folds the sink into the LSE it hands the cuDNN
-    DSA backward, because that kernel's ``d_qk != d_v`` branch consumes the LSE
-    verbatim. This helper drives the same kernel pair directly and skips the
-    fold, so a test can measure what the correction is worth without the layer
-    needing a switch for it.
+    The forward still competes against the real sink; only the backward is
+    driven with a denominator that knows nothing about it (the KV-only LSE the
+    forward returns, plus a ``-1e30`` sink). That is the quantity
+    ``mqa_sparse_attn``'s finite-sink correction buys, and it is measurable
+    whichever LSE convention the vendored cuDNN kernel follows:
+
+    * cuDNN >= 1.28 folds ``attn_sink`` into the LSE itself, so the KV-only LSE
+      *with* the real sink is already correct (measured 3.7e-3 -- which is why
+      that pairing cannot be used as the negative control);
+    * older kernels consume the passed LSE verbatim.
+
+    Either way ``logaddexp(lse_kv, -1e30) == lse_kv`` leaves the sink out of the
+    softmax denominator, so every ``p_k`` is overestimated (measured 1.96).
     """
     from paddlefleet.cudnn_ops import csa_sparse_attn_bwd_cudnn
     from paddlefleet.cudnn_ops.attn.csa_sparse_attn_fwd_cudnn import (
@@ -276,8 +284,8 @@ def _kernel_dq_with_kv_only_lse(q_np, kv_np, ti_np, dO_np, sink_mag):
         kvb.reshape([b * skv, DK]),
         out.reshape([b * s, hp, DV]),
         do.reshape([b * s, hp, DV]),
-        lse.reshape([b * s, hp]),  # KV-only: the sink is NOT folded in
-        sink,
+        lse.reshape([b * s, hp]),  # KV-only: the sink is NOT folded in ...
+        paddle.full([hp], _NEG_SINK, dtype="float32"),  # ... nor passed on
         _local_to_global_flat(ti, skv),
         softmax_scale=float(SM),
         topk_length=tl,
@@ -524,10 +532,14 @@ class TestSinkSpecifics(_Base):
         self.assertEqual(agree, 1.0)
 
     def test_finite_sink_lse_fix_matters(self):
-        """dk(576) != d_v(512): the finite-sink LSE fold is load-bearing.
+        """dk(576) != d_v(512): the finite-sink LSE handling is load-bearing.
 
-        The layer always folds the sink into the LSE it passes the backward;
-        driving the same kernels with the raw KV-only LSE must be far worse.
+        The layer folds the sink into the LSE it passes the backward (and
+        neutralises the sink argument so a folding kernel cannot count it
+        twice). Driving the same kernels with a backward that never sees the
+        sink at all must be far worse -- see
+        :func:`_kernel_dq_with_sinkless_bwd` for why that, and not the plain
+        KV-only LSE, is the version-independent control.
         """
         H, s = 8, 64
         q = _rand([1, s, H, DK], 0.3, 91)
@@ -536,7 +548,7 @@ class TestSinkSpecifics(_Base):
         dO = _rand([1, s, H * DV], 1.0, 94)
         rq, _, _ = _analytic_ref_grads(q, kv, ti, dO, 3.0)
         folded, _, _ = _kernel_grads(q, kv, ti, dO, 3.0)
-        raw = _kernel_dq_with_kv_only_lse(q, kv, ti, dO, 3.0)
+        raw = _kernel_dq_with_sinkless_bwd(q, kv, ti, dO, 3.0)
         e_folded, e_raw = _relerr(folded, rq), _relerr(raw, rq)
         self.assertLess(e_folded, 1e-2)
         self.assertGreater(e_raw, 0.5)

--- a/tests/single_card_tests/transformer/test_hybrid_mla_warmup_doc_mask_loss.py
+++ b/tests/single_card_tests/transformer/test_hybrid_mla_warmup_doc_mask_loss.py
@@ -223,11 +223,12 @@ def _capture_loss_args():
     reference. A sum over the last axis -- which is all the KL does -- is
     permutation invariant and may be taken on the column layout directly.
 
-    ``cap`` stays empty if the module was not in the warmup phase -- which is
-    itself the assertion that phase 3 does not reach this code. Phase 3
-    attaches through the *same* PyLayer now, so the discriminator is the
-    ``indexer_backend`` tag: ``"tilelang"`` is phase 2's full-candidate kernel,
-    ``"cudnn"`` is phase 3's top-k one, and only the former is recorded.
+    ``cap`` only records calls tagged ``indexer_backend="tilelang"`` -- phase
+    2's full-candidate kernel. Phase 3 attaches through the *same* PyLayer and
+    carries the same tag whenever ``csa_indexer_backend`` is left at its
+    ``"tilelang"`` default (as these fixtures do), so an empty ``cap`` is not a
+    reliable "phase 3 did not get here" signal; tests that need that control
+    assert on the recorded columns instead.
     """
     real = mqa_mod.TileLangCSAIndexerLossAutoScaler
     actual = [
@@ -847,7 +848,16 @@ class TestWarmupIndexerLossPrecision(unittest.TestCase):
         sparse = _warmup_module(sparse_loss=True)
         logged_sparse, cap_sparse, _ = self._step(sparse, seqlen, [seqlen])
         self.assertEqual(logged_sparse, 0.0)
-        self.assertEqual(cap_sparse, {}, "phase 3 reached the warmup KL")
+        # Phase 3 attaches through the same PyLayer, and this fixture leaves
+        # ``csa_indexer_backend`` at its ``"tilelang"`` default, so the spy
+        # records it too. What makes it the control is the *content*: the
+        # clamped range leaves every column at the -1 sentinel, so nothing is
+        # live and the KL it differentiates is identically zero.
+        self.assertTrue(bool((cap_sparse["columns"] == -1).all()))
+        self.assertFalse(
+            bool(cap_sparse["live"].any()), "phase 3 reached the warmup KL"
+        )
+        self.assertEqual(float(np.abs(cap_sparse["target"]).max()), 0.0)
 
         module = _warmup_module()
         logged, cap, _ = self._step(module, seqlen, [seqlen])


### PR DESCRIPTION
### PR Category

Operator Mechanism

### PR Types

Bug fixes

### Description

Two negative controls in the MQA + DSA single-card tests assert a property the
vendored kernels do not have, so both fail on SM100 (measured on B30Z / sm_103).
Neither is a product defect -- the controls are stale.

**1. `test_block_sparse_dsa_gradcheck.py::test_finite_sink_lse_fix_matters`**

It drove the cuDNN DSA backward with the KV-only LSE **plus the real sink** and
required the result to be far worse (`> 0.5`) than the layer's sink-inclusive
LSE. That pairing is in fact already correct, because the vendored backward
folds `attn_sink` into the LSE itself (`_interface_sm100.py`: *"lse: ... FlashMLA
KV-only LSE excluding sink"*). dq relative error against an fp32 autograd
reference (`b1/s64/h8/DK576/DV512`, `sink=3.0`):

| LSE / sink handed to the backward | dq rel-err |
| --- | --- |
| KV-only LSE + real sink (the old "uncorrected" control) | **0.0037** |
| sink-inclusive LSE + `-1e30` sink (what `mqa_sparse_attn` does) | **0.0037** |
| sink-inclusive LSE + real sink (sink counted twice) | 0.300 |
| KV-only LSE + `-1e30` sink (sink absent from the backward) | 1.956 |

The invariant is that the sink reaches the backward **exactly once**, not that
the layer must fold it. The control now removes the sink from the backward
altogether, which measures what the correction is worth under either kernel
convention.

The only non-test change is the comment in `mqa_sparse_attn.py` that justified
the fold with the "the kernel consumes the passed LSE verbatim / does NOT fold
the sink" claim, plus the `~75x` / `cos 0.976` figures that no longer reproduce.
Behaviour is untouched: folding *and* neutralising still counts the sink once.

**2. `test_hybrid_mla_warmup_doc_mask_loss.py::test_window_length_sequence_still_trains_the_indexer_in_warmup`**

It used the `indexer_backend` tag to assert the phase-3 control never reaches the
warmup KL spy (`cap_sparse == {}`). The fixture leaves `csa_indexer_backend` at
its `"tilelang"` default, so phase 3 carries the same tag and is recorded too --
the discriminator cannot work as written. The property under test does hold, so
assert on the recorded content instead: at `s == csa_window_size` the clamped
candidate range leaves every column at the `-1` sentinel, nothing is live and the
KL is identically zero, against phase 2's live columns and `9.10e-05`.

### Verification

Both files, twice -- once against this branch's `src/` and once against the
installed package -- `38 passed, 78 subtests passed`.
