### PR TITLE
Add HyperEncoder model (prefix-LM encoder) with unit tests

### DIFF
--- a/src/paddlefleet/models/hyperencoder/__init__.py
+++ b/src/paddlefleet/models/hyperencoder/__init__.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HyperEncoder components that live in PaddleFleet: spec builders and the
+model-specific layers.
+
+Config assembly and the top-level model live in PaddleFormers under
+``transformers/hyperencoder/`` (following the same split as
+``transformers/qwen3_vl``; see the module docstrings there for details).
+"""
+
+from .layer_specs import (
+    get_hyperencoder_block_spec,
+    get_hyperencoder_layer_specs,
+)
+from .modality_encoders import (
+    AudioEncoderConv,
+    ImageEncoderConv,
+    MlpProjector,
+    PatchEmbed,
+    get_abs_pos_1d,
+    get_abs_pos_2d,
+)
+
+__all__ = [
+    "get_hyperencoder_block_spec",
+    "get_hyperencoder_layer_specs",
+    "AudioEncoderConv",
+    "ImageEncoderConv",
+    "MlpProjector",
+    "PatchEmbed",
+    "get_abs_pos_1d",
+    "get_abs_pos_2d",
+]

--- a/src/paddlefleet/models/hyperencoder/attn_backend.py
+++ b/src/paddlefleet/models/hyperencoder/attn_backend.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Attention backend switches for HyperEncoder.
+
+## Environment variables
+
+| env | values | effect |
+|---|---|---|
+| ``HYPERBODY_ENCODER_ATTN_BACKEND`` | ``dp`` (default) / ``flex`` / ``triton`` | selects the ``core_attention`` implementation |
+| ``HYPERBODY_PACKED_FLEX_DECODER`` | ``0`` (default) / ``1`` | run the trunk with a single packed call |
+
+**The ``flex`` backend is not implemented here**: it is a compiled artifact of
+``torch.nn.attention.flex_attention`` and has no Paddle equivalent. The ``flex``
+and ``triton`` backends are equivalent under the packed layout, so this module
+supports ``dp`` and ``triton`` only and **raises on ``flex``** instead of
+silently falling back to ``dp`` (a silent downgrade would produce misleading
+results).
+
+## Functions instead of module-level constants
+
+The backend selection is read on every call rather than fixed at import time.
+Some scripts run several configurations back-to-back in one process; fixing the
+switch at import time would make a later configuration silently inherit the
+first one's backend.
+"""
+
+from __future__ import annotations
+
+import os
+
+__all__ = [
+    "encoder_attn_backend",
+    "use_triton_encoder_attn",
+    "use_packed_decoder",
+]
+
+_TRUE = ("1", "true", "on")
+_FALSE = ("0", "false", "off")
+
+
+def encoder_attn_backend() -> str:
+    """Return ``dp`` or ``triton``. ``flex`` raises (see module docstring)."""
+    v = os.environ.get("HYPERBODY_ENCODER_ATTN_BACKEND", "dp").lower()
+    if v == "flex":
+        raise ValueError(
+            "HYPERBODY_ENCODER_ATTN_BACKEND=flex is not implemented here: "
+            "flex is a compiled artifact of torch.nn.attention.flex_attention "
+            "and has no Paddle equivalent. Use triton for packed semantics "
+            "(it is equivalent to flex)."
+        )
+    if v not in ("dp", "triton"):
+        raise ValueError(
+            f"Unknown HYPERBODY_ENCODER_ATTN_BACKEND={v!r}; expected 'dp' or 'triton'"
+        )
+    return v
+
+
+def use_triton_encoder_attn() -> bool:
+    """Whether to replace ``core_attention`` with ``PrefixLMTritonCore``."""
+    return encoder_attn_backend() == "triton"
+
+
+def use_packed_decoder() -> bool:
+    """Whether the trunk runs as a single packed call."""
+    v = os.environ.get("HYPERBODY_PACKED_FLEX_DECODER", "0").lower()
+    if v not in _TRUE + _FALSE:
+        raise ValueError(
+            f"Unknown HYPERBODY_PACKED_FLEX_DECODER={v!r}; expected 0/1/false/true/off/on"
+        )
+    on = v in _TRUE
+    # The packed path attaches the segment layout to packed_seq_params, which
+    # only the triton backend reads. Enabling packed while staying on the dp
+    # backend would silently ignore the layout and degrade the mask, so this is
+    # a hard error.
+    if on and not use_triton_encoder_attn():
+        raise RuntimeError(
+            "HYPERBODY_PACKED_FLEX_DECODER=1 requires HYPERBODY_ENCODER_ATTN_BACKEND=triton: "
+            "the packed segment layout is only read by the triton core and would "
+            "be silently ignored on the dp backend."
+        )
+    return on

--- a/src/paddlefleet/models/hyperencoder/attn_backend.py
+++ b/src/paddlefleet/models/hyperencoder/attn_backend.py
@@ -12,14 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Attention backend switches for HyperEncoder.
+"""Attention backend selection for HyperEncoder.
 
-## Environment variables
+The backend and packed-decoder path are driven by config fields rather than
+environment variables, so they are declared with defaults, validated centrally
+(in ``HyperEncoderProvider.__post_init__``, which calls these functions), and
+serialized with the rest of the config:
 
-| env | values | effect |
+| field | values | effect |
 |---|---|---|
-| ``HYPERBODY_ENCODER_ATTN_BACKEND`` | ``dp`` (default) / ``flex`` / ``triton`` | selects the ``core_attention`` implementation |
-| ``HYPERBODY_PACKED_FLEX_DECODER`` | ``0`` (default) / ``1`` | run the trunk with a single packed call |
+| ``hyperencoder_attn_backend`` | ``dp`` (default) / ``triton`` | selects the ``core_attention`` implementation |
+| ``hyperencoder_packed_decoder`` | ``False`` (default) / ``True`` | run the trunk with a single packed call |
 
 **The ``flex`` backend is not implemented here**: it is a compiled artifact of
 ``torch.nn.attention.flex_attention`` and has no Paddle equivalent. The ``flex``
@@ -28,17 +31,12 @@ supports ``dp`` and ``triton`` only and **raises on ``flex``** instead of
 silently falling back to ``dp`` (a silent downgrade would produce misleading
 results).
 
-## Functions instead of module-level constants
-
-The backend selection is read on every call rather than fixed at import time.
-Some scripts run several configurations back-to-back in one process; fixing the
-switch at import time would make a later configuration silently inherit the
-first one's backend.
+The readers use ``getattr`` with defaults so any ``TransformerConfig`` works;
+the fields are authoritatively declared and validated on the HyperEncoder
+config.
 """
 
 from __future__ import annotations
-
-import os
 
 __all__ = [
     "encoder_attn_backend",
@@ -46,48 +44,41 @@ __all__ = [
     "use_packed_decoder",
 ]
 
-_TRUE = ("1", "true", "on")
-_FALSE = ("0", "false", "off")
 
-
-def encoder_attn_backend() -> str:
+def encoder_attn_backend(config) -> str:
     """Return ``dp`` or ``triton``. ``flex`` raises (see module docstring)."""
-    v = os.environ.get("HYPERBODY_ENCODER_ATTN_BACKEND", "dp").lower()
+    v = str(getattr(config, "hyperencoder_attn_backend", "dp")).lower()
     if v == "flex":
         raise ValueError(
-            "HYPERBODY_ENCODER_ATTN_BACKEND=flex is not implemented here: "
+            "hyperencoder_attn_backend='flex' is not implemented here: "
             "flex is a compiled artifact of torch.nn.attention.flex_attention "
             "and has no Paddle equivalent. Use triton for packed semantics "
             "(it is equivalent to flex)."
         )
     if v not in ("dp", "triton"):
         raise ValueError(
-            f"Unknown HYPERBODY_ENCODER_ATTN_BACKEND={v!r}; expected 'dp' or 'triton'"
+            f"Unknown hyperencoder_attn_backend={v!r}; expected 'dp' or 'triton'"
         )
     return v
 
 
-def use_triton_encoder_attn() -> bool:
+def use_triton_encoder_attn(config) -> bool:
     """Whether to replace ``core_attention`` with ``PrefixLMTritonCore``."""
-    return encoder_attn_backend() == "triton"
+    return encoder_attn_backend(config) == "triton"
 
 
-def use_packed_decoder() -> bool:
+def use_packed_decoder(config) -> bool:
     """Whether the trunk runs as a single packed call."""
-    v = os.environ.get("HYPERBODY_PACKED_FLEX_DECODER", "0").lower()
-    if v not in _TRUE + _FALSE:
-        raise ValueError(
-            f"Unknown HYPERBODY_PACKED_FLEX_DECODER={v!r}; expected 0/1/false/true/off/on"
-        )
-    on = v in _TRUE
+    on = bool(getattr(config, "hyperencoder_packed_decoder", False))
     # The packed path attaches the segment layout to packed_seq_params, which
     # only the triton backend reads. Enabling packed while staying on the dp
     # backend would silently ignore the layout and degrade the mask, so this is
     # a hard error.
-    if on and not use_triton_encoder_attn():
+    if on and not use_triton_encoder_attn(config):
         raise RuntimeError(
-            "HYPERBODY_PACKED_FLEX_DECODER=1 requires HYPERBODY_ENCODER_ATTN_BACKEND=triton: "
-            "the packed segment layout is only read by the triton core and would "
-            "be silently ignored on the dp backend."
+            "hyperencoder_packed_decoder=True requires "
+            "hyperencoder_attn_backend='triton': the packed segment layout is "
+            "only read by the triton core and would be silently ignored on the "
+            "dp backend."
         )
     return on

--- a/src/paddlefleet/models/hyperencoder/layer_specs.py
+++ b/src/paddlefleet/models/hyperencoder/layer_specs.py
@@ -91,7 +91,7 @@ def _is_moe_layer(config: TransformerConfig, layer_idx: int) -> bool:
 
 def get_hyperencoder_layer_specs(config: TransformerConfig) -> list[LayerSpec]:
     """Build the list of per-layer ``LayerSpec`` objects."""
-    triton_attn = use_triton_encoder_attn()
+    triton_attn = use_triton_encoder_attn(config)
     if (
         not triton_attn
         and getattr(config, "_attn_implementation", None) != "eager"

--- a/src/paddlefleet/models/hyperencoder/layer_specs.py
+++ b/src/paddlefleet/models/hyperencoder/layer_specs.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Layer specs for the HyperEncoder trunk.
+
+## What this builds
+
+The block is a standard GPT decoder block with four HyperEncoder-specific
+adjustments:
+
+1. Start from a standard per-layer decoder spec
+   (``get_gpt_layer_local_spec`` with ``normalization="RMSNorm"``).
+2. Replace each layer's ``input_layernorm`` and ``post_attention_layernorm``
+   with :class:`~paddlefleet.models.hyperencoder.norm.HyperEncoderRMSNorm`, an
+   RMSNorm that always computes in fp32.
+3. Set the attention mask type per layer (see "attn_mask_type" below).
+4. Replace the block's final layer norm with ``HyperEncoderRMSNorm`` as well
+   (done in :func:`get_hyperencoder_block_spec`).
+
+Note: PaddleFleet has no block-spec object, so the per-layer builder is called
+in a loop and returns a plain list. Also note the layer-norm naming: the
+pre-MLP norm is called ``post_attention_layernorm`` here.
+
+## How ``attn_mask_type`` is handled
+
+We pass **``AttnMaskType.no_mask``**, because:
+
+* We feed a complete dense mask ourselves
+  (``prefix_lm_mask.build_dense_mask``); the framework must not add another
+  causal layer on top.
+* Passing ``causal`` would make ``FusedScaleMaskSoftmax`` apply an extra causal
+  triangle, which conflicts with the prefix-LM semantics.
+* ``no_mask`` states the intent explicitly.
+
+The other switch that must be set explicitly is ``_attn_implementation="eager"``.
+Otherwise, under bf16, ``DotProductAttention`` takes the SDPA branch and forces
+``is_causal=True``, which would silently break the bidirectional encoder
+semantics. That switch lives at the config level rather than in the spec; see
+the assertion in :func:`get_hyperencoder_layer_specs`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from paddlefleet.models.hyperencoder.attn_backend import use_triton_encoder_attn
+from paddlefleet.models.hyperencoder.norm import HyperEncoderRMSNorm
+from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.prefix_lm_triton_core import PrefixLMTritonCore
+from paddlefleet.transformer.transformer_block import (
+    TransformerBlockSublayersSpec,
+)
+
+if TYPE_CHECKING:
+    from paddle.distributed.fleet.meta_parallel import LayerSpec
+
+    from paddlefleet.transformer.transformer_config import TransformerConfig
+
+__all__ = ["get_hyperencoder_layer_specs", "get_hyperencoder_block_spec"]
+
+
+def _is_moe_layer(config: TransformerConfig, layer_idx: int) -> bool:
+    """Whether layer ``layer_idx`` is a MoE layer.
+
+    ``moe_layer_freq`` is a per-layer list of 0/1 flags, so the check is simply
+    the ``layer_idx``-th entry; there is no ``i % N`` modulo semantics involved.
+    A plain int is rejected because the modulo interpretation would misplace the
+    MoE layers.
+    """
+    freq = config.moe_layer_freq
+    if isinstance(freq, (list, tuple)):
+        return bool(freq[layer_idx])
+    raise TypeError(
+        f"HyperEncoder requires moe_layer_freq to be a per-layer list, got "
+        f"{type(freq).__name__}. Passing an int would trigger `i % N` or "
+        "`(i+1) % N` semantics and misplace the MoE layers."
+    )
+
+
+def get_hyperencoder_layer_specs(config: TransformerConfig) -> list[LayerSpec]:
+    """Build the list of per-layer ``LayerSpec`` objects."""
+    triton_attn = use_triton_encoder_attn()
+    if (
+        not triton_attn
+        and getattr(config, "_attn_implementation", None) != "eager"
+    ):
+        raise ValueError(
+            "HyperEncoder requires config._attn_implementation='eager' to be set "
+            "explicitly. Otherwise, under bf16, DotProductAttention takes the SDPA "
+            "branch and forces is_causal=True, which silently breaks the "
+            "bidirectional encoder semantics."
+        )
+
+    specs: list[LayerSpec] = []
+    for i in range(config.num_hidden_layers):
+        spec = get_gpt_layer_local_spec(
+            config=config,
+            layer_number=i,
+            # dense vs. MoE is decided per layer by moe_layer_freq
+            num_experts=config.n_routed_experts
+            if _is_moe_layer(config, i)
+            else None,
+            moe_expert_fusion=config.moe_expert_fusion,
+            normalization="RMSNorm",
+            # See "How attn_mask_type is handled" in the module docstring.
+            attn_mask_type=AttnMaskType.no_mask,
+        )
+        # Replace both norms with the fp32 RMSNorm. Note the pre-MLP norm is
+        # named post_attention_layernorm in PaddleFleet.
+        spec.sublayers_spec.input_layernorm = HyperEncoderRMSNorm
+        spec.sublayers_spec.post_attention_layernorm = HyperEncoderRMSNorm
+        if triton_attn:
+            # Swap only core_attention; the outer SelfAttention still handles
+            # QKV projection / RoPE / output projection. Fail loudly if the
+            # swap point is missing rather than silently staying on dp.
+            attn = getattr(spec.sublayers_spec, "self_attn", None)
+            sub = getattr(attn, "sublayers_spec", None)
+            if sub is None or not hasattr(sub, "core_attention"):
+                raise RuntimeError(
+                    "Cannot install PrefixLMTritonCore: the layer spec has no "
+                    "self_attn.sublayers_spec.core_attention"
+                )
+            sub.core_attention = PrefixLMTritonCore
+        specs.append(spec)
+    return specs
+
+
+def get_hyperencoder_block_spec(
+    config: TransformerConfig,
+) -> TransformerBlockSublayersSpec:
+    """Build the spec for the full block (all layers plus the final norm)."""
+    return TransformerBlockSublayersSpec(
+        layer_specs=get_hyperencoder_layer_specs(config),
+        layer_norm=HyperEncoderRMSNorm,
+    )

--- a/src/paddlefleet/models/hyperencoder/modality_encoders.py
+++ b/src/paddlefleet/models/hyperencoder/modality_encoders.py
@@ -1,0 +1,239 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Image / audio modality towers for HyperEncoder.
+
+This module defines the small vision and audio front-ends that turn raw
+patches / mel-spectrogram frames into a shared embedding space, plus the
+projector that maps those embeddings into the language model width.
+
+Design notes:
+
+* ``MlpProjector`` exposes its submodule as the attribute ``layers`` because
+  the checkpoint weight keys are ``projector.layers.weight``. This name is kept
+  consistent across all projector types (including the ``nn.Sequential`` case).
+* ``ImageEncoderConv`` accepts an ``out_chans`` argument that it does not use.
+  It is retained only to keep the constructor signature stable.
+* ``AudioEncoderConv`` returns a 4-D channel-last tensor ``[B, 1, T', 768]``
+  (``h'=1, w'=T'``) so it is structurally identical to the image tower output
+  ``[B, h', w', 768]``. Downstream code relies on this shape equivalence to
+  reuse a single ``permute(0,3,1,2).flatten(2).transpose(1,2)`` path for both
+  modalities.
+
+Numerical details:
+
+* ``F.interpolate(align_corners=False)`` is used for position-embedding
+  resampling. Both interpolation helpers short-circuit when the source and
+  target sizes already match, returning the input unchanged.
+* ``F.gelu`` is called with ``approximate=False`` explicitly so it uses the
+  exact erf formulation rather than the tanh approximation.
+"""
+
+from __future__ import annotations
+
+import paddle
+import paddle.nn.functional as F
+from paddle import nn
+
+__all__ = [
+    "MlpProjector",
+    "PatchEmbed",
+    "ImageEncoderConv",
+    "AudioEncoderConv",
+    "get_abs_pos_2d",
+    "get_abs_pos_1d",
+]
+
+
+class MlpProjector(nn.Layer):
+    """Modality-level projector: 768 -> 1280. Shared by the image and audio towers.
+
+    Only ``projector_type="linear"`` is used in practice; the ``identity`` and
+    ``mlp_gelu`` variants are kept for completeness. All variants store their
+    submodule under ``self.layers`` so the checkpoint weight keys stay stable.
+    """
+
+    def __init__(self, cfg: dict) -> None:
+        super().__init__()
+        self.cfg = cfg
+        projector_type = cfg["projector_type"]
+        input_dim = cfg["input_dim"]
+        n_embed = cfg["n_embed"]
+        depth = cfg.get("depth", 1)
+
+        if projector_type == "identity":
+            modules: nn.Layer = nn.Identity()
+        elif projector_type == "linear":
+            modules = nn.Linear(input_dim, n_embed)
+        elif projector_type == "mlp_gelu":
+            layers = [nn.Linear(input_dim, n_embed)]
+            for _ in range(1, depth):
+                layers.append(nn.GELU())
+                layers.append(nn.Linear(n_embed, n_embed))
+            modules = nn.Sequential(*layers)
+        else:
+            raise ValueError(f"Unknown projector type: {projector_type}")
+
+        # Attribute name must be ``layers``; weight key is ``projector.layers.weight``.
+        self.layers = modules
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        """Apply ``self.layers(x)``."""
+        return self.layers(x)
+
+
+class PatchEmbed(nn.Layer):
+    """Image -> patch embedding via a single Conv2d."""
+
+    def __init__(
+        self,
+        kernel_size: tuple[int, int] = (14, 14),
+        stride: tuple[int, int] = (14, 14),
+        padding: tuple[int, int] = (0, 0),
+        in_chans: int = 3,
+        embed_dim: int = 768,
+    ) -> None:
+        super().__init__()
+        self.proj = nn.Conv2D(
+            in_chans,
+            embed_dim,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+        )
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        x = self.proj(x)
+        # B C H W -> B H W C
+        return x.transpose([0, 2, 3, 1])
+
+
+def get_abs_pos_2d(
+    abs_pos: paddle.Tensor, tgt_size: tuple[int, int]
+) -> paddle.Tensor:
+    """Resample a 2-D positional embedding to the actual patch grid.
+
+    When the source grid size already equals ``tgt_size`` the input is returned
+    unchanged (short-circuit). Otherwise the embedding is transposed to
+    channel-first, cast to fp32, resized with bilinear interpolation
+    (``align_corners=False``), cast back and transposed to channel-last.
+    """
+    src_size = (int(abs_pos.shape[1]), int(abs_pos.shape[2]))
+    if src_size != tuple(int(v) for v in tgt_size):
+        old = abs_pos.transpose([0, 3, 1, 2]).astype("float32")
+        new = F.interpolate(
+            old,
+            size=[int(tgt_size[0]), int(tgt_size[1])],
+            mode="bilinear",
+            align_corners=False,
+        ).astype(abs_pos.dtype)
+        return new.transpose([0, 2, 3, 1])
+    return abs_pos
+
+
+def get_abs_pos_1d(abs_pos: paddle.Tensor, tgt_size: int) -> paddle.Tensor:
+    """Resample a 1-D positional embedding. Short-circuits when sizes match."""
+    src_size = int(abs_pos.shape[1])
+    if src_size != int(tgt_size):
+        old = abs_pos.transpose([0, 2, 1]).astype("float32")
+        new = F.interpolate(
+            old, size=[int(tgt_size)], mode="linear", align_corners=False
+        )
+        return new.astype(abs_pos.dtype).transpose([0, 2, 1])
+    return abs_pos
+
+
+class ImageEncoderConv(nn.Layer):
+    """Patch embedding plus a learnable 2-D positional embedding.
+
+    Default constructor arguments:
+    ``img_size=728, patch_size=14, in_chans=3, embed_dim=768, out_chans=256``.
+
+    ``out_chans`` is accepted but never used; it is kept to preserve a stable
+    constructor signature.
+    """
+
+    def __init__(
+        self,
+        img_size: int = 728,
+        patch_size: int = 14,
+        in_chans: int = 3,
+        embed_dim: int = 768,
+        out_chans: int = 256,
+    ) -> None:
+        super().__init__()
+        self.img_size = img_size
+        self.patch_embed = PatchEmbed(
+            kernel_size=(patch_size, patch_size),
+            stride=(patch_size, patch_size),
+            in_chans=in_chans,
+            embed_dim=embed_dim,
+        )
+        grid = img_size // patch_size  # 728 // 14 = 52
+        # Learnable parameter (not a buffer), initialized to all zeros.
+        self.pos_embed = self.create_parameter(
+            shape=[1, grid, grid, embed_dim],
+            default_initializer=nn.initializer.Constant(0.0),
+        )
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        """``[B, 3, H, W]`` -> ``[B, H//14, W//14, 768]``."""
+        x = self.patch_embed(x)
+        if self.pos_embed is not None:
+            x = x + get_abs_pos_2d(self.pos_embed, (x.shape[1], x.shape[2]))
+        return x
+
+
+class AudioEncoderConv(nn.Layer):
+    """Mel-spectrogram convolutions plus a learnable 1-D positional embedding.
+
+    Default constructor arguments: ``num_mel_bins=128, embed_dim=768``.
+
+    ``conv2`` uses ``stride=2``, which is why the output length is
+    ``T' = (T+1)//2``. ``max_position_embeddings=1500`` sets the positional
+    embedding length.
+    """
+
+    def __init__(
+        self,
+        num_mel_bins: int = 128,
+        embed_dim: int = 768,
+        max_position_embeddings: int = 1500,
+    ) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv1D(
+            num_mel_bins, embed_dim, kernel_size=3, padding=1
+        )
+        self.conv2 = nn.Conv1D(
+            embed_dim, embed_dim, kernel_size=3, stride=2, padding=1
+        )
+        self.pos_embed = self.create_parameter(
+            shape=[1, max_position_embeddings, embed_dim],
+            default_initializer=nn.initializer.Constant(0.0),
+        )
+
+    def forward(self, input_features: paddle.Tensor) -> paddle.Tensor:
+        """``[B, 128, T]`` -> ``[B, 1, T', 768]``, with ``T' = (T+1)//2``.
+
+        The output is deliberately 4-D channel-last (``h'=1, w'=T'``) so it
+        matches the image tower's output shape.
+
+        Note: the conv layers must accumulate in fp32 for numerical stability.
+        """
+        # approximate=False forces the exact erf GELU rather than the tanh form.
+        x = F.gelu(self.conv1(input_features), approximate=False)
+        x = F.gelu(self.conv2(x), approximate=False)
+        x = x.transpose([0, 2, 1])  # [B, T', embed_dim]
+        x = x + get_abs_pos_1d(self.pos_embed, x.shape[1])
+        return x.unsqueeze(1)  # [B, 1, T', embed_dim]

--- a/src/paddlefleet/models/hyperencoder/norm.py
+++ b/src/paddlefleet/models/hyperencoder/norm.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RMSNorm variant used by HyperEncoder.
+
+This module keeps the HyperEncoder-specific RMSNorm in its own file because it
+is only used by HyperEncoder (``models/hyperencoder/layer_specs.py``). Keeping
+it separate avoids adding a single-model class to the shared norm module.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import paddle
+from paddle import Tensor
+
+# Optional import: older Paddle versions may not ship this utility.
+try:
+    from paddle.distributed.fleet.utils.sequence_parallel_utils import (
+        mark_as_sequence_parallel_parameter,
+    )
+except ImportError:  # older Paddle without this helper
+
+    def mark_as_sequence_parallel_parameter(parameter):
+        return parameter
+
+
+if TYPE_CHECKING:
+    from paddlefleet.transformer.transformer_config import TransformerConfig
+
+__all__ = ["HyperEncoderRMSNorm"]
+
+
+class HyperEncoderRMSNorm(paddle.nn.Layer):
+    """RMSNorm that always accumulates in fp32.
+
+    Reference computation:
+
+    .. code-block:: python
+
+        x_float = x.float()
+        x_norm  = x_float * paddle.rsqrt(x_float.pow(2).mean(-1, keepdim=True) + eps)
+        return (x_norm * self.weight).astype(x.dtype)
+
+    This class is used instead of a generic RMSNorm for three reasons:
+
+    1. A generic RMSNorm typically exposes its high-precision behavior as a
+       forward argument rather than a constructor option; since layers are
+       instantiated by the spec system, the call site cannot pass that flag.
+    2. A generic RMSNorm may route through a fused ``rms_norm`` kernel whose
+       ``mean(x**2)`` reduction order is not controllable. This class uses
+       ``paddle.mean`` directly instead.
+    3. A generic RMSNorm may derive its return dtype from the weight dtype,
+       whereas this class derives it from the input dtype ``x``. These agree
+       under bf16 training, but a fp32 weight would otherwise silently upcast
+       the output.
+
+    Two intentional (mathematically equivalent) differences from a plain
+    reference formulation:
+
+    * ``x_float.pow(2)`` is written as ``x_float * x_float``.
+    * The weight multiply casts the weight to fp32 explicitly. bf16 -> fp32 is
+      an exact conversion, so this only avoids relying on implicit type
+      promotion.
+
+    Sequence-parallel marking: the weight is tagged via
+    :func:`mark_as_sequence_parallel_parameter`, triggered by
+    ``input_is_parallel``.
+    """
+
+    def __init__(
+        self,
+        config: TransformerConfig,
+        normalized_shape=None,
+        norm_eps=None,
+        input_is_parallel=False,
+        **kwargs,
+    ):
+        super().__init__()
+        self.normalized_shape = (
+            config.hidden_size if normalized_shape is None else normalized_shape
+        )
+        self.variance_epsilon = (
+            config.rms_norm_eps if norm_eps is None else norm_eps
+        )
+        # Explicitly reject unsupported configurations instead of ignoring them.
+        if getattr(config, "normalization", "RMSNorm") != "RMSNorm":
+            raise ValueError(
+                f"HyperEncoderRMSNorm only supports RMSNorm, got {config.normalization!r}"
+            )
+        if getattr(config, "layernorm_zero_centered_gamma", False):
+            raise ValueError(
+                "HyperEncoderRMSNorm does not support zero-centered gamma"
+            )
+        if getattr(config, "persist_layer_norm", False):
+            raise ValueError(
+                "HyperEncoderRMSNorm does not support persistent layer norm"
+            )
+
+        self.weight = paddle.create_parameter(
+            shape=[self.normalized_shape],
+            dtype=config.params_dtype
+            if config.params_dtype is not None
+            else paddle.get_default_dtype(),
+            default_initializer=paddle.nn.initializer.Constant(1.0),
+        )
+        self.config = config
+
+        if input_is_parallel:
+            self.enable_sequence_parallel()
+
+    def forward(self, hidden_states: Tensor, **kwargs):
+        """Apply the RMSNorm.
+
+        ``**kwargs`` absorbs any extra flags a generic RMSNorm might accept;
+        this class always computes in fp32, so they have no effect. The
+        reduction goes through ``paddle.mean`` directly (not a fused kernel),
+        and the return dtype follows the input dtype.
+        """
+        t1 = hidden_states.astype(paddle.float32)
+        t4 = paddle.mean(t1 * t1, axis=-1, keepdim=True) + self.variance_epsilon
+        t5 = paddle.rsqrt(t4)
+        out = (t1 * t5) * self.weight.astype(paddle.float32)
+        return out.astype(hidden_states.dtype)
+
+    def enable_sequence_parallel(self):
+        """Tag the weight for sequence-parallel replication.
+
+        This mirrors the sequence-parallel marking used by the other norm
+        layers. It must be called explicitly for this class; it is only
+        exercised when tensor parallelism is enabled.
+        """
+        mark_as_sequence_parallel_parameter(self.weight)

--- a/src/paddlefleet/transformer/prefix_lm_mask.py
+++ b/src/paddlefleet/transformer/prefix_lm_mask.py
@@ -1,0 +1,335 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Three equivalent representations of the prefix-LM three-region mask, plus
+their dense expanders (used for cross-checking in unit tests).
+
+## Geometry
+
+A sequence is a concatenation of N mutually invisible segments, optionally
+followed by a padding tail:
+
+    │◄──── seg 0 ────►│◄──── seg 1 ────►│ … │◄── pad ──►│
+    │ prefix │ suffix │ prefix │ suffix │   │           │
+
+Segment ``i`` starts at ``s_i``, has a prefix (context) of length ``C_i``, a
+suffix (query) of length ``Q_i``, and total length ``L_i = C_i + Q_i``.
+``T = ΣL_i``; padding occupies ``[T, T+n_p)``; ``T' = T + n_p``.
+
+Allowed relations (three regions plus the pad self-loop; ``True`` = **forbidden**):
+
+| region of key column j | allowed query rows | meaning |
+|---|---|---|
+| prefix of seg i ``[s_i, s_i+C_i)`` | ``[s_i, s_i+L_i)`` | bidirectional within prefix; suffix sees the whole prefix |
+| suffix of seg i ``[s_i+C_i, s_i+L_i)`` | ``[j, s_i+L_i)`` | causal within suffix; prefix cannot see suffix |
+| pad ``[T, T')`` | ``{j}`` | self only, otherwise the whole pad row is masked and softmax(-inf) yields NaN |
+
+Two implicit semantics have no explicit statement and are realized by keeping
+the default "forbidden":
+  * prefix rows cannot see suffix columns (a suffix column's lowest allowed row
+    is ``j >= s_i+C_i``);
+  * real tokens cannot see pad columns (a pad column only opens the diagonal).
+
+## The three representations
+
+| function | output | consumer |
+|---|---|---|
+| :func:`build_dense_mask`             | ``[1,1,T',T']`` bool | eager path (explicit score + mask_func) |
+| :func:`build_flashmask_row_indices`  | ``[1,1,T',4]`` int32 | ``flashmask_attention`` column-sparse path |
+| :func:`build_prefix_lm_layout`       | dict (4 fields)      | Triton kernel (geometry passed directly) |
+
+:func:`expand_row_indices_to_dense` and :func:`expand_layout_to_dense` are for
+unit tests only. They make it possible to *assert* that all three paths share
+the same mask source of truth, rather than assume it.
+
+## FlashMask 4-column encoding
+
+Each key column ``j`` is given ``[LTS, LTE, UTS, UTE]``:
+
+  * lower-triangle side (rows **>** j): row range ``[LTS, LTE)`` is **masked**
+  * upper-triangle side (rows **<** j): row range ``[UTS, UTE)`` is **masked**
+
+The diagonal (row == j) is **never masked by this encoding**, so the pad
+self-loop is free. Substituting the table above (with ``UTS ≡ 0`` and
+``LTE ≡ T'`` constant, only two values vary):
+
+    UTE(j) = s_i        if j ∈ prefix_i        else j
+    LTS(j) = s_i + L_i  if j ∈ seg i           else j + 1   (j ∈ pad)
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import paddle
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = [
+    "prefix_lm_segment_starts",
+    "prefix_lm_pad_len",
+    "build_dense_mask",
+    "build_flashmask_row_indices",
+    "build_prefix_lm_layout",
+    "expand_row_indices_to_dense",
+    "expand_layout_to_dense",
+]
+
+# Column order of the 4 fields, matching paddle's flashmask_attention.
+_LTS, _LTE, _UTS, _UTE = 0, 1, 2, 3
+
+
+def _check_lens(
+    prefix_lens: Sequence[int], suffix_lens: Sequence[int], pad_len: int
+) -> None:
+    if len(prefix_lens) != len(suffix_lens):
+        raise ValueError(
+            f"prefix_lens and suffix_lens must have the same number of segments, "
+            f"got {len(prefix_lens)} vs {len(suffix_lens)}"
+        )
+    if len(prefix_lens) == 0:
+        raise ValueError("at least one segment is required")
+    if any(int(c) < 0 for c in prefix_lens):
+        raise ValueError(
+            f"prefix_lens must be non-negative, got {list(prefix_lens)}"
+        )
+    if any(int(q) <= 0 for q in suffix_lens):
+        # The suffix is the latent query, always a positive length; a length of
+        # 0 would degenerate the row selection into an empty range.
+        raise ValueError(
+            f"suffix_lens must be positive, got {list(suffix_lens)}"
+        )
+    if int(pad_len) < 0:
+        raise ValueError(f"pad_len must be non-negative, got {pad_len}")
+
+
+def prefix_lm_segment_starts(
+    prefix_lens: Sequence[int], suffix_lens: Sequence[int]
+) -> list[int]:
+    """Segment starts ``s_i`` (prefix sum), length N."""
+    starts, acc = [], 0
+    for c, q in zip(prefix_lens, suffix_lens):
+        starts.append(acc)
+        acc += int(c) + int(q)
+    return starts
+
+
+def prefix_lm_pad_len(
+    seq_len: int, tp_size: int, sequence_parallel: bool, align: int = 128
+) -> int:
+    """Padding length needed to round ``seq_len`` up to a multiple of
+    ``lcm(base, align)``.
+
+    ``base`` is ``tp_size`` when sequence parallel is enabled (so the sequence
+    scatters evenly across the SP partitions), otherwise 1; ``align`` adds a
+    further fixed alignment. ``align`` is an explicit argument here rather than
+    an environment variable.
+    """
+    base = int(tp_size) if sequence_parallel else 1
+    mult = math.lcm(base, max(int(align), 1))
+    return (mult - (int(seq_len) % mult)) % mult
+
+
+def build_dense_mask(
+    prefix_lens: Sequence[int],
+    suffix_lens: Sequence[int],
+    pad_len: int = 0,
+    place=None,
+) -> paddle.Tensor:
+    """Representation 1: dense boolean mask ``[1, 1, T', T']``, ``True`` = forbidden.
+
+    Start with everything forbidden, then open four regions per segment:
+    prefix<->prefix (bidirectional), suffix->prefix, causal within suffix, and
+    the pad self-loop. Different segments stay fully forbidden against each
+    other, which enforces isolation.
+    """
+    _check_lens(prefix_lens, suffix_lens, pad_len)
+    starts = prefix_lm_segment_starts(prefix_lens, suffix_lens)
+    total = starts[-1] + int(prefix_lens[-1]) + int(suffix_lens[-1])
+    tp = total + int(pad_len)
+
+    mask = paddle.ones([1, 1, tp, tp], dtype="bool")
+    if place is not None:
+        mask = mask.to(place)
+
+    for s, c, q in zip(starts, prefix_lens, suffix_lens):
+        c, q = int(c), int(q)
+        real_end = s + c + q
+        if c > 0:
+            # prefix <-> prefix, bidirectional
+            mask[:, :, s : s + c, s : s + c] = False
+            # suffix can see the whole prefix of its segment
+            mask[:, :, s + c : real_end, s : s + c] = False
+        # causal within suffix (triu(diagonal=1) = strict upper triangle forbidden)
+        causal = paddle.triu(paddle.ones([q, q], dtype="bool"), diagonal=1)
+        if place is not None:
+            causal = causal.to(place)
+        mask[:, :, s + c : real_end, s + c : real_end] = causal
+
+    # pad rows see only themselves; without this the whole pad row is -inf and
+    # softmax yields NaN
+    if int(pad_len) > 0:
+        idx = paddle.arange(total, tp, dtype="int64")
+        if place is not None:
+            idx = idx.to(place)
+        mask[0, 0, idx, idx] = False
+    return mask
+
+
+def build_flashmask_row_indices(
+    prefix_lens: Sequence[int],
+    suffix_lens: Sequence[int],
+    pad_len: int = 0,
+    place=None,
+) -> paddle.Tensor:
+    """Representation 2: FlashMask column-sparse indices ``[1, 1, T', 4]`` int32.
+
+    The 4 columns are ``[LTS, LTE, UTS, UTE]`` (see the encoding notes in the
+    module docstring). There is no per-column Python loop: ``repeat_interleave``
+    broadcasts the per-segment ``(s_i, s_i+L_i)`` onto the column axis, then two
+    ``where`` calls against ``arange`` compute the fields.
+    """
+    _check_lens(prefix_lens, suffix_lens, pad_len)
+    starts = prefix_lm_segment_starts(prefix_lens, suffix_lens)
+    seg_lens = [int(c) + int(q) for c, q in zip(prefix_lens, suffix_lens)]
+    total = starts[-1] + seg_lens[-1]
+    tp = total + int(pad_len)
+
+    seg_len_t = paddle.to_tensor(seg_lens, dtype="int32")
+    start_t = paddle.to_tensor(starts, dtype="int32")
+    prefix_t = paddle.to_tensor([int(c) for c in prefix_lens], dtype="int32")
+
+    # Broadcast segment-level values onto the column axis:
+    # col_start[j] = s_i, col_end[j] = s_i + L_i, col_prefix_end[j] = s_i + C_i
+    col_start = paddle.repeat_interleave(start_t, seg_len_t)
+    col_end = paddle.repeat_interleave(start_t + seg_len_t, seg_len_t)
+    col_prefix_end = paddle.repeat_interleave(start_t + prefix_t, seg_len_t)
+
+    j_real = paddle.arange(total, dtype="int32")
+    is_prefix_col = j_real < col_prefix_end
+
+    tp_t = paddle.full([total], tp, dtype="int32")
+    lts_real = col_end  # rows >= s_i+L_i forbidden
+    lte_real = tp_t
+    uts_real = paddle.zeros([total], dtype="int32")
+    ute_real = paddle.where(
+        is_prefix_col, col_start, j_real
+    )  # prefix col opens to s_i; suffix col opens to j
+
+    if int(pad_len) > 0:
+        j_pad = paddle.arange(total, tp, dtype="int32")
+        lts = paddle.concat(
+            [lts_real, j_pad + 1]
+        )  # pad col: rows > j forbidden
+        lte = paddle.concat(
+            [lte_real, paddle.full([int(pad_len)], tp, dtype="int32")]
+        )
+        uts = paddle.concat(
+            [uts_real, paddle.zeros([int(pad_len)], dtype="int32")]
+        )
+        ute = paddle.concat([ute_real, j_pad])  # pad col: rows < j forbidden
+    else:
+        lts, lte, uts, ute = lts_real, lte_real, uts_real, ute_real
+
+    out = paddle.stack([lts, lte, uts, ute], axis=-1).reshape([1, 1, tp, 4])
+    if place is not None:
+        out = out.to(place)
+    return out
+
+
+def build_prefix_lm_layout(
+    prefix_lens: Sequence[int],
+    suffix_lens: Sequence[int],
+    pad_len: int = 0,
+) -> dict[str, object]:
+    """Representation 3: geometry layout for the Triton kernel (plain Python
+    scalars, no tensors)."""
+    _check_lens(prefix_lens, suffix_lens, pad_len)
+    return {
+        "segment_starts": tuple(
+            prefix_lm_segment_starts(prefix_lens, suffix_lens)
+        ),
+        "n_contexts": tuple(int(c) for c in prefix_lens),
+        "n_queries": tuple(int(q) for q in suffix_lens),
+        "pad_len": int(pad_len),
+    }
+
+
+def expand_row_indices_to_dense(row_indices: paddle.Tensor) -> paddle.Tensor:
+    """Expand representation 2 into a dense ``[1,1,T',T']`` bool (``True`` =
+    forbidden). **Unit tests only.**
+
+    Derived strictly from the FlashMask semantics, without referencing the other
+    two representations, so that it can serve as an independent cross-check.
+    """
+    if row_indices.ndim != 4 or row_indices.shape[-1] != 4:
+        raise ValueError(
+            f"row_indices shape should be [1,1,T',4], got {row_indices.shape}"
+        )
+    tp = int(row_indices.shape[2])
+    ri = row_indices.reshape([tp, 4]).astype("int64")
+    lts, lte, uts, ute = ri[:, _LTS], ri[:, _LTE], ri[:, _UTS], ri[:, _UTE]
+
+    rows = paddle.arange(tp, dtype="int64").reshape([tp, 1])  # row r
+    cols = paddle.arange(tp, dtype="int64").reshape([1, tp])  # column j
+
+    lower = rows > cols  # lower-triangle side
+    upper = rows < cols  # upper-triangle side
+    in_lower_band = (rows >= lts.reshape([1, tp])) & (
+        rows < lte.reshape([1, tp])
+    )
+    in_upper_band = (rows >= uts.reshape([1, tp])) & (
+        rows < ute.reshape([1, tp])
+    )
+
+    forbidden = (lower & in_lower_band) | (upper & in_upper_band)
+    return forbidden.reshape([1, 1, tp, tp])
+
+
+def expand_layout_to_dense(layout: dict[str, object]) -> paddle.Tensor:
+    """Expand representation 3 into a dense ``[1,1,T',T']`` bool (``True`` =
+    forbidden). **Unit tests only.**
+
+    Written directly from the "allowed relations" table in the module docstring,
+    region by region, without reusing :func:`build_dense_mask`.
+    """
+    starts = list(layout["segment_starts"])  # type: ignore[arg-type]
+    n_ctx = list(layout["n_contexts"])  # type: ignore[arg-type]
+    n_q = list(layout["n_queries"])  # type: ignore[arg-type]
+    pad_len = int(layout["pad_len"])  # type: ignore[arg-type]
+
+    total = starts[-1] + n_ctx[-1] + n_q[-1]
+    tp = total + pad_len
+
+    rows = paddle.arange(tp, dtype="int64").reshape([tp, 1])
+    cols = paddle.arange(tp, dtype="int64").reshape([1, tp])
+    allowed = paddle.zeros([tp, tp], dtype="bool")
+
+    for s, c, q in zip(starts, n_ctx, n_q):
+        seg_end = s + c + q
+        col_in_prefix = (cols >= s) & (cols < s + c)
+        col_in_suffix = (cols >= s + c) & (cols < seg_end)
+        row_in_seg = (rows >= s) & (rows < seg_end)
+        # prefix column: allow all rows of the segment
+        allowed = allowed | (col_in_prefix & row_in_seg)
+        # suffix column j: allow rows [j, seg_end)
+        allowed = allowed | (col_in_suffix & row_in_seg & (rows >= cols))
+
+    if pad_len > 0:
+        col_in_pad = cols >= total
+        allowed = allowed | (col_in_pad & (rows == cols))
+
+    return paddle.logical_not(allowed).reshape([1, 1, tp, tp])

--- a/src/paddlefleet/transformer/prefix_lm_triton_core.py
+++ b/src/paddlefleet/transformer/prefix_lm_triton_core.py
@@ -117,10 +117,10 @@ class PrefixLMTritonCore(FleetLayer):
             if softmax_scale is not None
             else 1.0 / math.sqrt(float(head_dim))
         )
-        # Block sizes and launch tuning come from config fields (declared and
-        # validated on the HyperEncoder config). Changing the block shape changes
-        # both the plan and the softmax reduction tree, so it must be consistent
-        # across a run.
+        # Block sizes and launch tuning are read from config with defaults (the
+        # fields are declared on the HyperEncoder config). Changing the block
+        # shape changes both the plan and the softmax reduction tree, so it must
+        # be consistent across a run.
         self.block_m = int(getattr(config, "hyperencoder_triton_block_m", 64))
         self.block_n = int(getattr(config, "hyperencoder_triton_block_n", 64))
         self.fwd_warps = int(

--- a/src/paddlefleet/transformer/prefix_lm_triton_core.py
+++ b/src/paddlefleet/transformer/prefix_lm_triton_core.py
@@ -1,0 +1,227 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton core-attention for packed prefix-LM, a drop-in for `DotProductAttention`.
+
+## What it does
+
+This class occupies the `self_attention.submodules.core_attention` slot: the
+outer `SelfAttention` still owns QKV projection, RoPE, and output projection;
+only the softmax + masked matmul is replaced here.
+
+## Tensor layout
+
+The class works in batch-major layout:
+
+| | q/k/v into core | tensor out of core |
+|---|---|---|
+| this class | batch-major `[B, S, N, D]` | `[B, S, N*D]` |
+
+When sequence parallel (SP) is enabled, the surrounding attention module
+transposes `[S, B, ...]` back to `[B, S, ...]` before calling core and
+transposes it back afterwards, so this class only needs to handle
+`[B, S, N, D]`. The kernel itself expects `[B, N, T, D]` (grid is
+`(q_block, batch*head)`), so core permutes once before launching.
+
+Note: under SP, `linear_qkv` is `ColumnParallelLinear(sequence_parallel=True)`,
+which all-gathers `[S/tp, B, H]` back to the full `S` in the forward pass.
+Therefore core sees the full `S` (equal to `layout.seq_total`), not `S/tp`,
+and the plan does not need to be sliced per rank.
+
+## Where the layout comes from
+
+The segment layout is read from `packed_seq_params.prefix_lm_layout` (a dict).
+It MUST be attached by the model code; if it is missing this class raises an
+error rather than silently degrading to "no mask", which would drop the
+prefix-LM three-region semantics while loss still appears to decrease normally.
+
+The layout is passed through `packed_seq_params` rather than an instance
+attribute or thread-local state: recompute reruns forward under `no_grad`,
+where thread-local state has already been popped and instance attributes are
+not recompute-safe.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from typing import TYPE_CHECKING
+
+from paddlefleet.transformer.layer import FleetLayer
+from paddlefleet.triton_ops.prefix_lm_attention import (
+    SegmentLayout,
+    layout_from_hyperbody_dict,
+    triton_prefix_lm_attention,
+)
+
+if TYPE_CHECKING:
+    from paddle import Tensor
+
+__all__ = ["PrefixLMTritonCore", "PREFIX_LM_LAYOUT_ATTR"]
+
+#: Field name attached to `PackedSeqParams`. There is deliberately no alias
+#: fallback: a misspelled name should raise an error rather than silently
+#: running with no mask.
+PREFIX_LM_LAYOUT_ATTR = "prefix_lm_layout"
+
+_LAYOUT_CACHE: dict[tuple, SegmentLayout] = {}
+
+
+class PrefixLMTritonCore(FleetLayer):
+    """Triton core-attention for packed prefix-LM.
+
+    The constructor signature mirrors `DotProductAttention.__init__` so this
+    class can directly occupy the `core_attention` slot; unused parameters are
+    accepted and discarded.
+    """
+
+    def __init__(
+        self,
+        config,
+        layer_number: int = 1,
+        attn_mask_type=None,
+        attention_type: str = "self",
+        cp_comm_type: str | None = None,
+        pg_collection=None,
+        softmax_scale: float | None = None,
+        **_unused,
+    ) -> None:
+        super().__init__(config=config)
+        del attn_mask_type, attention_type, cp_comm_type, _unused
+
+        self.config = config
+        self.layer_number = layer_number
+        # The surrounding attention module reads this attribute to decide
+        # whether to slice flashmask row indices. This path does not use
+        # flashmask, but the attribute must exist to avoid an AttributeError.
+        self.context_parallel_size = 1
+
+        head_dim = getattr(config, "head_dim", None)
+        if head_dim is None:
+            head_dim = config.hidden_size // config.num_attention_heads
+        self.head_dim = head_dim
+        # Default softmax scale is 1/sqrt(head_dim); `softmax_scale` allows an
+        # external override.
+        self.softmax_scale = (
+            float(softmax_scale)
+            if softmax_scale is not None
+            else 1.0 / math.sqrt(float(head_dim))
+        )
+        # Block sizes are configurable via env vars: changing the block shape
+        # changes both the plan and the softmax reduction tree, so it must be
+        # set consistently across a run.
+        self.block_m = int(os.environ.get("HYPERBODY_TRITON_BLOCK_M", "64"))
+        self.block_n = int(os.environ.get("HYPERBODY_TRITON_BLOCK_N", "64"))
+
+        if (
+            pg_collection is not None
+            and getattr(pg_collection, "cp", None) is not None
+        ):
+            cp = pg_collection.cp
+            if getattr(cp, "nranks", 1) > 1:
+                raise RuntimeError(
+                    "PrefixLMTritonCore does not support context parallel"
+                )
+
+    def _resolve_layout(
+        self, seq_total: int, packed_seq_params
+    ) -> SegmentLayout:
+        """Resolve the segment layout from `packed_seq_params.prefix_lm_layout`."""
+        hint = (
+            getattr(packed_seq_params, PREFIX_LM_LAYOUT_ATTR, None)
+            if packed_seq_params is not None
+            else None
+        )
+        if not isinstance(hint, dict):
+            raise RuntimeError(
+                f"PrefixLMTritonCore requires packed_seq_params.{PREFIX_LM_LAYOUT_ATTR} "
+                f"(a dict), got {type(hint).__name__}. The packed prefix-LM segment "
+                "layout must be supplied by the model code; without it the attention "
+                "would silently degrade to no mask and lose the three-region semantics."
+            )
+        key = (
+            tuple(int(x) for x in hint["segment_starts"]),
+            tuple(int(x) for x in hint["n_contexts"]),
+            tuple(int(x) for x in hint["n_queries"]),
+            int(hint.get("pad_len", 0)),
+            seq_total,
+        )
+        layout = _LAYOUT_CACHE.get(key)
+        if layout is None:
+            layout = layout_from_hyperbody_dict(hint, seq_total)
+            _LAYOUT_CACHE[key] = layout
+        return layout
+
+    def forward(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        attention_mask: Tensor | None = None,
+        attn_mask_startend_row_indices: Tensor | None = None,
+        *,
+        attn_mask_type=None,
+        attention_bias: Tensor | None = None,
+        packed_seq_params=None,
+        **_unused,
+    ) -> Tensor:
+        """`[B, S, N, D]` -> `[B, S, N*D]`."""
+        del attn_mask_type, _unused
+        if attention_bias is not None:
+            raise ValueError(
+                "PrefixLMTritonCore does not support attention_bias"
+            )
+        # Neither a dense mask nor flashmask row indices should be passed: the
+        # mask semantics live entirely in the layout. Passing either means the
+        # caller expected a different backend, so this is treated as an error
+        # rather than silently ignored.
+        if (
+            attention_mask is not None
+            or attn_mask_startend_row_indices is not None
+        ):
+            raise ValueError(
+                "PrefixLMTritonCore derives its mask semantics entirely from "
+                "prefix_lm_layout and does not accept attention_mask / "
+                "attn_mask_startend_row_indices. Passing either indicates the "
+                "wrong attention path was selected."
+            )
+        if query.dim() != 4:
+            raise ValueError(
+                f"PrefixLMTritonCore expects q/k/v as 4-D [B,S,N,D], got {tuple(query.shape)}"
+            )
+
+        b, s, n_heads, head_dim = query.shape
+        layout = self._resolve_layout(s, packed_seq_params)
+
+        # [B,S,N,D] -> contiguous [B,N,S,D] to feed the (batch*head) grid
+        qt = query.transpose([0, 2, 1, 3]).contiguous()
+        kt = key.transpose([0, 2, 1, 3]).contiguous()
+        vt = value.transpose([0, 2, 1, 3]).contiguous()
+        if kt.shape[1] != n_heads:
+            raise ValueError(
+                "PrefixLMTritonCore does not support GQA/MQA (the kernel assumes "
+                f"equal head counts for q/k/v): q heads {n_heads}, k heads {kt.shape[1]}"
+            )
+
+        out = triton_prefix_lm_attention(
+            qt,
+            kt,
+            vt,
+            layout,
+            scale=self.softmax_scale,
+            block_m=self.block_m,
+            block_n=self.block_n,
+        )
+        # [B,N,S,D] -> [B,S,N*D]
+        return out.transpose([0, 2, 1, 3]).reshape([b, s, n_heads * head_dim])

--- a/src/paddlefleet/transformer/prefix_lm_triton_core.py
+++ b/src/paddlefleet/transformer/prefix_lm_triton_core.py
@@ -55,7 +55,6 @@ not recompute-safe.
 from __future__ import annotations
 
 import math
-import os
 from typing import TYPE_CHECKING
 
 from paddlefleet.transformer.layer import FleetLayer
@@ -118,11 +117,27 @@ class PrefixLMTritonCore(FleetLayer):
             if softmax_scale is not None
             else 1.0 / math.sqrt(float(head_dim))
         )
-        # Block sizes are configurable via env vars: changing the block shape
-        # changes both the plan and the softmax reduction tree, so it must be
-        # set consistently across a run.
-        self.block_m = int(os.environ.get("HYPERBODY_TRITON_BLOCK_M", "64"))
-        self.block_n = int(os.environ.get("HYPERBODY_TRITON_BLOCK_N", "64"))
+        # Block sizes and launch tuning come from config fields (declared and
+        # validated on the HyperEncoder config). Changing the block shape changes
+        # both the plan and the softmax reduction tree, so it must be consistent
+        # across a run.
+        self.block_m = int(getattr(config, "hyperencoder_triton_block_m", 64))
+        self.block_n = int(getattr(config, "hyperencoder_triton_block_n", 64))
+        self.fwd_warps = int(
+            getattr(config, "hyperencoder_triton_fwd_warps", 4)
+        )
+        self.fwd_stages = int(
+            getattr(config, "hyperencoder_triton_fwd_stages", 2)
+        )
+        self.bwd_warps = int(
+            getattr(config, "hyperencoder_triton_bwd_warps", 4)
+        )
+        self.bwd_stages = int(
+            getattr(config, "hyperencoder_triton_bwd_stages", 2)
+        )
+        self.plan_cache_size = int(
+            getattr(config, "hyperencoder_triton_plan_cache_size", 64)
+        )
 
         if (
             pg_collection is not None
@@ -222,6 +237,11 @@ class PrefixLMTritonCore(FleetLayer):
             scale=self.softmax_scale,
             block_m=self.block_m,
             block_n=self.block_n,
+            fwd_warps=self.fwd_warps,
+            fwd_stages=self.fwd_stages,
+            bwd_warps=self.bwd_warps,
+            bwd_stages=self.bwd_stages,
+            plan_cache_size=self.plan_cache_size,
         )
         # [B,N,S,D] -> [B,S,N*D]
         return out.transpose([0, 2, 1, 3]).reshape([b, s, n_heads * head_dim])

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -317,6 +317,22 @@ class TransformerConfig(ModelParallelConfig):
     flashmask_use_varlen: bool = False
     """If True, convert flashmask to varlen in attention."""
 
+    # ---- HyperEncoder attention backend ----
+    # Used only by the HyperEncoder model (models/hyperencoder/*). Declared here
+    # so the switches are first-class config fields (validated, serialized,
+    # test-covered) instead of environment variables. Other models leave them at
+    # their defaults and never read them. The Triton kernel launch tuning
+    # (block size / warps / stages / plan-cache) is not exposed: production never
+    # varies it, so those values are fixed in the kernel.
+    hyperencoder_attn_backend: str = "dp"
+    """HyperEncoder core-attention backend: "dp" (dense per-layer mask) or
+    "triton" (packed prefix-LM core). Validated in the model config's
+    __post_init__ ("flex" and unknown values raise)."""
+
+    hyperencoder_packed_decoder: bool = False
+    """Run the HyperEncoder trunk as a single packed call. Requires
+    hyperencoder_attn_backend="triton"."""
+
     intermediate_size: int | None = None
     """Transformer Feed-Forward Network hidden size. This is set to 4*hidden_size
     if not provided."""

--- a/src/paddlefleet/triton_ops/prefix_lm_attention.py
+++ b/src/paddlefleet/triton_ops/prefix_lm_attention.py
@@ -42,7 +42,6 @@ implementation details.
 
 from __future__ import annotations
 
-import os
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any
@@ -433,10 +432,8 @@ def build_exec_plan(layout: SegmentLayout, block_m: int, block_n: int) -> dict:
 # Rebuilding it on every call costs ~2ms of Python loops + transfer (for a 4k
 # token pack) while the flash kernel itself is only ~0.05ms; with recompute
 # enabled each layer pays it twice. So the device-side tensors are memoized by
-# layout. The cache-size env var lets deployments tune the memory footprint.
-_PLAN_CACHE_MAX = int(
-    os.environ.get("HYPERBODY_TRITON_BLOCK_PLAN_CACHE_SIZE", "64")
-)
+# layout. The cache cap (`cache_max`) comes from a config field and lets
+# deployments tune the memory footprint (0 disables caching).
 _EXEC_PLAN_CACHE: OrderedDict[tuple, dict] = OrderedDict()
 
 
@@ -455,9 +452,11 @@ def _layout_cache_key(
     )
 
 
-def get_exec_plan(layout: SegmentLayout, block_m: int, block_n: int) -> dict:
-    """Return the cached exec plan (device-side tensors), LRU-capped at `_PLAN_CACHE_MAX`."""
-    if _PLAN_CACHE_MAX <= 0:
+def get_exec_plan(
+    layout: SegmentLayout, block_m: int, block_n: int, cache_max: int = 64
+) -> dict:
+    """Return the cached exec plan (device-side tensors), LRU-capped at `cache_max`."""
+    if cache_max <= 0:
         return build_exec_plan(layout, block_m, block_n)
     key = _layout_cache_key(layout, block_m, block_n)
     val = _EXEC_PLAN_CACHE.get(key)
@@ -466,7 +465,7 @@ def get_exec_plan(layout: SegmentLayout, block_m: int, block_n: int) -> dict:
         return val
     val = build_exec_plan(layout, block_m, block_n)
     _EXEC_PLAN_CACHE[key] = val
-    if len(_EXEC_PLAN_CACHE) > _PLAN_CACHE_MAX:
+    if len(_EXEC_PLAN_CACHE) > cache_max:
         _EXEC_PLAN_CACHE.popitem(last=False)
     return val
 
@@ -525,23 +524,8 @@ def _st(x) -> tuple:
 # ---------------------------------------------------------------------------
 
 
-# warps/stages are read from env vars: num_warps directly determines the
-# softmax reduction tree, so it (and num_stages) are configurable to tune the
-# launch configuration.
-def _fwd_launch() -> tuple[int, int]:
-    return (
-        int(os.environ.get("HYPERBODY_TRITON_FWD_WARPS", "4")),
-        int(os.environ.get("HYPERBODY_TRITON_FWD_STAGES", "2")),
-    )
-
-
-def _bwd_launch() -> tuple[int, int]:
-    return (
-        int(os.environ.get("HYPERBODY_TRITON_BWD_WARPS", "4")),
-        int(os.environ.get("HYPERBODY_TRITON_BWD_STAGES", "2")),
-    )
-
-
+# num_warps directly determines the softmax reduction tree, so it (and
+# num_stages) are passed in from config fields to tune the launch configuration.
 def triton_prefix_lm_forward(
     query,
     key,
@@ -551,6 +535,9 @@ def triton_prefix_lm_forward(
     scale: float,
     block_m: int = 64,
     block_n: int = 64,
+    num_warps: int = 4,
+    num_stages: int = 2,
+    cache_max: int = 64,
     plan: dict | None = None,
 ):
     """Run the Triton prefix-LM flash forward.
@@ -559,6 +546,8 @@ def triton_prefix_lm_forward(
         query/key/value: `[B, H, T, D]`, ideally contiguous.
         layout: packed segment layout (`T == seq_total`).
         scale: softmax scale.
+        num_warps/num_stages: launch configuration for the forward kernel.
+        cache_max: LRU cap for the exec-plan cache.
         plan: output of `get_exec_plan`; if omitted it is built on the fly
             (slower, same semantics).
 
@@ -570,11 +559,14 @@ def triton_prefix_lm_forward(
     b, h, t, d = query.shape
     if t != layout.seq_total:
         raise ValueError(f"seq len {t} != layout.seq_total {layout.seq_total}")
-    p = plan if plan is not None else get_exec_plan(layout, block_m, block_n)
+    p = (
+        plan
+        if plan is not None
+        else get_exec_plan(layout, block_m, block_n, cache_max)
+    )
 
     out = paddle.empty_like(query)
     lse = paddle.empty([b, h, t], dtype="float32")
-    warps, stages = _fwd_launch()
     _kernels()["_prefix_lm_fwd_kernel"][(p["n_q_blocks"], b * h)](
         query,
         key,
@@ -599,8 +591,8 @@ def triton_prefix_lm_forward(
         HEAD_DIM=d,
         BLOCK_M=block_m,
         BLOCK_N=block_n,
-        num_warps=warps,
-        num_stages=stages,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
     return out, lse
 
@@ -617,6 +609,9 @@ def triton_prefix_lm_backward(
     scale: float,
     block_m: int = 64,
     block_n: int = 64,
+    num_warps: int = 4,
+    num_stages: int = 2,
+    cache_max: int = 64,
     plan: dict | None = None,
 ):
     """Run the Triton prefix-LM flash backward.
@@ -633,7 +628,11 @@ def triton_prefix_lm_backward(
     import paddle
 
     b, h, t, d = query.shape
-    p = plan if plan is not None else get_exec_plan(layout, block_m, block_n)
+    p = (
+        plan
+        if plan is not None
+        else get_exec_plan(layout, block_m, block_n, cache_max)
+    )
     ks = _kernels()
 
     dout = dout.contiguous()
@@ -654,7 +653,7 @@ def triton_prefix_lm_backward(
         HEAD_DIM=d,
         BLOCK_M=block_m,
     )
-    warps, stages = _bwd_launch()
+    warps, stages = num_warps, num_stages
     ks["_prefix_lm_dkdv_kernel"][(p["n_kv_blocks"], b * h)](
         query,
         key,
@@ -745,8 +744,22 @@ def _attn_cls():
         """
 
         @staticmethod
-        def forward(ctx, query, key, value, layout, scale, block_m, block_n):
-            plan = get_exec_plan(layout, block_m, block_n)
+        def forward(
+            ctx,
+            query,
+            key,
+            value,
+            layout,
+            scale,
+            block_m,
+            block_n,
+            fwd_warps,
+            fwd_stages,
+            bwd_warps,
+            bwd_stages,
+            cache_max,
+        ):
+            plan = get_exec_plan(layout, block_m, block_n, cache_max)
             out, lse = triton_prefix_lm_forward(
                 query,
                 key,
@@ -755,6 +768,9 @@ def _attn_cls():
                 scale=scale,
                 block_m=block_m,
                 block_n=block_n,
+                num_warps=fwd_warps,
+                num_stages=fwd_stages,
+                cache_max=cache_max,
                 plan=plan,
             )
             ctx.save_for_backward(query, key, value, out, lse)
@@ -762,6 +778,9 @@ def _attn_cls():
             ctx.scale = scale
             ctx.block_m = block_m
             ctx.block_n = block_n
+            ctx.bwd_warps = bwd_warps
+            ctx.bwd_stages = bwd_stages
+            ctx.cache_max = cache_max
             # PyLayer contract: stop_gradient inputs must return None
             ctx.needs_grad = (
                 not query.stop_gradient,
@@ -784,11 +803,17 @@ def _attn_cls():
                 scale=ctx.scale,
                 block_m=ctx.block_m,
                 block_n=ctx.block_n,
-                plan=get_exec_plan(ctx.layout, ctx.block_m, ctx.block_n),
+                num_warps=ctx.bwd_warps,
+                num_stages=ctx.bwd_stages,
+                cache_max=ctx.cache_max,
+                plan=get_exec_plan(
+                    ctx.layout, ctx.block_m, ctx.block_n, ctx.cache_max
+                ),
             )
             gq, gk, gv = ctx.needs_grad
-            # One gradient slot per TENSOR input, in order; layout/scale/block_*
-            # are non-tensors and do not occupy a slot.
+            # One gradient slot per TENSOR input, in order; the non-tensor args
+            # (layout / scale / block_* / warps / stages / cache_max) do not
+            # occupy a slot.
             return (dq if gq else None, dk if gk else None, dv if gv else None)
 
     _ATTN_CLS = _PrefixLMTritonAttn
@@ -807,6 +832,24 @@ def triton_prefix_lm_attention(
     scale: float,
     block_m: int = 64,
     block_n: int = 64,
+    fwd_warps: int = 4,
+    fwd_stages: int = 2,
+    bwd_warps: int = 4,
+    bwd_stages: int = 2,
+    plan_cache_size: int = 64,
 ):
     """Differentiable Triton prefix-LM attention; inputs are `[B, H, T, D]`."""
-    return _attn_cls().apply(query, key, value, layout, scale, block_m, block_n)
+    return _attn_cls().apply(
+        query,
+        key,
+        value,
+        layout,
+        scale,
+        block_m,
+        block_n,
+        fwd_warps,
+        fwd_stages,
+        bwd_warps,
+        bwd_stages,
+        plan_cache_size,
+    )

--- a/src/paddlefleet/triton_ops/prefix_lm_attention.py
+++ b/src/paddlefleet/triton_ops/prefix_lm_attention.py
@@ -1,0 +1,812 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Host-side plan (a block-sparse schedule) for packed prefix-LM attention.
+
+## What this is
+
+The packed + Triton attention path does not compute the mask inside the
+kernel. Instead it consumes a set of integer arrays precomputed on the host:
+
+* `tok_seg_start` / `tok_seg_ctx`: per-token segment identity (pad is -1 / 0);
+* `kv_lo` / `kv_hi`: the KV block range to scan per q-block for the forward
+  pass and the dQ pass;
+* `q_lo` / `q_hi`: the q-block range to scan per KV block for the dK/dV pass;
+* `full_flags` / `full_flags_bwd`: whether each `(q-block, kv-block)` tile is
+  FULL (all pairs allowed, so the kernel can take the mask-free fast path).
+
+This layer is pure integer logic with no floating point, so a bug here cannot
+be hidden by numerical noise: either a shape mismatch crashes outright, or an
+incorrect scan range / FULL flag silently produces a wrong result. The plan is
+validated by exact integer equality (`np.array_equal`) against a dense
+reference implementation.
+
+## Why this is a separate file that does not import paddle compute
+
+The function bodies use only `int` / `list` / `range`; only the final step
+packs the results into `paddle.Tensor`. Keeping the plan free of framework
+compute means the result is deterministic and does not depend on operator
+implementation details.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SegmentLayout:
+    """Per-segment layout of one packed encoder sequence.
+
+    Attributes:
+        segment_starts: global start index of each segment in the packed sequence.
+        n_contexts: context-prefix length of each segment (may be < 128, never 0).
+        n_queries: query-suffix length of each segment (e.g. 256 / 8192).
+        seq_total: total length including trailing pad (128-aligned).
+        pad_start: index of the first pad token; `== seq_total` means no pad.
+    """
+
+    segment_starts: tuple[int, ...]
+    n_contexts: tuple[int, ...]
+    n_queries: tuple[int, ...]
+    seq_total: int
+    pad_start: int
+
+    @property
+    def segment_ends(self) -> tuple[int, ...]:
+        """End index (exclusive) of each segment."""
+        return tuple(
+            s + c + q
+            for s, c, q in zip(
+                self.segment_starts, self.n_contexts, self.n_queries
+            )
+        )
+
+
+def layout_from_hyperbody_dict(
+    layout: dict[str, Any], seq_total: int
+) -> SegmentLayout:
+    """Build a `SegmentLayout` from a layout dict.
+
+    The dict is attached to `packed_seq_params` by the packed forward pass;
+    it is the copy that survives recompute, when thread-local state has already
+    been popped.
+    """
+    segment_starts = tuple(int(x) for x in layout["segment_starts"])
+    n_contexts = tuple(int(x) for x in layout["n_contexts"])
+    n_queries = tuple(int(x) for x in layout["n_queries"])
+    pad_len = int(layout.get("pad_len", 0))
+    pad_start = seq_total - pad_len
+
+    if not (len(segment_starts) == len(n_contexts) == len(n_queries)):
+        raise ValueError(
+            f"segment_starts/n_contexts/n_queries length mismatch: "
+            f"{len(segment_starts)}/{len(n_contexts)}/{len(n_queries)}"
+        )
+    return SegmentLayout(
+        segment_starts=segment_starts,
+        n_contexts=n_contexts,
+        n_queries=n_queries,
+        seq_total=seq_total,
+        pad_start=pad_start,
+    )
+
+
+def default_scale(head_dim: int) -> float:
+    """`1/sqrt(head_dim)`."""
+    import math
+
+    return 1.0 / math.sqrt(float(head_dim))
+
+
+# ---------------------------------------------------------------------------
+# Per-token segment metadata + host-side block-sparse plan (pure integer)
+# ---------------------------------------------------------------------------
+
+
+def build_token_segment_arrays_list(
+    layout: SegmentLayout,
+) -> tuple[list[int], list[int]]:
+    """Expand the layout into two per-token `int` lists.
+
+    The mask is encoded as per-token segment identity (rather than one seg-id
+    per q-block), so q-blocks that straddle a segment boundary need no special
+    case: two tokens are in the same segment iff their `tok_seg_start` matches.
+    Pad tokens are marked `-1` and never share a segment with any token (their
+    self-loop is handled by an explicit pad-diagonal term inside the kernel).
+    """
+    n = layout.seq_total
+    tok_seg_start = [-1] * n
+    tok_seg_ctx = [0] * n
+    for start, nctx, end in zip(
+        layout.segment_starts, layout.n_contexts, layout.segment_ends
+    ):
+        for t in range(start, end):
+            tok_seg_start[t] = int(start)
+            tok_seg_ctx[t] = int(nctx)
+    return tok_seg_start, tok_seg_ctx
+
+
+def build_block_plan_list(
+    layout: SegmentLayout, block_m: int, block_n: int
+) -> tuple[list[int], list[int], int]:
+    """Compute the `[kv_lo, kv_hi)` KV block range to scan per q-block.
+
+    Pure host-side integer arithmetic (O(#segments), no kernel compilation).
+    Fully masked KV blocks are skipped. The range does not need to be tight:
+    over-scanning only costs performance, since the kernel predicate zeroes out
+    any disallowed position anyway.
+
+    The upper bound exploits the prefix-LM causal structure: query-suffix rows
+    only attend to the context prefix plus earlier query rows, so a q-block's
+    KV reach is at most `max(segment_ctx_end, q_block_end)`. This prunes the
+    fully-masked tail that a naive `hi = segment_end` would scan for every
+    early q-block, which is the dominant waste on long query segments.
+    """
+    n = layout.seq_total
+    num_q_blocks = (n + block_m - 1) // block_m
+
+    seg_start = layout.segment_starts
+    seg_ctx = layout.n_contexts
+    seg_ends = layout.segment_ends
+    pad_start = layout.pad_start
+
+    kv_lo = [0] * num_q_blocks
+    kv_hi = [0] * num_q_blocks
+
+    for qb in range(num_q_blocks):
+        q0 = qb * block_m
+        q1 = min(q0 + block_m, n)
+        lo = n  # min over per-row seg_start
+        hi = 0  # max reachable kv over rows
+        has_pad = False
+        for s, nctx, e in zip(seg_start, seg_ctx, seg_ends):
+            # Does this segment intersect the q-row range [q0, q1)?
+            if s < q1 and e > q0:
+                ctx_end = s + nctx
+                # Causal reach: context rows see ctx_end; query rows see their
+                # own index (at most q1-1 within the block, clipped by e).
+                # `max(ctx_end, min(q1, e))` is a tight upper bound that also
+                # covers the full prefix for a pure-context q-block.
+                seg_hi = max(ctx_end, min(q1, e))
+                lo = min(lo, s)
+                hi = max(hi, seg_hi)
+        if (
+            q1 > pad_start
+        ):  # block contains pad rows -> need their diagonal columns
+            has_pad = True
+        if lo == n and not has_pad:
+            # entirely outside all segments and no pad (should not happen) -> empty
+            kv_lo[qb] = 0
+            kv_hi[qb] = 0
+            continue
+        if has_pad:
+            lo = min(lo, q0)
+            hi = max(hi, q1)
+        kv_lo[qb] = lo // block_n
+        kv_hi[qb] = (hi + block_n - 1) // block_n
+
+    return kv_lo, kv_hi, num_q_blocks
+
+
+def build_block_plan_bwd_list(
+    layout: SegmentLayout, block_m: int, block_n: int
+) -> tuple[list[int], list[int], int]:
+    """Reverse-lookup the `[q_lo, q_hi)` q-block range to scan per KV block for dK/dV.
+
+    Symmetric to `build_block_plan_list`. The LO-side causal pruning mirrors the
+    forward HI-side pruning: a KV column in the query suffix is only seen by rows
+    with `q_idx >= k_idx`, so a pure query-suffix KV block is first reached from
+    its own first column rather than from the segment start; a KV block hitting
+    the context prefix is still reached by the whole segment (context is seen by
+    every row in the segment).
+    """
+    n = layout.seq_total
+    num_kv_blocks = (n + block_n - 1) // block_n
+    seg_start = layout.segment_starts
+    seg_ctx = layout.n_contexts
+    seg_ends = layout.segment_ends
+    pad_start = layout.pad_start
+
+    q_lo = [0] * num_kv_blocks
+    q_hi = [0] * num_kv_blocks
+
+    for kb in range(num_kv_blocks):
+        k0 = kb * block_n
+        k1 = min(k0 + block_n, n)
+        lo = n
+        hi = 0
+        has_pad = False
+        for s, nctx, e in zip(seg_start, seg_ctx, seg_ends):
+            if s < k1 and e > k0:
+                ctx_end = s + nctx
+                first_col = max(
+                    k0, s
+                )  # first KV column of this segment in the block
+                if first_col < ctx_end:
+                    # block hits this segment's context -> the whole segment reads it
+                    seg_lo = s
+                else:
+                    # pure query-suffix columns -> causal: reached only from that column on
+                    seg_lo = first_col
+                lo = min(lo, seg_lo)
+                hi = max(hi, e)
+        if k1 > pad_start:
+            has_pad = True
+        if lo == n and not has_pad:
+            q_lo[kb] = 0
+            q_hi[kb] = 0
+            continue
+        if has_pad:
+            lo = min(lo, k0)
+            hi = max(hi, k1)
+        q_lo[kb] = lo // block_m
+        q_hi[kb] = (hi + block_m - 1) // block_m
+
+    return q_lo, q_hi, num_kv_blocks
+
+
+def _tile_is_full(
+    seg_start: tuple[int, ...],
+    seg_ctx: tuple[int, ...],
+    seg_ends: tuple[int, ...],
+    n: int,
+    pad_start: int,
+    q0: int,
+    q1: int,
+    k0: int,
+    k1: int,
+) -> bool:
+    """Is every `(q, k)` pair in `[q0,q1) x [k0,k1)` allowed?
+
+    Pure integer test (O(#segments), no dense mask materialized). A tile is FULL
+    iff it is a complete in-range tile with no pad rows/columns, lies entirely
+    within a single segment `(s, nctx, e)` (no cross-segment pairs), and the
+    three-region predicate holds block-wise: either (A) the whole k-tile is
+    context (`k1 <= ctx_end`), or (B) the whole q-tile is query suffix
+    (`q0 >= ctx_end`) and the block is causally ordered (`q0 >= k1 - 1`). Tiles
+    that cross segments, exceed `seq_len`, or touch pad are always PARTIAL (the
+    conservative direction: only performance is lost, never correctness).
+
+    Note: mislabeling the other way (marking a partial tile FULL) would produce
+    a wrong result, so a tile is declared FULL only when it is provably safe.
+    """
+    if q1 > n or q1 > pad_start:  # out-of-range or pad-touching q-tile
+        return False
+    if k1 > n or k1 > pad_start:  # out-of-range or pad-touching kv-tile
+        return False
+    seg = None
+    for s, nctx, e in zip(seg_start, seg_ctx, seg_ends):
+        if s <= q0 and q1 <= e and s <= k0 and k1 <= e:
+            seg = (s, nctx)
+            break
+    if seg is None:  # crosses segments -> some pairs not allowed
+        return False
+    s, nctx = seg
+    ctx_end = s + nctx
+    if k1 <= ctx_end:  # case (A): the whole k-tile is context
+        return True
+    if (
+        q0 < ctx_end
+    ):  # some q rows are context -> they do not see query-suffix k
+        return False
+    return q0 >= k1 - 1  # case (B): all query suffix and block-wise causal
+
+
+def build_block_full_flags_list(
+    layout: SegmentLayout,
+    block_m: int,
+    block_n: int,
+    kv_lo: list[int],
+    kv_hi: list[int],
+) -> list[list[int]]:
+    """FULL(1)/partial(0) flag for each `(q-block, kv-block)` in the forward scan range.
+
+    Only tiles inside the forward scan range `[kv_lo, kv_hi)` are tested; tiles
+    outside are always 0 (the forward / dQ kernel never visits them).
+    """
+    n = layout.seq_total
+    num_q_blocks = (n + block_m - 1) // block_m
+    num_kv_blocks = (n + block_n - 1) // block_n
+    flags = [[0] * num_kv_blocks for _ in range(num_q_blocks)]
+
+    seg_start = layout.segment_starts
+    seg_ctx = layout.n_contexts
+    seg_ends = layout.segment_ends
+    pad_start = layout.pad_start
+
+    for qb in range(num_q_blocks):
+        q0 = qb * block_m
+        q1 = q0 + block_m
+        for blk in range(kv_lo[qb], kv_hi[qb]):
+            k0 = blk * block_n
+            k1 = k0 + block_n
+            if _tile_is_full(
+                seg_start, seg_ctx, seg_ends, n, pad_start, q0, q1, k0, k1
+            ):
+                flags[qb][blk] = 1
+    return flags
+
+
+def build_block_full_flags_bwd_list(
+    layout: SegmentLayout,
+    block_m: int,
+    block_n: int,
+    q_lo: list[int],
+    q_hi: list[int],
+) -> list[list[int]]:
+    """FULL/partial flags for the dK/dV scan range.
+
+    The FULL rule uses the same `_tile_is_full` and the same
+    `[num_q_blocks, num_kv_blocks]` shape indexed `[qb, kb]`, but fills the
+    reverse scan set: the dK/dV kernel loops KV-block outer / q-block inner, so
+    the set of `(qb, kb)` tiles it visits differs from the forward set (the
+    causal pruning is asymmetric) and must be computed separately. The dQ kernel
+    shares the forward scan order and reuses the forward flags directly.
+    """
+    n = layout.seq_total
+    num_q_blocks = (n + block_m - 1) // block_m
+    num_kv_blocks = (n + block_n - 1) // block_n
+    flags = [[0] * num_kv_blocks for _ in range(num_q_blocks)]
+
+    seg_start = layout.segment_starts
+    seg_ctx = layout.n_contexts
+    seg_ends = layout.segment_ends
+    pad_start = layout.pad_start
+
+    for kb in range(num_kv_blocks):
+        k0 = kb * block_n
+        k1 = k0 + block_n
+        for qb in range(q_lo[kb], q_hi[kb]):
+            q0 = qb * block_m
+            q1 = q0 + block_m
+            if _tile_is_full(
+                seg_start, seg_ctx, seg_ends, n, pad_start, q0, q1, k0, k1
+            ):
+                flags[qb][kb] = 1
+    return flags
+
+
+# ---------------------------------------------------------------------------
+# Pack into paddle.Tensor -- dtypes must be int32 / int8
+# ---------------------------------------------------------------------------
+
+
+def build_exec_plan(layout: SegmentLayout, block_m: int, block_n: int) -> dict:
+    """Build all integer arrays the kernel needs in one shot, as `paddle.Tensor`.
+
+    dtypes: segment / range arrays are `int32`, flags are `int8`. The kernel
+    dereferences by element type, so a wrong dtype silently reads wrong values
+    instead of raising.
+    """
+    import paddle
+
+    seg_start, seg_ctx = build_token_segment_arrays_list(layout)
+    kv_lo, kv_hi, n_q_blocks = build_block_plan_list(layout, block_m, block_n)
+    flags = build_block_full_flags_list(layout, block_m, block_n, kv_lo, kv_hi)
+    q_lo, q_hi, n_kv_blocks = build_block_plan_bwd_list(
+        layout, block_m, block_n
+    )
+    flags_bwd = build_block_full_flags_bwd_list(
+        layout, block_m, block_n, q_lo, q_hi
+    )
+
+    def _i32(v):
+        return paddle.to_tensor(v, dtype="int32")
+
+    def _i8(v):
+        return paddle.to_tensor(v, dtype="int8")
+
+    return {
+        "tok_seg_start": _i32(seg_start),
+        "tok_seg_ctx": _i32(seg_ctx),
+        "kv_lo": _i32(kv_lo),
+        "kv_hi": _i32(kv_hi),
+        "full_flags": _i8(flags),
+        "q_lo": _i32(q_lo),
+        "q_hi": _i32(q_hi),
+        "full_flags_bwd": _i8(flags_bwd),
+        "n_q_blocks": n_q_blocks,
+        "n_kv_blocks": n_kv_blocks,
+    }
+
+
+# ---------------------------------------------------------------------------
+# exec-plan LRU cache
+# ---------------------------------------------------------------------------
+
+# The plan is a pure function of `(layout, block_m, block_n)` plus one H2D copy.
+# Rebuilding it on every call costs ~2ms of Python loops + transfer (for a 4k
+# token pack) while the flash kernel itself is only ~0.05ms; with recompute
+# enabled each layer pays it twice. So the device-side tensors are memoized by
+# layout. The cache-size env var lets deployments tune the memory footprint.
+_PLAN_CACHE_MAX = int(
+    os.environ.get("HYPERBODY_TRITON_BLOCK_PLAN_CACHE_SIZE", "64")
+)
+_EXEC_PLAN_CACHE: OrderedDict[tuple, dict] = OrderedDict()
+
+
+def _layout_cache_key(
+    layout: SegmentLayout, block_m: int, block_n: int
+) -> tuple:
+    """Cache key for `(layout, block_m, block_n)`."""
+    return (
+        layout.segment_starts,
+        layout.n_contexts,
+        layout.n_queries,
+        layout.seq_total,
+        layout.pad_start,
+        block_m,
+        block_n,
+    )
+
+
+def get_exec_plan(layout: SegmentLayout, block_m: int, block_n: int) -> dict:
+    """Return the cached exec plan (device-side tensors), LRU-capped at `_PLAN_CACHE_MAX`."""
+    if _PLAN_CACHE_MAX <= 0:
+        return build_exec_plan(layout, block_m, block_n)
+    key = _layout_cache_key(layout, block_m, block_n)
+    val = _EXEC_PLAN_CACHE.get(key)
+    if val is not None:
+        _EXEC_PLAN_CACHE.move_to_end(key)
+        return val
+    val = build_exec_plan(layout, block_m, block_n)
+    _EXEC_PLAN_CACHE[key] = val
+    if len(_EXEC_PLAN_CACHE) > _PLAN_CACHE_MAX:
+        _EXEC_PLAN_CACHE.popitem(last=False)
+    return val
+
+
+# ---------------------------------------------------------------------------
+# Triton kernel loading (lazy)
+# ---------------------------------------------------------------------------
+
+_KERNEL_NAMES = (
+    "_prefix_lm_fwd_kernel",
+    "_prefix_lm_delta_kernel",
+    "_prefix_lm_dkdv_kernel",
+    "_prefix_lm_dq_kernel",
+)
+_KERNELS: dict | None = None
+
+
+def _kernels() -> dict:
+    """Lazily load the 4 kernels and wrap them with paddle's Triton compat decorator.
+
+    Loading is lazy for two reasons:
+    * the plan functions above are pure integer code and should remain
+      importable even when triton is not installed in the environment;
+    * `paddle.enable_compat(scope={"triton"})` must be called BEFORE
+      `import triton`, i.e. the torch-compat layer must be enabled before
+      importing triton.
+    """
+    global _KERNELS
+    if _KERNELS is None:
+        import paddle
+
+        from .utils import (
+            enable_compat_on_triton_kernel,
+            is_torch_compat_available,
+        )
+
+        if is_torch_compat_available():
+            paddle.enable_compat(scope={"triton"})
+
+        from . import prefix_lm_kernels as _pk
+
+        _KERNELS = {
+            n: enable_compat_on_triton_kernel(getattr(_pk, n))
+            for n in _KERNEL_NAMES
+        }
+    return _KERNELS
+
+
+def _st(x) -> tuple:
+    """Element-wise stride (paddle's `.strides` matches torch's `.stride()`)."""
+    return tuple(x.strides)
+
+
+# ---------------------------------------------------------------------------
+# Host-side wrappers for the forward / backward passes
+# ---------------------------------------------------------------------------
+
+
+# warps/stages are read from env vars: num_warps directly determines the
+# softmax reduction tree, so it (and num_stages) are configurable to tune the
+# launch configuration.
+def _fwd_launch() -> tuple[int, int]:
+    return (
+        int(os.environ.get("HYPERBODY_TRITON_FWD_WARPS", "4")),
+        int(os.environ.get("HYPERBODY_TRITON_FWD_STAGES", "2")),
+    )
+
+
+def _bwd_launch() -> tuple[int, int]:
+    return (
+        int(os.environ.get("HYPERBODY_TRITON_BWD_WARPS", "4")),
+        int(os.environ.get("HYPERBODY_TRITON_BWD_STAGES", "2")),
+    )
+
+
+def triton_prefix_lm_forward(
+    query,
+    key,
+    value,
+    layout: SegmentLayout,
+    *,
+    scale: float,
+    block_m: int = 64,
+    block_n: int = 64,
+    plan: dict | None = None,
+):
+    """Run the Triton prefix-LM flash forward.
+
+    Args:
+        query/key/value: `[B, H, T, D]`, ideally contiguous.
+        layout: packed segment layout (`T == seq_total`).
+        scale: softmax scale.
+        plan: output of `get_exec_plan`; if omitted it is built on the fly
+            (slower, same semantics).
+
+    Returns:
+        `(out, lse)`, where `out` is `[B,H,T,D]` and `lse` is `[B,H,T]` fp32.
+    """
+    import paddle
+
+    b, h, t, d = query.shape
+    if t != layout.seq_total:
+        raise ValueError(f"seq len {t} != layout.seq_total {layout.seq_total}")
+    p = plan if plan is not None else get_exec_plan(layout, block_m, block_n)
+
+    out = paddle.empty_like(query)
+    lse = paddle.empty([b, h, t], dtype="float32")
+    warps, stages = _fwd_launch()
+    _kernels()["_prefix_lm_fwd_kernel"][(p["n_q_blocks"], b * h)](
+        query,
+        key,
+        value,
+        out,
+        lse,
+        p["tok_seg_start"],
+        p["tok_seg_ctx"],
+        p["kv_lo"],
+        p["kv_hi"],
+        p["full_flags"],
+        *_st(query),
+        *_st(key),
+        *_st(value),
+        *_st(out),
+        *_st(lse),
+        *_st(p["full_flags"]),
+        t,
+        layout.pad_start,
+        scale,
+        H=h,
+        HEAD_DIM=d,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=warps,
+        num_stages=stages,
+    )
+    return out, lse
+
+
+def triton_prefix_lm_backward(
+    dout,
+    query,
+    key,
+    value,
+    out,
+    lse,
+    layout: SegmentLayout,
+    *,
+    scale: float,
+    block_m: int = 64,
+    block_n: int = 64,
+    plan: dict | None = None,
+):
+    """Run the Triton prefix-LM flash backward.
+
+    Three passes, no atomic accumulation: `delta` is independent per q-block;
+    `dk`/`dv` are owned exclusively by the KV-block-outer program (using
+    `q_lo`/`q_hi`/`full_flags_bwd`); `dq` is owned exclusively by the
+    q-block-outer program (reusing the forward `kv_lo`/`kv_hi`/`full_flags`).
+    The result is therefore deterministically reproducible.
+
+    Returns:
+        `(dq, dk, dv)`, same dtype as the inputs.
+    """
+    import paddle
+
+    b, h, t, d = query.shape
+    p = plan if plan is not None else get_exec_plan(layout, block_m, block_n)
+    ks = _kernels()
+
+    dout = dout.contiguous()
+    delta = paddle.empty([b, h, t], dtype="float32")
+    dq = paddle.empty_like(query)
+    dk = paddle.empty_like(key)
+    dv = paddle.empty_like(value)
+
+    ks["_prefix_lm_delta_kernel"][(p["n_q_blocks"], b * h)](
+        out,
+        dout,
+        delta,
+        *_st(out),
+        *_st(dout),
+        *_st(delta),
+        t,
+        H=h,
+        HEAD_DIM=d,
+        BLOCK_M=block_m,
+    )
+    warps, stages = _bwd_launch()
+    ks["_prefix_lm_dkdv_kernel"][(p["n_kv_blocks"], b * h)](
+        query,
+        key,
+        value,
+        dout,
+        lse,
+        delta,
+        dk,
+        dv,
+        p["tok_seg_start"],
+        p["tok_seg_ctx"],
+        p["q_lo"],
+        p["q_hi"],
+        p["full_flags_bwd"],
+        *_st(query),
+        *_st(key),
+        *_st(value),
+        *_st(dout),
+        *_st(lse),
+        *_st(delta),
+        *_st(dk),
+        *_st(dv),
+        *_st(p["full_flags_bwd"]),
+        t,
+        layout.pad_start,
+        scale,
+        H=h,
+        HEAD_DIM=d,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=warps,
+        num_stages=stages,
+    )
+    ks["_prefix_lm_dq_kernel"][(p["n_q_blocks"], b * h)](
+        query,
+        key,
+        value,
+        dout,
+        lse,
+        delta,
+        dq,
+        p["tok_seg_start"],
+        p["tok_seg_ctx"],
+        p["kv_lo"],
+        p["kv_hi"],
+        p["full_flags"],
+        *_st(query),
+        *_st(key),
+        *_st(value),
+        *_st(dout),
+        *_st(lse),
+        *_st(delta),
+        *_st(dq),
+        *_st(p["full_flags"]),
+        t,
+        layout.pad_start,
+        scale,
+        H=h,
+        HEAD_DIM=d,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=warps,
+        num_stages=stages,
+    )
+    return dq, dk, dv
+
+
+# ---------------------------------------------------------------------------
+# autograd wrapper + drop-in core-attention
+# ---------------------------------------------------------------------------
+
+
+def _attn_cls():
+    """Lazily build the `PyLayer` subclass -- defining it requires importing
+    paddle, while this module must stay usable in pure-integer mode."""
+    global _ATTN_CLS
+    if _ATTN_CLS is not None:
+        return _ATTN_CLS
+
+    import paddle
+
+    class _PrefixLMTritonAttn(paddle.autograd.PyLayer):
+        """Bind the Triton fwd/bwd into a single differentiable op.
+
+        The backward reads the layout from a non-tensor field on ctx rather than
+        any instance attribute: recompute reruns forward under `no_grad`, and
+        instance attributes are not recompute-safe.
+        """
+
+        @staticmethod
+        def forward(ctx, query, key, value, layout, scale, block_m, block_n):
+            plan = get_exec_plan(layout, block_m, block_n)
+            out, lse = triton_prefix_lm_forward(
+                query,
+                key,
+                value,
+                layout,
+                scale=scale,
+                block_m=block_m,
+                block_n=block_n,
+                plan=plan,
+            )
+            ctx.save_for_backward(query, key, value, out, lse)
+            ctx.layout = layout
+            ctx.scale = scale
+            ctx.block_m = block_m
+            ctx.block_n = block_n
+            # PyLayer contract: stop_gradient inputs must return None
+            ctx.needs_grad = (
+                not query.stop_gradient,
+                not key.stop_gradient,
+                not value.stop_gradient,
+            )
+            return out
+
+        @staticmethod
+        def backward(ctx, dout):
+            query, key, value, out, lse = ctx.saved_tensor()
+            dq, dk, dv = triton_prefix_lm_backward(
+                dout,
+                query,
+                key,
+                value,
+                out,
+                lse,
+                ctx.layout,
+                scale=ctx.scale,
+                block_m=ctx.block_m,
+                block_n=ctx.block_n,
+                plan=get_exec_plan(ctx.layout, ctx.block_m, ctx.block_n),
+            )
+            gq, gk, gv = ctx.needs_grad
+            # One gradient slot per TENSOR input, in order; layout/scale/block_*
+            # are non-tensors and do not occupy a slot.
+            return (dq if gq else None, dk if gk else None, dv if gv else None)
+
+    _ATTN_CLS = _PrefixLMTritonAttn
+    return _ATTN_CLS
+
+
+_ATTN_CLS = None
+
+
+def triton_prefix_lm_attention(
+    query,
+    key,
+    value,
+    layout: SegmentLayout,
+    *,
+    scale: float,
+    block_m: int = 64,
+    block_n: int = 64,
+):
+    """Differentiable Triton prefix-LM attention; inputs are `[B, H, T, D]`."""
+    return _attn_cls().apply(query, key, value, layout, scale, block_m, block_n)

--- a/src/paddlefleet/triton_ops/prefix_lm_kernels.py
+++ b/src/paddlefleet/triton_ops/prefix_lm_kernels.py
@@ -1,0 +1,669 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The 4 Triton kernels for packed prefix-LM attention.
+
+These are hand-tuned Triton kernels implementing packed prefix-LM flash
+attention: one forward kernel plus three backward kernels (delta, dK/dV, and
+dQ). The kernel bodies use only `triton` / `tl` and do not touch
+any deep-learning framework.
+
+Note: Triton's `@triton.jit` retrieves source code via `inspect`, so these
+kernels must live in a real `.py` file; defining them by `exec` on a string
+would raise
+`ValueError: @jit functions should be defined in a Python file`.
+"""
+
+import triton
+import triton.language as tl
+
+__all__ = [
+    "_prefix_lm_fwd_kernel",
+    "_prefix_lm_delta_kernel",
+    "_prefix_lm_dkdv_kernel",
+    "_prefix_lm_dq_kernel",
+]
+
+# ==== Triton kernels ====
+
+
+@triton.jit
+def _prefix_lm_fwd_kernel(
+    Q,
+    K,
+    V,
+    Out,
+    Lse,
+    seg_start_ptr,
+    seg_ctx_ptr,
+    kv_lo_ptr,
+    kv_hi_ptr,
+    full_ptr,
+    stride_qb,
+    stride_qh,
+    stride_qt,
+    stride_qd,
+    stride_kb,
+    stride_kh,
+    stride_kt,
+    stride_kd,
+    stride_vb,
+    stride_vh,
+    stride_vt,
+    stride_vd,
+    stride_ob,
+    stride_oh,
+    stride_ot,
+    stride_od,
+    stride_lb,
+    stride_lh,
+    stride_lt,
+    stride_fm,
+    stride_fn,
+    seq_len,
+    pad_start,
+    scale,
+    H: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Flash-attention forward with the packed prefix-LM three-region mask.
+
+    grid = (num_q_blocks, B * H). Online softmax in fp32; output cast to the
+    input dtype on store. ``Lse`` (m + log l, fp32) is saved for backward.
+
+    ``full_ptr`` is a per-``(q-block, kv-block)`` int8 flag (see
+    :func:`build_block_full_flags`): on a FULL block every pair is allowed,
+    so the whole three-region predicate, the two ``seg_start`` / ``seg_ctx``
+    loads, and both ``tl.where`` calls are skipped -- the compute/issue-side
+    overhead that dominates long single-segment forwards. Partial blocks run
+    the exact masked path. Both branches are numerically identical on the
+    blocks they handle (validated bit-for-bit vs the dense reference).
+    """
+
+    pid_m = tl.program_id(0)
+    pid_bh = tl.program_id(1)
+    b = pid_bh // H
+    h = pid_bh % H
+
+    q_offs = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    d_offs = tl.arange(0, HEAD_DIM)
+
+    q_base = Q + b * stride_qb + h * stride_qh
+    q_ptrs = q_base + q_offs[:, None] * stride_qt + d_offs[None, :] * stride_qd
+    q_mask = q_offs[:, None] < seq_len
+    # Keep Q/K/V in their native dtype (bf16 in training) so ``tl.dot`` runs
+    # on the bf16 tensor cores with an fp32 accumulator -- same numerics as
+    # flex_attention. Upcasting to fp32 here would force the non-tensor-core
+    # ieee path (~10-30x slower). For fp32 inputs (parity tests) the load
+    # stays fp32 and ``input_precision="ieee"`` keeps the dot exact.
+    q = tl.load(q_ptrs, mask=q_mask, other=0.0)
+
+    # per-q-row segment metadata
+    q_seg_start = tl.load(
+        seg_start_ptr + q_offs, mask=q_offs < seq_len, other=-1
+    )
+    q_seg_ctx = tl.load(seg_ctx_ptr + q_offs, mask=q_offs < seq_len, other=0)
+    q_local = q_offs - q_seg_start
+    q_in_ctx = q_local < q_seg_ctx
+    q_is_real = q_offs < pad_start
+
+    m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+
+    kv_lo = tl.load(kv_lo_ptr + pid_m)
+    kv_hi = tl.load(kv_hi_ptr + pid_m)
+
+    k_base = K + b * stride_kb + h * stride_kh
+    v_base = V + b * stride_vb + h * stride_vh
+    full_row = full_ptr + pid_m * stride_fm
+
+    for blk in range(kv_lo, kv_hi):
+        k_offs = blk * BLOCK_N + tl.arange(0, BLOCK_N)
+        k_valid = k_offs < seq_len
+        k_ptrs = (
+            k_base + k_offs[:, None] * stride_kt + d_offs[None, :] * stride_kd
+        )
+        k = tl.load(k_ptrs, mask=k_valid[:, None], other=0.0)
+
+        s = (
+            tl.dot(q, tl.trans(k), input_precision="ieee") * scale
+        )  # [BLOCK_M, BLOCK_N]
+
+        is_full = tl.load(full_row + blk * stride_fn) != 0
+        if is_full:
+            # FULL block: every pair allowed -> no predicate, no tl.where.
+            # ``build_block_full_flags`` only flags a block full when it is a
+            # complete in-range single-segment tile with no pad, so k_valid
+            # is all-true here too and needs no re-masking.
+            m_new = tl.maximum(m_i, tl.max(s, axis=1))
+            m_safe = tl.where(m_new == float("-inf"), 0.0, m_new)
+            p = tl.exp(s - m_safe[:, None])
+            alpha = tl.exp(m_i - m_safe)
+            alpha = tl.where(m_i == float("-inf"), 0.0, alpha)
+            l_i = l_i * alpha + tl.sum(p, axis=1)
+            v_ptrs = (
+                v_base
+                + k_offs[:, None] * stride_vt
+                + d_offs[None, :] * stride_vd
+            )
+            v = tl.load(v_ptrs, mask=k_valid[:, None], other=0.0)
+            acc = acc * alpha[:, None] + tl.dot(
+                p.to(v.dtype), v, input_precision="ieee"
+            )
+            m_i = m_new
+        else:
+            k_seg_start = tl.load(
+                seg_start_ptr + k_offs, mask=k_valid, other=-2
+            )
+            k_seg_ctx = tl.load(seg_ctx_ptr + k_offs, mask=k_valid, other=0)
+            k_local = k_offs - k_seg_start
+            k_in_ctx = k_local < k_seg_ctx
+            k_is_real = k_offs < pad_start
+
+            same_seg = (
+                (q_seg_start[:, None] == k_seg_start[None, :])
+                & q_is_real[:, None]
+                & k_is_real[None, :]
+            )
+            qc = q_in_ctx[:, None]
+            kc = k_in_ctx[None, :]
+            ge = q_local[:, None] >= k_local[None, :]
+            region = (qc & kc) | ((~qc) & kc) | ((~qc) & (~kc) & ge)
+            allow = same_seg & region
+            # pad diagonal self-loop: q in pad and q_idx == k_idx
+            pad_diag = (~q_is_real[:, None]) & (
+                q_offs[:, None] == k_offs[None, :]
+            )
+            allow = allow | pad_diag
+            allow = allow & k_valid[None, :]
+
+            s = tl.where(allow, s, float("-inf"))
+
+            m_new = tl.maximum(m_i, tl.max(s, axis=1))
+            m_safe = tl.where(m_new == float("-inf"), 0.0, m_new)
+            p = tl.exp(s - m_safe[:, None])
+            p = tl.where(allow, p, 0.0)
+            alpha = tl.exp(m_i - m_safe)
+            alpha = tl.where(m_i == float("-inf"), 0.0, alpha)
+            l_i = l_i * alpha + tl.sum(p, axis=1)
+            v_ptrs = (
+                v_base
+                + k_offs[:, None] * stride_vt
+                + d_offs[None, :] * stride_vd
+            )
+            v = tl.load(v_ptrs, mask=k_valid[:, None], other=0.0)
+            acc = acc * alpha[:, None] + tl.dot(
+                p.to(v.dtype), v, input_precision="ieee"
+            )
+            m_i = m_new
+
+    l_safe = tl.where(l_i == 0.0, 1.0, l_i)
+    out = acc / l_safe[:, None]
+    lse = tl.where(l_i == 0.0, float("-inf"), m_i + tl.log(l_safe))
+
+    o_base = Out + b * stride_ob + h * stride_oh
+    o_ptrs = o_base + q_offs[:, None] * stride_ot + d_offs[None, :] * stride_od
+    tl.store(
+        o_ptrs, out.to(Out.dtype.element_ty), mask=q_offs[:, None] < seq_len
+    )
+    l_base = Lse + b * stride_lb + h * stride_lh
+    tl.store(l_base + q_offs * stride_lt, lse, mask=q_offs < seq_len)
+
+
+@triton.jit
+def _prefix_lm_delta_kernel(
+    Out,
+    DOut,
+    Delta,
+    stride_ob,
+    stride_oh,
+    stride_ot,
+    stride_od,
+    stride_dob,
+    stride_doh,
+    stride_dot,
+    stride_dod,
+    stride_deb,
+    stride_deh,
+    stride_det,
+    seq_len,
+    H: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    """delta[i] = rowsum(dO[i] * O[i]); one fp32 scalar per query row."""
+
+    pid_m = tl.program_id(0)
+    pid_bh = tl.program_id(1)
+    b = pid_bh // H
+    h = pid_bh % H
+    offs = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    d_offs = tl.arange(0, HEAD_DIM)
+    valid = offs < seq_len
+
+    o_ptrs = (
+        Out
+        + b * stride_ob
+        + h * stride_oh
+        + offs[:, None] * stride_ot
+        + d_offs[None, :] * stride_od
+    )
+    do_ptrs = (
+        DOut
+        + b * stride_dob
+        + h * stride_doh
+        + offs[:, None] * stride_dot
+        + d_offs[None, :] * stride_dod
+    )
+    o = tl.load(o_ptrs, mask=valid[:, None], other=0.0).to(tl.float32)
+    do = tl.load(do_ptrs, mask=valid[:, None], other=0.0).to(tl.float32)
+    delta = tl.sum(o * do, axis=1)
+    tl.store(
+        Delta + b * stride_deb + h * stride_deh + offs * stride_det,
+        delta,
+        mask=valid,
+    )
+
+
+@triton.jit
+def _prefix_lm_dkdv_kernel(
+    Q,
+    K,
+    V,
+    DOut,
+    Lse,
+    Delta,
+    DK,
+    DV,
+    seg_start_ptr,
+    seg_ctx_ptr,
+    q_lo_ptr,
+    q_hi_ptr,
+    full_ptr,
+    stride_qb,
+    stride_qh,
+    stride_qt,
+    stride_qd,
+    stride_kb,
+    stride_kh,
+    stride_kt,
+    stride_kd,
+    stride_vb,
+    stride_vh,
+    stride_vt,
+    stride_vd,
+    stride_dob,
+    stride_doh,
+    stride_dot,
+    stride_dod,
+    stride_lb,
+    stride_lh,
+    stride_lt,
+    stride_deb,
+    stride_deh,
+    stride_det,
+    stride_dkb,
+    stride_dkh,
+    stride_dkt,
+    stride_dkd,
+    stride_dvb,
+    stride_dvh,
+    stride_dvt,
+    stride_dvd,
+    stride_fm,
+    stride_fn,
+    seq_len,
+    pad_start,
+    scale,
+    H: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Accumulate dK, dV for one KV block over its relevant Q blocks.
+
+    grid = (num_kv_blocks, B*H). Recomputes ``P = exp(scale*QKᵀ − lse)`` with
+    the same three-region mask as forward. ``dV = Pᵀ@dO``,
+    ``dS = P∘(dP−delta)`` with ``dP = dO@Vᵀ``, ``dK = scale·(dSᵀ@Q)``.
+
+    ``full_ptr`` is the int8 ``[num_q_blocks, num_kv_blocks]`` flag indexed
+    ``[qb, kb]`` (see :func:`build_block_full_flags_bwd`): on a FULL block
+    every pair is allowed, so the q-side ``seg_start`` / ``seg_ctx`` loads,
+    the three-region predicate, and both ``tl.where`` calls are skipped.
+    Partial blocks run the exact masked path; numerically identical per block.
+    """
+
+    pid_n = tl.program_id(0)
+    pid_bh = tl.program_id(1)
+    b = pid_bh // H
+    h = pid_bh % H
+
+    k_offs = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    d_offs = tl.arange(0, HEAD_DIM)
+    k_valid = k_offs < seq_len
+
+    k_ptrs = (
+        K
+        + b * stride_kb
+        + h * stride_kh
+        + k_offs[:, None] * stride_kt
+        + d_offs[None, :] * stride_kd
+    )
+    v_ptrs = (
+        V
+        + b * stride_vb
+        + h * stride_vh
+        + k_offs[:, None] * stride_vt
+        + d_offs[None, :] * stride_vd
+    )
+    k = tl.load(k_ptrs, mask=k_valid[:, None], other=0.0)
+    v = tl.load(v_ptrs, mask=k_valid[:, None], other=0.0)
+
+    k_seg_start = tl.load(seg_start_ptr + k_offs, mask=k_valid, other=-2)
+    k_seg_ctx = tl.load(seg_ctx_ptr + k_offs, mask=k_valid, other=0)
+    k_local = k_offs - k_seg_start
+    k_in_ctx = k_local < k_seg_ctx
+    k_is_real = k_offs < pad_start
+
+    dk = tl.zeros([BLOCK_N, HEAD_DIM], dtype=tl.float32)
+    dv = tl.zeros([BLOCK_N, HEAD_DIM], dtype=tl.float32)
+
+    q_lo = tl.load(q_lo_ptr + pid_n)
+    q_hi = tl.load(q_hi_ptr + pid_n)
+    full_col = full_ptr + pid_n * stride_fn
+
+    for blk in range(q_lo, q_hi):
+        q_offs = blk * BLOCK_M + tl.arange(0, BLOCK_M)
+        q_valid = q_offs < seq_len
+        q_ptrs = (
+            Q
+            + b * stride_qb
+            + h * stride_qh
+            + q_offs[:, None] * stride_qt
+            + d_offs[None, :] * stride_qd
+        )
+        q = tl.load(q_ptrs, mask=q_valid[:, None], other=0.0)
+        do_ptrs = (
+            DOut
+            + b * stride_dob
+            + h * stride_doh
+            + q_offs[:, None] * stride_dot
+            + d_offs[None, :] * stride_dod
+        )
+        do = tl.load(do_ptrs, mask=q_valid[:, None], other=0.0)
+        lse = tl.load(
+            Lse + b * stride_lb + h * stride_lh + q_offs * stride_lt,
+            mask=q_valid,
+            other=0.0,
+        )
+        delta = tl.load(
+            Delta + b * stride_deb + h * stride_deh + q_offs * stride_det,
+            mask=q_valid,
+            other=0.0,
+        )
+
+        s = (
+            tl.dot(q, tl.trans(k), input_precision="ieee") * scale
+        )  # [BLOCK_M, BLOCK_N]
+
+        is_full = tl.load(full_col + blk * stride_fm) != 0
+        if is_full:
+            # FULL block: every pair allowed -> no q-side seg loads, no
+            # predicate, no tl.where. ``build_block_full_flags_bwd`` only
+            # flags a block full when it is a complete in-range single-segment
+            # tile with no pad, so k_valid/q_valid are all-true here too.
+            p = tl.exp(s - lse[:, None])  # [BLOCK_M, BLOCK_N]
+            dv += tl.dot(tl.trans(p).to(do.dtype), do, input_precision="ieee")
+            dp = tl.dot(do, tl.trans(v), input_precision="ieee")
+            ds = p * (dp - delta[:, None])
+            dk += (
+                tl.dot(tl.trans(ds).to(q.dtype), q, input_precision="ieee")
+                * scale
+            )
+        else:
+            q_seg_start = tl.load(
+                seg_start_ptr + q_offs, mask=q_valid, other=-1
+            )
+            q_seg_ctx = tl.load(seg_ctx_ptr + q_offs, mask=q_valid, other=0)
+            q_local = q_offs - q_seg_start
+            q_in_ctx = q_local < q_seg_ctx
+            q_is_real = q_offs < pad_start
+
+            same_seg = (
+                (q_seg_start[:, None] == k_seg_start[None, :])
+                & q_is_real[:, None]
+                & k_is_real[None, :]
+            )
+            qc = q_in_ctx[:, None]
+            kc = k_in_ctx[None, :]
+            ge = q_local[:, None] >= k_local[None, :]
+            region = (qc & kc) | ((~qc) & kc) | ((~qc) & (~kc) & ge)
+            allow = same_seg & region
+            pad_diag = (~q_is_real[:, None]) & (
+                q_offs[:, None] == k_offs[None, :]
+            )
+            allow = (allow | pad_diag) & k_valid[None, :] & q_valid[:, None]
+
+            p = tl.where(
+                allow, tl.exp(s - lse[:, None]), 0.0
+            )  # [BLOCK_M, BLOCK_N]
+
+            # dV += Pᵀ @ dO
+            dv += tl.dot(tl.trans(p).to(do.dtype), do, input_precision="ieee")
+            # dP = dO @ Vᵀ ; dS = P∘(dP−delta) ; dK += scale·(dSᵀ@Q)
+            dp = tl.dot(do, tl.trans(v), input_precision="ieee")
+            ds = p * (dp - delta[:, None])
+            ds = tl.where(allow, ds, 0.0)
+            dk += (
+                tl.dot(tl.trans(ds).to(q.dtype), q, input_precision="ieee")
+                * scale
+            )
+
+    dk_ptrs = (
+        DK
+        + b * stride_dkb
+        + h * stride_dkh
+        + k_offs[:, None] * stride_dkt
+        + d_offs[None, :] * stride_dkd
+    )
+    dv_ptrs = (
+        DV
+        + b * stride_dvb
+        + h * stride_dvh
+        + k_offs[:, None] * stride_dvt
+        + d_offs[None, :] * stride_dvd
+    )
+    tl.store(dk_ptrs, dk.to(DK.dtype.element_ty), mask=k_valid[:, None])
+    tl.store(dv_ptrs, dv.to(DV.dtype.element_ty), mask=k_valid[:, None])
+
+
+@triton.jit
+def _prefix_lm_dq_kernel(
+    Q,
+    K,
+    V,
+    DOut,
+    Lse,
+    Delta,
+    DQ,
+    seg_start_ptr,
+    seg_ctx_ptr,
+    kv_lo_ptr,
+    kv_hi_ptr,
+    full_ptr,
+    stride_qb,
+    stride_qh,
+    stride_qt,
+    stride_qd,
+    stride_kb,
+    stride_kh,
+    stride_kt,
+    stride_kd,
+    stride_vb,
+    stride_vh,
+    stride_vt,
+    stride_vd,
+    stride_dob,
+    stride_doh,
+    stride_dot,
+    stride_dod,
+    stride_lb,
+    stride_lh,
+    stride_lt,
+    stride_deb,
+    stride_deh,
+    stride_det,
+    stride_dqb,
+    stride_dqh,
+    stride_dqt,
+    stride_dqd,
+    stride_fm,
+    stride_fn,
+    seq_len,
+    pad_start,
+    scale,
+    H: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Accumulate dQ for one Q block over its relevant KV blocks (no atomics).
+
+    grid = (num_q_blocks, B*H). ``dS = P∘(dP−delta)``, ``dQ = scale·(dS@K)``.
+
+    Shares the FORWARD scan orientation (per-q-block KV range), so it reuses
+    the forward ``full_flags`` indexed ``[pid_m, blk]``: on a FULL block the
+    k-side ``seg_start`` / ``seg_ctx`` loads, the predicate, and both
+    ``tl.where`` calls are skipped. Partial blocks run the exact masked path.
+    """
+
+    pid_m = tl.program_id(0)
+    pid_bh = tl.program_id(1)
+    b = pid_bh // H
+    h = pid_bh % H
+
+    q_offs = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    d_offs = tl.arange(0, HEAD_DIM)
+    q_valid = q_offs < seq_len
+
+    q_ptrs = (
+        Q
+        + b * stride_qb
+        + h * stride_qh
+        + q_offs[:, None] * stride_qt
+        + d_offs[None, :] * stride_qd
+    )
+    q = tl.load(q_ptrs, mask=q_valid[:, None], other=0.0)
+    do_ptrs = (
+        DOut
+        + b * stride_dob
+        + h * stride_doh
+        + q_offs[:, None] * stride_dot
+        + d_offs[None, :] * stride_dod
+    )
+    do = tl.load(do_ptrs, mask=q_valid[:, None], other=0.0)
+    lse = tl.load(
+        Lse + b * stride_lb + h * stride_lh + q_offs * stride_lt,
+        mask=q_valid,
+        other=0.0,
+    )
+    delta = tl.load(
+        Delta + b * stride_deb + h * stride_deh + q_offs * stride_det,
+        mask=q_valid,
+        other=0.0,
+    )
+
+    q_seg_start = tl.load(seg_start_ptr + q_offs, mask=q_valid, other=-1)
+    q_seg_ctx = tl.load(seg_ctx_ptr + q_offs, mask=q_valid, other=0)
+    q_local = q_offs - q_seg_start
+    q_in_ctx = q_local < q_seg_ctx
+    q_is_real = q_offs < pad_start
+
+    dq = tl.zeros([BLOCK_M, HEAD_DIM], dtype=tl.float32)
+
+    kv_lo = tl.load(kv_lo_ptr + pid_m)
+    kv_hi = tl.load(kv_hi_ptr + pid_m)
+    full_row = full_ptr + pid_m * stride_fm
+
+    for blk in range(kv_lo, kv_hi):
+        k_offs = blk * BLOCK_N + tl.arange(0, BLOCK_N)
+        k_valid = k_offs < seq_len
+        k_ptrs = (
+            K
+            + b * stride_kb
+            + h * stride_kh
+            + k_offs[:, None] * stride_kt
+            + d_offs[None, :] * stride_kd
+        )
+        v_ptrs = (
+            V
+            + b * stride_vb
+            + h * stride_vh
+            + k_offs[:, None] * stride_vt
+            + d_offs[None, :] * stride_vd
+        )
+        k = tl.load(k_ptrs, mask=k_valid[:, None], other=0.0)
+        v = tl.load(v_ptrs, mask=k_valid[:, None], other=0.0)
+
+        s = tl.dot(q, tl.trans(k), input_precision="ieee") * scale
+
+        is_full = tl.load(full_row + blk * stride_fn) != 0
+        if is_full:
+            # FULL block: every pair allowed -> no k-side seg loads, no
+            # predicate, no tl.where.
+            p = tl.exp(s - lse[:, None])
+            dp = tl.dot(do, tl.trans(v), input_precision="ieee")
+            ds = p * (dp - delta[:, None])
+            dq += tl.dot(ds.to(k.dtype), k, input_precision="ieee") * scale
+        else:
+            k_seg_start = tl.load(
+                seg_start_ptr + k_offs, mask=k_valid, other=-2
+            )
+            k_seg_ctx = tl.load(seg_ctx_ptr + k_offs, mask=k_valid, other=0)
+            k_local = k_offs - k_seg_start
+            k_in_ctx = k_local < k_seg_ctx
+            k_is_real = k_offs < pad_start
+
+            same_seg = (
+                (q_seg_start[:, None] == k_seg_start[None, :])
+                & q_is_real[:, None]
+                & k_is_real[None, :]
+            )
+            qc = q_in_ctx[:, None]
+            kc = k_in_ctx[None, :]
+            ge = q_local[:, None] >= k_local[None, :]
+            region = (qc & kc) | ((~qc) & kc) | ((~qc) & (~kc) & ge)
+            allow = same_seg & region
+            pad_diag = (~q_is_real[:, None]) & (
+                q_offs[:, None] == k_offs[None, :]
+            )
+            allow = (allow | pad_diag) & k_valid[None, :] & q_valid[:, None]
+
+            p = tl.where(allow, tl.exp(s - lse[:, None]), 0.0)
+            dp = tl.dot(do, tl.trans(v), input_precision="ieee")
+            ds = p * (dp - delta[:, None])
+            ds = tl.where(allow, ds, 0.0)
+            dq += tl.dot(ds.to(k.dtype), k, input_precision="ieee") * scale
+
+    dq_ptrs = (
+        DQ
+        + b * stride_dqb
+        + h * stride_dqh
+        + q_offs[:, None] * stride_dqt
+        + d_offs[None, :] * stride_dqd
+    )
+    tl.store(dq_ptrs, dq.to(DQ.dtype.element_ty), mask=q_valid[:, None])

--- a/tests/single_card_tests/models/hyperencoder/test_attn_backend.py
+++ b/tests/single_card_tests/models/hyperencoder/test_attn_backend.py
@@ -12,110 +12,72 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for the HyperEncoder attention-backend env switches."""
+"""Unit tests for the HyperEncoder attention-backend config helpers."""
 
-import os
+import types
 import unittest
-from contextlib import contextmanager
 
 from paddlefleet.models.hyperencoder import attn_backend
 
 
-@contextmanager
-def _env(**kv):
-    saved = {k: os.environ.get(k) for k in kv}
-    try:
-        for k, v in kv.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
-        yield
-    finally:
-        for k, v in saved.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
+def _cfg(**kw):
+    """A duck-typed config carrying only the hyperencoder_* fields under test."""
+    return types.SimpleNamespace(**kw)
 
 
 class TestEncoderAttnBackend(unittest.TestCase):
     def test_default_is_dp(self):
-        with _env(HYPERBODY_ENCODER_ATTN_BACKEND=None):
-            self.assertEqual(attn_backend.encoder_attn_backend(), "dp")
-            self.assertFalse(attn_backend.use_triton_encoder_attn())
+        # A config without the field falls back to the "dp" default.
+        self.assertEqual(attn_backend.encoder_attn_backend(_cfg()), "dp")
+        self.assertFalse(attn_backend.use_triton_encoder_attn(_cfg()))
 
     def test_triton_selected(self):
-        with _env(HYPERBODY_ENCODER_ATTN_BACKEND="triton"):
-            self.assertEqual(attn_backend.encoder_attn_backend(), "triton")
-            self.assertTrue(attn_backend.use_triton_encoder_attn())
+        c = _cfg(hyperencoder_attn_backend="triton")
+        self.assertEqual(attn_backend.encoder_attn_backend(c), "triton")
+        self.assertTrue(attn_backend.use_triton_encoder_attn(c))
 
     def test_case_insensitive(self):
-        with _env(HYPERBODY_ENCODER_ATTN_BACKEND="TRITON"):
-            self.assertEqual(attn_backend.encoder_attn_backend(), "triton")
+        c = _cfg(hyperencoder_attn_backend="TRITON")
+        self.assertEqual(attn_backend.encoder_attn_backend(c), "triton")
 
     def test_flex_raises(self):
-        with (
-            _env(HYPERBODY_ENCODER_ATTN_BACKEND="flex"),
-            self.assertRaises(ValueError),
-        ):
-            attn_backend.encoder_attn_backend()
+        with self.assertRaises(ValueError):
+            attn_backend.encoder_attn_backend(
+                _cfg(hyperencoder_attn_backend="flex")
+            )
 
     def test_unknown_backend_raises(self):
-        with (
-            _env(HYPERBODY_ENCODER_ATTN_BACKEND="nope"),
-            self.assertRaises(ValueError),
-        ):
-            attn_backend.encoder_attn_backend()
+        with self.assertRaises(ValueError):
+            attn_backend.encoder_attn_backend(
+                _cfg(hyperencoder_attn_backend="nope")
+            )
 
 
 class TestUsePackedDecoder(unittest.TestCase):
     def test_default_off(self):
-        with _env(
-            HYPERBODY_PACKED_FLEX_DECODER=None,
-            HYPERBODY_ENCODER_ATTN_BACKEND=None,
-        ):
-            self.assertFalse(attn_backend.use_packed_decoder())
+        self.assertFalse(attn_backend.use_packed_decoder(_cfg()))
 
     def test_on_with_triton(self):
-        with _env(
-            HYPERBODY_PACKED_FLEX_DECODER="1",
-            HYPERBODY_ENCODER_ATTN_BACKEND="triton",
-        ):
-            self.assertTrue(attn_backend.use_packed_decoder())
+        c = _cfg(
+            hyperencoder_packed_decoder=True,
+            hyperencoder_attn_backend="triton",
+        )
+        self.assertTrue(attn_backend.use_packed_decoder(c))
 
-    def test_truthy_variants(self):
-        for v in ("1", "true", "on", "TRUE", "On"):
-            with _env(
-                HYPERBODY_PACKED_FLEX_DECODER=v,
-                HYPERBODY_ENCODER_ATTN_BACKEND="triton",
-            ):
-                self.assertTrue(attn_backend.use_packed_decoder())
-
-    def test_falsy_variants(self):
-        for v in ("0", "false", "off"):
-            with _env(
-                HYPERBODY_PACKED_FLEX_DECODER=v,
-                HYPERBODY_ENCODER_ATTN_BACKEND="dp",
-            ):
-                self.assertFalse(attn_backend.use_packed_decoder())
-
-    def test_unknown_value_raises(self):
-        with (
-            _env(HYPERBODY_PACKED_FLEX_DECODER="maybe"),
-            self.assertRaises(ValueError),
-        ):
-            attn_backend.use_packed_decoder()
+    def test_off_with_dp(self):
+        c = _cfg(
+            hyperencoder_packed_decoder=False,
+            hyperencoder_attn_backend="dp",
+        )
+        self.assertFalse(attn_backend.use_packed_decoder(c))
 
     def test_on_without_triton_raises(self):
-        with (
-            _env(
-                HYPERBODY_PACKED_FLEX_DECODER="1",
-                HYPERBODY_ENCODER_ATTN_BACKEND="dp",
-            ),
-            self.assertRaises(RuntimeError),
-        ):
-            attn_backend.use_packed_decoder()
+        c = _cfg(
+            hyperencoder_packed_decoder=True,
+            hyperencoder_attn_backend="dp",
+        )
+        with self.assertRaises(RuntimeError):
+            attn_backend.use_packed_decoder(c)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/models/hyperencoder/test_attn_backend.py
+++ b/tests/single_card_tests/models/hyperencoder/test_attn_backend.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the HyperEncoder attention-backend env switches."""
+
+import os
+import unittest
+from contextlib import contextmanager
+
+from paddlefleet.models.hyperencoder import attn_backend
+
+
+@contextmanager
+def _env(**kv):
+    saved = {k: os.environ.get(k) for k in kv}
+    try:
+        for k, v in kv.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+class TestEncoderAttnBackend(unittest.TestCase):
+    def test_default_is_dp(self):
+        with _env(HYPERBODY_ENCODER_ATTN_BACKEND=None):
+            self.assertEqual(attn_backend.encoder_attn_backend(), "dp")
+            self.assertFalse(attn_backend.use_triton_encoder_attn())
+
+    def test_triton_selected(self):
+        with _env(HYPERBODY_ENCODER_ATTN_BACKEND="triton"):
+            self.assertEqual(attn_backend.encoder_attn_backend(), "triton")
+            self.assertTrue(attn_backend.use_triton_encoder_attn())
+
+    def test_case_insensitive(self):
+        with _env(HYPERBODY_ENCODER_ATTN_BACKEND="TRITON"):
+            self.assertEqual(attn_backend.encoder_attn_backend(), "triton")
+
+    def test_flex_raises(self):
+        with (
+            _env(HYPERBODY_ENCODER_ATTN_BACKEND="flex"),
+            self.assertRaises(ValueError),
+        ):
+            attn_backend.encoder_attn_backend()
+
+    def test_unknown_backend_raises(self):
+        with (
+            _env(HYPERBODY_ENCODER_ATTN_BACKEND="nope"),
+            self.assertRaises(ValueError),
+        ):
+            attn_backend.encoder_attn_backend()
+
+
+class TestUsePackedDecoder(unittest.TestCase):
+    def test_default_off(self):
+        with _env(
+            HYPERBODY_PACKED_FLEX_DECODER=None,
+            HYPERBODY_ENCODER_ATTN_BACKEND=None,
+        ):
+            self.assertFalse(attn_backend.use_packed_decoder())
+
+    def test_on_with_triton(self):
+        with _env(
+            HYPERBODY_PACKED_FLEX_DECODER="1",
+            HYPERBODY_ENCODER_ATTN_BACKEND="triton",
+        ):
+            self.assertTrue(attn_backend.use_packed_decoder())
+
+    def test_truthy_variants(self):
+        for v in ("1", "true", "on", "TRUE", "On"):
+            with _env(
+                HYPERBODY_PACKED_FLEX_DECODER=v,
+                HYPERBODY_ENCODER_ATTN_BACKEND="triton",
+            ):
+                self.assertTrue(attn_backend.use_packed_decoder())
+
+    def test_falsy_variants(self):
+        for v in ("0", "false", "off"):
+            with _env(
+                HYPERBODY_PACKED_FLEX_DECODER=v,
+                HYPERBODY_ENCODER_ATTN_BACKEND="dp",
+            ):
+                self.assertFalse(attn_backend.use_packed_decoder())
+
+    def test_unknown_value_raises(self):
+        with (
+            _env(HYPERBODY_PACKED_FLEX_DECODER="maybe"),
+            self.assertRaises(ValueError),
+        ):
+            attn_backend.use_packed_decoder()
+
+    def test_on_without_triton_raises(self):
+        with (
+            _env(
+                HYPERBODY_PACKED_FLEX_DECODER="1",
+                HYPERBODY_ENCODER_ATTN_BACKEND="dp",
+            ),
+            self.assertRaises(RuntimeError),
+        ):
+            attn_backend.use_packed_decoder()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/models/hyperencoder/test_init_exports.py
+++ b/tests/single_card_tests/models/hyperencoder/test_init_exports.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the HyperEncoder package re-exports."""
+
+import unittest
+
+import paddle  # noqa: F401
+
+
+class TestPackageExports(unittest.TestCase):
+    def test_all_names_are_exported(self):
+        from paddlefleet.models import hyperencoder
+
+        for name in hyperencoder.__all__:
+            self.assertTrue(
+                hasattr(hyperencoder, name),
+                f"{name} listed in __all__ but not importable",
+            )
+
+    def test_symbols_are_callable(self):
+        from paddlefleet.models.hyperencoder import (
+            AudioEncoderConv,
+            ImageEncoderConv,
+            MlpProjector,
+            PatchEmbed,
+            get_abs_pos_1d,
+            get_abs_pos_2d,
+            get_hyperencoder_block_spec,
+            get_hyperencoder_layer_specs,
+        )
+
+        for sym in (
+            AudioEncoderConv,
+            ImageEncoderConv,
+            MlpProjector,
+            PatchEmbed,
+            get_abs_pos_1d,
+            get_abs_pos_2d,
+            get_hyperencoder_block_spec,
+            get_hyperencoder_layer_specs,
+        ):
+            self.assertTrue(callable(sym))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/models/hyperencoder/test_layer_specs.py
+++ b/tests/single_card_tests/models/hyperencoder/test_layer_specs.py
@@ -14,10 +14,8 @@
 
 """Unit tests for the HyperEncoder layer-spec builders."""
 
-import os
 import types
 import unittest
-from contextlib import contextmanager
 from unittest import mock
 
 import paddle  # noqa: F401
@@ -33,24 +31,6 @@ from paddlefleet.models.hyperencoder.norm import (
 )
 
 
-@contextmanager
-def _env(**kv):
-    saved = {k: os.environ.get(k) for k in kv}
-    try:
-        for k, v in kv.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
-        yield
-    finally:
-        for k, v in saved.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
-
-
 def _cfg(**over):
     base = {
         "num_hidden_layers": 2,
@@ -58,6 +38,7 @@ def _cfg(**over):
         "n_routed_experts": 4,
         "moe_expert_fusion": True,
         "_attn_implementation": "eager",
+        "hyperencoder_attn_backend": "dp",
     }
     base.update(over)
     return types.SimpleNamespace(**base)
@@ -96,34 +77,28 @@ class TestIsMoeLayer(unittest.TestCase):
 
 class TestLayerSpecsEager(unittest.TestCase):
     def test_missing_eager_raises(self):
-        with _env(HYPERBODY_ENCODER_ATTN_BACKEND=None):
-            cfg = _cfg(_attn_implementation="sdpa")
-            with self.assertRaises(ValueError):
-                get_hyperencoder_layer_specs(cfg)
+        cfg = _cfg(_attn_implementation="sdpa")
+        with self.assertRaises(ValueError):
+            get_hyperencoder_layer_specs(cfg)
 
     def test_happy_path_replaces_norms(self):
-        with _env(HYPERBODY_ENCODER_ATTN_BACKEND=None):
-            cfg = _cfg()
-            with mock.patch.object(
-                layer_specs,
-                "get_gpt_layer_local_spec",
-                side_effect=lambda **kw: _make_spec(),
-            ) as build:
-                specs = get_hyperencoder_layer_specs(cfg)
-            self.assertEqual(len(specs), 2)
-            for s in specs:
-                self.assertIs(
-                    s.sublayers_spec.input_layernorm, HyperEncoderRMSNorm
-                )
-                self.assertIs(
-                    s.sublayers_spec.post_attention_layernorm,
-                    HyperEncoderRMSNorm,
-                )
-            # MoE layer index 1 should receive num_experts; index 0 should not.
-            num_experts = [
-                c.kwargs["num_experts"] for c in build.call_args_list
-            ]
-            self.assertEqual(num_experts, [None, 4])
+        cfg = _cfg()
+        with mock.patch.object(
+            layer_specs,
+            "get_gpt_layer_local_spec",
+            side_effect=lambda **kw: _make_spec(),
+        ) as build:
+            specs = get_hyperencoder_layer_specs(cfg)
+        self.assertEqual(len(specs), 2)
+        for s in specs:
+            self.assertIs(s.sublayers_spec.input_layernorm, HyperEncoderRMSNorm)
+            self.assertIs(
+                s.sublayers_spec.post_attention_layernorm,
+                HyperEncoderRMSNorm,
+            )
+        # MoE layer index 1 should receive num_experts; index 0 should not.
+        num_experts = [c.kwargs["num_experts"] for c in build.call_args_list]
+        self.assertEqual(num_experts, [None, 4])
 
 
 class TestLayerSpecsTriton(unittest.TestCase):
@@ -132,48 +107,43 @@ class TestLayerSpecsTriton(unittest.TestCase):
             PrefixLMTritonCore,
         )
 
-        with _env(HYPERBODY_ENCODER_ATTN_BACKEND="triton"):
-            cfg = _cfg()
-            with mock.patch.object(
-                layer_specs,
-                "get_gpt_layer_local_spec",
-                side_effect=lambda **kw: _make_spec(),
-            ):
-                specs = get_hyperencoder_layer_specs(cfg)
-            for s in specs:
-                self.assertIs(
-                    s.sublayers_spec.self_attn.sublayers_spec.core_attention,
-                    PrefixLMTritonCore,
-                )
+        cfg = _cfg(hyperencoder_attn_backend="triton")
+        with mock.patch.object(
+            layer_specs,
+            "get_gpt_layer_local_spec",
+            side_effect=lambda **kw: _make_spec(),
+        ):
+            specs = get_hyperencoder_layer_specs(cfg)
+        for s in specs:
+            self.assertIs(
+                s.sublayers_spec.self_attn.sublayers_spec.core_attention,
+                PrefixLMTritonCore,
+            )
 
     def test_triton_missing_core_attention_raises(self):
-        with _env(HYPERBODY_ENCODER_ATTN_BACKEND="triton"):
-            cfg = _cfg()
-            with (
-                mock.patch.object(
-                    layer_specs,
-                    "get_gpt_layer_local_spec",
-                    side_effect=lambda **kw: _make_spec(
-                        with_core_attention=False
-                    ),
-                ),
-                self.assertRaises(RuntimeError),
-            ):
-                get_hyperencoder_layer_specs(cfg)
+        cfg = _cfg(hyperencoder_attn_backend="triton")
+        with (
+            mock.patch.object(
+                layer_specs,
+                "get_gpt_layer_local_spec",
+                side_effect=lambda **kw: _make_spec(with_core_attention=False),
+            ),
+            self.assertRaises(RuntimeError),
+        ):
+            get_hyperencoder_layer_specs(cfg)
 
 
 class TestBlockSpec(unittest.TestCase):
     def test_block_spec_wraps_layers_and_final_norm(self):
-        with _env(HYPERBODY_ENCODER_ATTN_BACKEND=None):
-            cfg = _cfg()
-            with mock.patch.object(
-                layer_specs,
-                "get_gpt_layer_local_spec",
-                side_effect=lambda **kw: _make_spec(),
-            ):
-                block = get_hyperencoder_block_spec(cfg)
-            self.assertEqual(len(block.layer_specs), 2)
-            self.assertIs(block.layer_norm, HyperEncoderRMSNorm)
+        cfg = _cfg()
+        with mock.patch.object(
+            layer_specs,
+            "get_gpt_layer_local_spec",
+            side_effect=lambda **kw: _make_spec(),
+        ):
+            block = get_hyperencoder_block_spec(cfg)
+        self.assertEqual(len(block.layer_specs), 2)
+        self.assertIs(block.layer_norm, HyperEncoderRMSNorm)
 
 
 if __name__ == "__main__":

--- a/tests/single_card_tests/models/hyperencoder/test_layer_specs.py
+++ b/tests/single_card_tests/models/hyperencoder/test_layer_specs.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the HyperEncoder layer-spec builders."""
+
+import os
+import types
+import unittest
+from contextlib import contextmanager
+from unittest import mock
+
+import paddle  # noqa: F401
+
+from paddlefleet.models.hyperencoder import layer_specs
+from paddlefleet.models.hyperencoder.layer_specs import (
+    _is_moe_layer,
+    get_hyperencoder_block_spec,
+    get_hyperencoder_layer_specs,
+)
+from paddlefleet.models.hyperencoder.norm import (
+    HyperEncoderRMSNorm,
+)
+
+
+@contextmanager
+def _env(**kv):
+    saved = {k: os.environ.get(k) for k in kv}
+    try:
+        for k, v in kv.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _cfg(**over):
+    base = {
+        "num_hidden_layers": 2,
+        "moe_layer_freq": [0, 1],
+        "n_routed_experts": 4,
+        "moe_expert_fusion": True,
+        "_attn_implementation": "eager",
+    }
+    base.update(over)
+    return types.SimpleNamespace(**base)
+
+
+def _make_spec(with_core_attention=True):
+    """Fabricate a spec object shaped like get_gpt_layer_local_spec's return."""
+    sub = types.SimpleNamespace(
+        input_layernorm=None, post_attention_layernorm=None
+    )
+    if with_core_attention:
+        attn_sub = types.SimpleNamespace(core_attention=object())
+        sub.self_attn = types.SimpleNamespace(sublayers_spec=attn_sub)
+    else:
+        sub.self_attn = types.SimpleNamespace(
+            sublayers_spec=types.SimpleNamespace()
+        )
+    return types.SimpleNamespace(sublayers_spec=sub)
+
+
+class TestIsMoeLayer(unittest.TestCase):
+    def test_list(self):
+        cfg = types.SimpleNamespace(moe_layer_freq=[0, 1, 0])
+        self.assertFalse(_is_moe_layer(cfg, 0))
+        self.assertTrue(_is_moe_layer(cfg, 1))
+
+    def test_tuple(self):
+        cfg = types.SimpleNamespace(moe_layer_freq=(1, 0))
+        self.assertTrue(_is_moe_layer(cfg, 0))
+
+    def test_int_raises(self):
+        cfg = types.SimpleNamespace(moe_layer_freq=2)
+        with self.assertRaises(TypeError):
+            _is_moe_layer(cfg, 0)
+
+
+class TestLayerSpecsEager(unittest.TestCase):
+    def test_missing_eager_raises(self):
+        with _env(HYPERBODY_ENCODER_ATTN_BACKEND=None):
+            cfg = _cfg(_attn_implementation="sdpa")
+            with self.assertRaises(ValueError):
+                get_hyperencoder_layer_specs(cfg)
+
+    def test_happy_path_replaces_norms(self):
+        with _env(HYPERBODY_ENCODER_ATTN_BACKEND=None):
+            cfg = _cfg()
+            with mock.patch.object(
+                layer_specs,
+                "get_gpt_layer_local_spec",
+                side_effect=lambda **kw: _make_spec(),
+            ) as build:
+                specs = get_hyperencoder_layer_specs(cfg)
+            self.assertEqual(len(specs), 2)
+            for s in specs:
+                self.assertIs(
+                    s.sublayers_spec.input_layernorm, HyperEncoderRMSNorm
+                )
+                self.assertIs(
+                    s.sublayers_spec.post_attention_layernorm,
+                    HyperEncoderRMSNorm,
+                )
+            # MoE layer index 1 should receive num_experts; index 0 should not.
+            num_experts = [
+                c.kwargs["num_experts"] for c in build.call_args_list
+            ]
+            self.assertEqual(num_experts, [None, 4])
+
+
+class TestLayerSpecsTriton(unittest.TestCase):
+    def test_triton_installs_core_attention(self):
+        from paddlefleet.transformer.prefix_lm_triton_core import (
+            PrefixLMTritonCore,
+        )
+
+        with _env(HYPERBODY_ENCODER_ATTN_BACKEND="triton"):
+            cfg = _cfg()
+            with mock.patch.object(
+                layer_specs,
+                "get_gpt_layer_local_spec",
+                side_effect=lambda **kw: _make_spec(),
+            ):
+                specs = get_hyperencoder_layer_specs(cfg)
+            for s in specs:
+                self.assertIs(
+                    s.sublayers_spec.self_attn.sublayers_spec.core_attention,
+                    PrefixLMTritonCore,
+                )
+
+    def test_triton_missing_core_attention_raises(self):
+        with _env(HYPERBODY_ENCODER_ATTN_BACKEND="triton"):
+            cfg = _cfg()
+            with (
+                mock.patch.object(
+                    layer_specs,
+                    "get_gpt_layer_local_spec",
+                    side_effect=lambda **kw: _make_spec(
+                        with_core_attention=False
+                    ),
+                ),
+                self.assertRaises(RuntimeError),
+            ):
+                get_hyperencoder_layer_specs(cfg)
+
+
+class TestBlockSpec(unittest.TestCase):
+    def test_block_spec_wraps_layers_and_final_norm(self):
+        with _env(HYPERBODY_ENCODER_ATTN_BACKEND=None):
+            cfg = _cfg()
+            with mock.patch.object(
+                layer_specs,
+                "get_gpt_layer_local_spec",
+                side_effect=lambda **kw: _make_spec(),
+            ):
+                block = get_hyperencoder_block_spec(cfg)
+            self.assertEqual(len(block.layer_specs), 2)
+            self.assertIs(block.layer_norm, HyperEncoderRMSNorm)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/models/hyperencoder/test_modality_encoders.py
+++ b/tests/single_card_tests/models/hyperencoder/test_modality_encoders.py
@@ -154,5 +154,39 @@ class TestAudioEncoderConv(unittest.TestCase):
         self.assertIsNotNone(x.grad)
 
 
+class TestMuonSliceSpecs(unittest.TestCase):
+    """These modules intentionally do not expose a Muon slice-spec hook.
+
+    ``muon_slice_specs`` is only needed for weights that pack several logically
+    independent matrices into one tensor (fused QKV / gate-up / stacked experts).
+    None of these modules does: the projector is a single ``nn.Linear``, the
+    towers are ``Conv`` kernels plus non-matrix positional tables. Muon handles
+    them with its default per-weight update, so the hook is deliberately absent;
+    this assertion locks that decision in.
+    """
+
+    def test_no_slice_hook(self):
+        modules = [
+            MlpProjector(
+                {"projector_type": "linear", "input_dim": 4, "n_embed": 6}
+            ),
+            PatchEmbed(
+                kernel_size=(2, 2), stride=(2, 2), in_chans=3, embed_dim=8
+            ),
+            ImageEncoderConv(
+                img_size=8, patch_size=2, in_chans=3, embed_dim=8, out_chans=16
+            ),
+            AudioEncoderConv(
+                num_mel_bins=4, embed_dim=8, max_position_embeddings=64
+            ),
+        ]
+        for m in modules:
+            self.assertFalse(
+                hasattr(m, "muon_slice_specs"),
+                f"{type(m).__name__} unexpectedly declares muon_slice_specs; "
+                "if a fused weight was added, provide a real spec here.",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/models/hyperencoder/test_modality_encoders.py
+++ b/tests/single_card_tests/models/hyperencoder/test_modality_encoders.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the HyperEncoder image / audio modality towers."""
+
+import unittest
+
+import paddle
+
+# The accuracy-compatible conv path routes conv2d to a kernel registered only
+# for GPU; disable it so the towers exercise the standard kernel.
+paddle.set_flags({"FLAGS_use_accuracy_compatible_kernel": False})
+
+from paddlefleet.models.hyperencoder.modality_encoders import (
+    AudioEncoderConv,
+    ImageEncoderConv,
+    MlpProjector,
+    PatchEmbed,
+    get_abs_pos_1d,
+    get_abs_pos_2d,
+)
+
+
+class TestMlpProjector(unittest.TestCase):
+    def test_identity(self):
+        proj = MlpProjector(
+            {"projector_type": "identity", "input_dim": 4, "n_embed": 4}
+        )
+        x = paddle.randn([2, 4])
+        self.assertTrue(paddle.allclose(proj(x), x))
+
+    def test_linear_forward_and_backward(self):
+        proj = MlpProjector(
+            {"projector_type": "linear", "input_dim": 4, "n_embed": 6}
+        )
+        x = paddle.randn([3, 4])
+        x.stop_gradient = False
+        out = proj(x)
+        self.assertEqual(out.shape, [3, 6])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(proj.layers.weight.grad)
+        self.assertIsNotNone(proj.layers.bias.grad)
+
+    def test_mlp_gelu(self):
+        proj = MlpProjector(
+            {
+                "projector_type": "mlp_gelu",
+                "input_dim": 4,
+                "n_embed": 5,
+                "depth": 2,
+            }
+        )
+        x = paddle.randn([2, 4])
+        out = proj(x)
+        self.assertEqual(out.shape, [2, 5])
+
+    def test_unknown_type_raises(self):
+        with self.assertRaises(ValueError):
+            MlpProjector(
+                {"projector_type": "nope", "input_dim": 4, "n_embed": 4}
+            )
+
+    def test_linear_no_bias(self):
+        proj = MlpProjector(
+            {"projector_type": "linear", "input_dim": 4, "n_embed": 6}
+        )
+        proj.layers.bias = None
+        x = paddle.randn([3, 4])
+        out = proj(x)
+        self.assertEqual(out.shape, [3, 6])
+
+
+class TestPatchEmbed(unittest.TestCase):
+    def test_output_is_channel_last(self):
+        pe = PatchEmbed(
+            kernel_size=(2, 2), stride=(2, 2), in_chans=3, embed_dim=8
+        )
+        x = paddle.randn([1, 3, 4, 4])
+        out = pe(x)
+        # [B, H//2, W//2, embed_dim]
+        self.assertEqual(out.shape, [1, 2, 2, 8])
+
+
+class TestAbsPos2d(unittest.TestCase):
+    def test_short_circuit_when_sizes_match(self):
+        abs_pos = paddle.randn([1, 4, 4, 8])
+        out = get_abs_pos_2d(abs_pos, (4, 4))
+        self.assertTrue(out is abs_pos)
+
+    def test_interpolates_when_sizes_differ(self):
+        abs_pos = paddle.randn([1, 4, 4, 8])
+        out = get_abs_pos_2d(abs_pos, (2, 2))
+        self.assertEqual(out.shape, [1, 2, 2, 8])
+
+
+class TestAbsPos1d(unittest.TestCase):
+    def test_short_circuit_when_sizes_match(self):
+        abs_pos = paddle.randn([1, 10, 8])
+        out = get_abs_pos_1d(abs_pos, 10)
+        self.assertTrue(out is abs_pos)
+
+    def test_interpolates_when_sizes_differ(self):
+        abs_pos = paddle.randn([1, 10, 8])
+        out = get_abs_pos_1d(abs_pos, 5)
+        self.assertEqual(out.shape, [1, 5, 8])
+
+
+class TestImageEncoderConv(unittest.TestCase):
+    def test_forward_and_backward(self):
+        enc = ImageEncoderConv(
+            img_size=8, patch_size=2, in_chans=3, embed_dim=8, out_chans=16
+        )
+        x = paddle.randn([1, 3, 8, 8])
+        x.stop_gradient = False
+        out = enc(x)
+        # grid = 8 // 2 = 4
+        self.assertEqual(out.shape, [1, 4, 4, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+
+    def test_pos_embed_interpolated_when_grid_differs(self):
+        enc = ImageEncoderConv(
+            img_size=8, patch_size=2, in_chans=3, embed_dim=8, out_chans=16
+        )
+        # A 12x12 image -> 6x6 grid, forcing the pos-embed interpolation branch.
+        x = paddle.randn([1, 3, 12, 12])
+        out = enc(x)
+        self.assertEqual(out.shape, [1, 6, 6, 8])
+
+
+class TestAudioEncoderConv(unittest.TestCase):
+    def test_forward_and_backward(self):
+        enc = AudioEncoderConv(
+            num_mel_bins=4, embed_dim=8, max_position_embeddings=64
+        )
+        x = paddle.randn([1, 4, 20])
+        x.stop_gradient = False
+        out = enc(x)
+        # T' = (20 + 1) // 2 = 10 ; shape [B, 1, T', embed_dim]
+        self.assertEqual(out.shape, [1, 1, 10, 8])
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/models/hyperencoder/test_norm.py
+++ b/tests/single_card_tests/models/hyperencoder/test_norm.py
@@ -112,5 +112,13 @@ class TestForwardBackward(unittest.TestCase):
         self.assertTrue(paddle.allclose(norm.weight.grad, w2.grad, atol=1e-4))
 
 
+class TestMuonSliceSpecs(unittest.TestCase):
+    def test_no_slice_hook(self):
+        # weight is a 1-D RMSNorm scale (not a matrix): Muon leaves it to the
+        # AdamW group, so the module intentionally does not expose the hook.
+        norm = HyperEncoderRMSNorm(_cfg())
+        self.assertFalse(hasattr(norm, "muon_slice_specs"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/single_card_tests/models/hyperencoder/test_norm.py
+++ b/tests/single_card_tests/models/hyperencoder/test_norm.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for HyperEncoderRMSNorm."""
+
+import types
+import unittest
+
+import paddle
+
+from paddlefleet.models.hyperencoder.norm import (
+    HyperEncoderRMSNorm,
+)
+
+
+def _cfg(**over):
+    base = {
+        "hidden_size": 8,
+        "rms_norm_eps": 1e-6,
+        "normalization": "RMSNorm",
+        "layernorm_zero_centered_gamma": False,
+        "persist_layer_norm": False,
+        "params_dtype": paddle.float32,
+    }
+    base.update(over)
+    return types.SimpleNamespace(**base)
+
+
+class TestConstruction(unittest.TestCase):
+    def test_defaults_from_config(self):
+        norm = HyperEncoderRMSNorm(_cfg())
+        self.assertEqual(norm.normalized_shape, 8)
+        self.assertAlmostEqual(norm.variance_epsilon, 1e-6)
+        self.assertEqual(norm.weight.shape, [8])
+
+    def test_explicit_shape_and_eps(self):
+        norm = HyperEncoderRMSNorm(_cfg(), normalized_shape=4, norm_eps=1e-5)
+        self.assertEqual(norm.normalized_shape, 4)
+        self.assertAlmostEqual(norm.variance_epsilon, 1e-5)
+
+    def test_params_dtype_none_falls_back_to_default(self):
+        # params_dtype None -> weight dtype defaults to paddle's default dtype.
+        norm = HyperEncoderRMSNorm(_cfg(params_dtype=None))
+        self.assertEqual(norm.weight.shape, [8])
+
+    def test_non_rmsnorm_raises(self):
+        with self.assertRaises(ValueError):
+            HyperEncoderRMSNorm(_cfg(normalization="LayerNorm"))
+
+    def test_zero_centered_gamma_raises(self):
+        with self.assertRaises(ValueError):
+            HyperEncoderRMSNorm(_cfg(layernorm_zero_centered_gamma=True))
+
+    def test_persist_layer_norm_raises(self):
+        with self.assertRaises(ValueError):
+            HyperEncoderRMSNorm(_cfg(persist_layer_norm=True))
+
+    def test_input_is_parallel_marks_weight(self):
+        # Should not raise even when the SP helper is a no-op fallback.
+        norm = HyperEncoderRMSNorm(_cfg(), input_is_parallel=True)
+        self.assertIsNotNone(norm.weight)
+
+
+class TestForwardBackward(unittest.TestCase):
+    def test_forward_matches_reference(self):
+        norm = HyperEncoderRMSNorm(_cfg())
+        x = paddle.randn([2, 3, 8], dtype="float32")
+        out = norm(x)
+        ref = x * paddle.rsqrt(paddle.mean(x * x, axis=-1, keepdim=True) + 1e-6)
+        self.assertTrue(paddle.allclose(out, ref, atol=1e-5))
+        self.assertEqual(out.dtype, x.dtype)
+
+    def test_backward_produces_grads(self):
+        norm = HyperEncoderRMSNorm(_cfg())
+        x = paddle.randn([4, 8], dtype="float32")
+        x.stop_gradient = False
+        out = norm(x)
+        out.sum().backward()
+        self.assertIsNotNone(x.grad)
+        self.assertIsNotNone(norm.weight.grad)
+        self.assertEqual(x.grad.shape, x.shape)
+        self.assertEqual(norm.weight.grad.shape, norm.weight.shape)
+
+    def test_gradient_numeric_close(self):
+        eps = 1e-6
+        norm = HyperEncoderRMSNorm(_cfg(), norm_eps=eps)
+        norm.weight.set_value(paddle.randn([8], dtype="float32"))
+        x = paddle.randn([3, 8], dtype="float32")
+        x.stop_gradient = False
+        norm(x).sum().backward()
+        # Cross-check against the same expression built from plain paddle ops.
+        x2 = x.detach()
+        x2.stop_gradient = False
+        w2 = norm.weight.detach()
+        w2.stop_gradient = False
+        t1 = x2.astype("float32")
+        t5 = paddle.rsqrt(paddle.mean(t1 * t1, axis=-1, keepdim=True) + eps)
+        ref = (t1 * t5) * w2.astype("float32")
+        ref.sum().backward()
+        self.assertTrue(paddle.allclose(x.grad, x2.grad, atol=1e-4))
+        self.assertTrue(paddle.allclose(norm.weight.grad, w2.grad, atol=1e-4))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_prefix_lm_attention_parity.py
+++ b/tests/single_card_tests/transformer/test_prefix_lm_attention_parity.py
@@ -1,0 +1,173 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GPU numerical parity for the Triton packed prefix-LM attention.
+
+Unlike ``test_prefix_lm_triton_core.py`` (which stubs the kernel to check the
+host-side permute / guard logic on CPU), this test runs the *real* Triton
+forward and backward and compares them against an fp32 dense reference built
+from :func:`build_dense_mask`. It covers representative combinations of
+multi-segment packs, padding, dtype and block size.
+
+Requires a GPU with Triton; it skips cleanly otherwise.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import paddle
+import paddle.nn.functional as F
+
+from paddlefleet.transformer.prefix_lm_mask import (
+    build_dense_mask,
+    build_prefix_lm_layout,
+)
+
+_GPU = paddle.is_compiled_with_cuda() and paddle.device.cuda.device_count() > 0
+
+
+def _cos(a: np.ndarray, b: np.ndarray) -> float:
+    x, y = a.reshape(-1).astype(np.float64), b.reshape(-1).astype(np.float64)
+    denom = np.linalg.norm(x) * np.linalg.norm(y)
+    return float(x @ y / denom) if denom > 0 else 1.0
+
+
+def _dense_attention(q, k, v, forbidden, scale):
+    """fp32 dense reference. q/k/v: ``[B, H, T, D]``; forbidden ``[1,1,T,T]``."""
+    qf, kf, vf = (t.astype("float32") for t in (q, k, v))
+    score = paddle.matmul(qf, kf, transpose_y=True) * scale
+    neg_inf = paddle.full_like(score, float("-inf"))
+    score = paddle.where(forbidden, neg_inf, score)
+    prob = F.softmax(score, axis=-1)
+    return paddle.matmul(prob, vf)
+
+
+# (prefix_lens, suffix_lens, pad_len, block_m, block_n, dtype, description)
+# block_m == block_n throughout: block_m drives the softmax reduction tree and is
+# kept equal to block_n in practice (the production default is 64/64).
+_CASES = [
+    ([10], [64], 0, 64, 64, "bfloat16", "single segment, no pad"),
+    ([10], [64], 54, 64, 64, "bfloat16", "single segment + pad"),
+    (
+        [16, 24],
+        [32, 32],
+        24,
+        32,
+        32,
+        "bfloat16",
+        "two segments packed + pad, block 32",
+    ),
+    (
+        [5, 5, 5],
+        [8, 8, 8],
+        25,
+        32,
+        32,
+        "bfloat16",
+        "three segments + pad, block 32",
+    ),
+    ([0, 8], [16, 16], 0, 64, 64, "bfloat16", "first segment prefix=0"),
+    ([16, 24], [32, 32], 24, 64, 64, "float16", "two segments, fp16"),
+]
+
+_H, _D = 4, 64
+_MIN_COS_FWD, _MAX_ABS_FWD = 0.999, 3e-2
+_MIN_COS_BWD, _MAX_ABS_BWD = 0.99, 8e-2
+
+
+@unittest.skipUnless(_GPU, "Triton prefix-LM attention requires a GPU")
+class TestPrefixLMAttentionParity(unittest.TestCase):
+    def _run_case(self, prefix, suffix, pad, block_m, block_n, dtype):
+        from paddlefleet.triton_ops.prefix_lm_attention import (
+            layout_from_hyperbody_dict,
+            triton_prefix_lm_attention,
+        )
+
+        total = sum(int(c) + int(q) for c, q in zip(prefix, suffix))
+        tp = total + pad
+        scale = 1.0 / np.sqrt(_D)
+        layout = layout_from_hyperbody_dict(
+            build_prefix_lm_layout(prefix, suffix, pad), tp
+        )
+        forbidden = build_dense_mask(prefix, suffix, pad)
+
+        paddle.seed(20260911)
+        base = [paddle.randn([1, _H, tp, _D]).astype(dtype) for _ in range(3)]
+        gout = paddle.randn([1, _H, tp, _D]).astype(dtype)
+
+        # --- reference (fp32 dense) ---
+        rq, rk, rv = (t.detach() for t in base)
+        for t in (rq, rk, rv):
+            t.stop_gradient = False
+        ref_out = _dense_attention(rq, rk, rv, forbidden, scale)
+        (ref_out * gout.astype("float32")).sum().backward()
+
+        # --- triton kernel ---
+        tq, tk, tv = (t.detach() for t in base)
+        for t in (tq, tk, tv):
+            t.stop_gradient = False
+        got_out = triton_prefix_lm_attention(
+            tq, tk, tv, layout, scale=scale, block_m=block_m, block_n=block_n
+        )
+        (got_out * gout).sum().backward()
+
+        # Real-token region only: pad rows/cols are sliced off downstream.
+        def _slice(t):
+            return t.astype("float32").numpy()[:, :, :total]
+
+        checks = {
+            "out": (
+                _slice(ref_out),
+                _slice(got_out),
+                _MIN_COS_FWD,
+                _MAX_ABS_FWD,
+            ),
+            "dq": (
+                _slice(rq.grad),
+                _slice(tq.grad),
+                _MIN_COS_BWD,
+                _MAX_ABS_BWD,
+            ),
+            "dk": (
+                _slice(rk.grad),
+                _slice(tk.grad),
+                _MIN_COS_BWD,
+                _MAX_ABS_BWD,
+            ),
+            "dv": (
+                _slice(rv.grad),
+                _slice(tv.grad),
+                _MIN_COS_BWD,
+                _MAX_ABS_BWD,
+            ),
+        }
+        for name, (r, g, min_cos, max_abs) in checks.items():
+            cos, mabs = _cos(r, g), float(np.abs(r - g).max())
+            self.assertGreaterEqual(
+                cos, min_cos, f"{name}: cos={cos:.6f} (max_abs={mabs:.4f})"
+            )
+            self.assertLessEqual(
+                mabs, max_abs, f"{name}: max_abs={mabs:.4f} (cos={cos:.6f})"
+            )
+
+    def test_parity_cases(self):
+        for prefix, suffix, pad, bm, bn, dtype, desc in _CASES:
+            with self.subTest(desc=desc):
+                self._run_case(prefix, suffix, pad, bm, bn, dtype)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_prefix_lm_mask.py
+++ b/tests/single_card_tests/transformer/test_prefix_lm_mask.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the prefix-LM three-region mask representations."""
+
+import unittest
+
+import paddle
+
+from paddlefleet.transformer.prefix_lm_mask import (
+    build_dense_mask,
+    build_flashmask_row_indices,
+    build_prefix_lm_layout,
+    expand_layout_to_dense,
+    expand_row_indices_to_dense,
+    prefix_lm_pad_len,
+    prefix_lm_segment_starts,
+)
+
+
+class TestCheckLens(unittest.TestCase):
+    def test_mismatched_lengths(self):
+        with self.assertRaises(ValueError):
+            build_dense_mask([1, 2], [1])
+
+    def test_empty(self):
+        with self.assertRaises(ValueError):
+            build_dense_mask([], [])
+
+    def test_negative_prefix(self):
+        with self.assertRaises(ValueError):
+            build_dense_mask([-1], [2])
+
+    def test_non_positive_suffix(self):
+        with self.assertRaises(ValueError):
+            build_dense_mask([2], [0])
+
+    def test_negative_pad(self):
+        with self.assertRaises(ValueError):
+            build_dense_mask([2], [2], pad_len=-1)
+
+
+class TestSegmentStarts(unittest.TestCase):
+    def test_prefix_sum(self):
+        self.assertEqual(prefix_lm_segment_starts([2, 3], [1, 1]), [0, 3])
+
+
+class TestPadLen(unittest.TestCase):
+    def test_sp_disabled_uses_align(self):
+        # base = 1, align = 128 -> round up to 128
+        self.assertEqual(
+            prefix_lm_pad_len(100, tp_size=4, sequence_parallel=False), 28
+        )
+
+    def test_sp_enabled_uses_lcm(self):
+        # base = tp_size = 4, lcm(4, 128) = 128
+        self.assertEqual(
+            prefix_lm_pad_len(100, tp_size=4, sequence_parallel=True), 28
+        )
+
+    def test_already_aligned(self):
+        self.assertEqual(
+            prefix_lm_pad_len(128, tp_size=1, sequence_parallel=False), 0
+        )
+
+
+class TestBuildDenseMask(unittest.TestCase):
+    def test_shape_no_pad(self):
+        m = build_dense_mask([2], [2])
+        self.assertEqual(m.shape, [1, 1, 4, 4])
+        self.assertEqual(m.dtype, paddle.bool)
+
+    def test_zero_prefix_segment(self):
+        # c == 0 skips the prefix-open branch but still opens causal suffix.
+        m = build_dense_mask([0], [3])
+        self.assertEqual(m.shape, [1, 1, 3, 3])
+
+    def test_with_pad_self_loop(self):
+        m = build_dense_mask([2], [2], pad_len=2)
+        self.assertEqual(m.shape, [1, 1, 6, 6])
+        # pad rows only see themselves (diagonal is False = allowed).
+        self.assertFalse(bool(m[0, 0, 5, 5]))
+        self.assertTrue(bool(m[0, 0, 5, 0]))
+
+
+class TestFlashMaskRowIndices(unittest.TestCase):
+    def test_shape_no_pad(self):
+        ri = build_flashmask_row_indices([2], [2])
+        self.assertEqual(ri.shape, [1, 1, 4, 4])
+
+    def test_shape_with_pad(self):
+        ri = build_flashmask_row_indices([2], [2], pad_len=2)
+        self.assertEqual(ri.shape, [1, 1, 6, 4])
+
+
+class TestLayout(unittest.TestCase):
+    def test_fields(self):
+        layout = build_prefix_lm_layout([2, 1], [2, 1], pad_len=2)
+        self.assertEqual(layout["segment_starts"], (0, 4))
+        self.assertEqual(layout["n_contexts"], (2, 1))
+        self.assertEqual(layout["n_queries"], (2, 1))
+        self.assertEqual(layout["pad_len"], 2)
+
+
+class TestExpandRowIndices(unittest.TestCase):
+    def test_bad_shape_raises(self):
+        with self.assertRaises(ValueError):
+            expand_row_indices_to_dense(
+                paddle.zeros([1, 1, 4, 3], dtype="int32")
+            )
+
+    def test_expand_shape(self):
+        ri = build_flashmask_row_indices([2], [2])
+        dense = expand_row_indices_to_dense(ri)
+        self.assertEqual(dense.shape, [1, 1, 4, 4])
+
+
+class TestExpandLayout(unittest.TestCase):
+    def test_no_pad(self):
+        layout = build_prefix_lm_layout([2], [2])
+        dense = expand_layout_to_dense(layout)
+        self.assertEqual(dense.shape, [1, 1, 4, 4])
+
+    def test_with_pad(self):
+        layout = build_prefix_lm_layout([2], [2], pad_len=2)
+        dense = expand_layout_to_dense(layout)
+        self.assertEqual(dense.shape, [1, 1, 6, 6])
+
+
+class TestThreeRepresentationsAgree(unittest.TestCase):
+    """The three representations must expand to a bit-identical dense mask."""
+
+    def _check(self, prefix_lens, suffix_lens, pad_len):
+        dense = build_dense_mask(prefix_lens, suffix_lens, pad_len)
+        via_ri = expand_row_indices_to_dense(
+            build_flashmask_row_indices(prefix_lens, suffix_lens, pad_len)
+        )
+        via_layout = expand_layout_to_dense(
+            build_prefix_lm_layout(prefix_lens, suffix_lens, pad_len)
+        )
+        self.assertTrue(bool((dense == via_ri).all()))
+        self.assertTrue(bool((dense == via_layout).all()))
+
+    def test_single_segment_no_pad(self):
+        self._check([3], [2], 0)
+
+    def test_multi_segment_with_pad(self):
+        self._check([2, 3], [2, 1], 4)
+
+    def test_zero_prefix(self):
+        self._check([0, 2], [3, 2], 2)
+
+
+class TestExplicitPlace(unittest.TestCase):
+    """Exercise the optional ``place`` argument on the tensor builders."""
+
+    def setUp(self):
+        # Use whatever place the default tensor lives on, so the test is
+        # agnostic to CPU/GPU execution.
+        self.place = paddle.zeros([1]).place
+
+    def test_dense_mask_with_place(self):
+        m = build_dense_mask([2], [2], pad_len=2, place=self.place)
+        self.assertEqual(m.shape, [1, 1, 6, 6])
+
+    def test_row_indices_with_place(self):
+        ri = build_flashmask_row_indices([2], [2], pad_len=2, place=self.place)
+        self.assertEqual(ri.shape, [1, 1, 6, 4])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/transformer/test_prefix_lm_triton_core.py
+++ b/tests/single_card_tests/transformer/test_prefix_lm_triton_core.py
@@ -19,10 +19,8 @@ it is replaced with a stub so the surrounding permute / reshape / guard logic
 can be validated deterministically on CPU.
 """
 
-import os
 import types
 import unittest
-from contextlib import contextmanager
 from unittest import mock
 
 import paddle
@@ -35,30 +33,14 @@ from paddlefleet.transformer.prefix_lm_triton_core import (
 )
 
 
-@contextmanager
-def _env(**kv):
-    saved = {k: os.environ.get(k) for k in kv}
-    try:
-        for k, v in kv.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
-        yield
-    finally:
-        for k, v in saved.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
-
-
-def _cfg(head_dim=None, hidden_size=32, num_attention_heads=4):
-    return types.SimpleNamespace(
-        head_dim=head_dim,
-        hidden_size=hidden_size,
-        num_attention_heads=num_attention_heads,
-    )
+def _cfg(head_dim=None, hidden_size=32, num_attention_heads=4, **over):
+    base = {
+        "head_dim": head_dim,
+        "hidden_size": hidden_size,
+        "num_attention_heads": num_attention_heads,
+    }
+    base.update(over)
+    return types.SimpleNamespace(**base)
 
 
 def _psp(layout=None):
@@ -88,11 +70,33 @@ class TestInit(unittest.TestCase):
         core = PrefixLMTritonCore(_cfg(head_dim=8), softmax_scale=0.5)
         self.assertAlmostEqual(core.softmax_scale, 0.5)
 
-    def test_block_sizes_from_env(self):
-        with _env(HYPERBODY_TRITON_BLOCK_M="32", HYPERBODY_TRITON_BLOCK_N="16"):
-            core = PrefixLMTritonCore(_cfg(head_dim=8))
-            self.assertEqual(core.block_m, 32)
-            self.assertEqual(core.block_n, 16)
+    def test_block_sizes_default(self):
+        core = PrefixLMTritonCore(_cfg(head_dim=8))
+        self.assertEqual(core.block_m, 64)
+        self.assertEqual(core.block_n, 64)
+        self.assertEqual(core.fwd_warps, 4)
+        self.assertEqual(core.plan_cache_size, 64)
+
+    def test_tuning_from_config(self):
+        core = PrefixLMTritonCore(
+            _cfg(
+                head_dim=8,
+                hyperencoder_triton_block_m=32,
+                hyperencoder_triton_block_n=16,
+                hyperencoder_triton_fwd_warps=8,
+                hyperencoder_triton_fwd_stages=3,
+                hyperencoder_triton_bwd_warps=2,
+                hyperencoder_triton_bwd_stages=1,
+                hyperencoder_triton_plan_cache_size=0,
+            )
+        )
+        self.assertEqual(core.block_m, 32)
+        self.assertEqual(core.block_n, 16)
+        self.assertEqual(core.fwd_warps, 8)
+        self.assertEqual(core.fwd_stages, 3)
+        self.assertEqual(core.bwd_warps, 2)
+        self.assertEqual(core.bwd_stages, 1)
+        self.assertEqual(core.plan_cache_size, 0)
 
     def test_context_parallel_rejected(self):
         cp = types.SimpleNamespace(nranks=2)
@@ -174,9 +178,12 @@ class TestForwardHappyPath(unittest.TestCase):
         b, s, n, d = 1, 4, 4, 8
         q = paddle.randn([b, s, n, d])
 
-        def fake_kernel(qt, kt, vt, layout, scale, block_m, block_n):
+        def fake_kernel(qt, kt, vt, layout, scale, block_m, block_n, **kw):
             # kernel operates on [B, N, S, D]; echo the shape back.
             self.assertEqual(qt.shape, [b, n, s, d])
+            # tuning knobs are forwarded from config as keyword args.
+            self.assertIn("fwd_warps", kw)
+            self.assertIn("plan_cache_size", kw)
             return paddle.zeros([b, n, s, d], dtype=qt.dtype)
 
         with (

--- a/tests/single_card_tests/transformer/test_prefix_lm_triton_core.py
+++ b/tests/single_card_tests/transformer/test_prefix_lm_triton_core.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the PrefixLMTritonCore host-side logic.
+
+The Triton kernel launch itself is exercised on GPU by the parity tests; here
+it is replaced with a stub so the surrounding permute / reshape / guard logic
+can be validated deterministically on CPU.
+"""
+
+import os
+import types
+import unittest
+from contextlib import contextmanager
+from unittest import mock
+
+import paddle
+
+from paddlefleet.transformer import (
+    prefix_lm_triton_core as core_mod,
+)
+from paddlefleet.transformer.prefix_lm_triton_core import (
+    PrefixLMTritonCore,
+)
+
+
+@contextmanager
+def _env(**kv):
+    saved = {k: os.environ.get(k) for k in kv}
+    try:
+        for k, v in kv.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def _cfg(head_dim=None, hidden_size=32, num_attention_heads=4):
+    return types.SimpleNamespace(
+        head_dim=head_dim,
+        hidden_size=hidden_size,
+        num_attention_heads=num_attention_heads,
+    )
+
+
+def _psp(layout=None):
+    if layout is None:
+        layout = {
+            "segment_starts": (0,),
+            "n_contexts": (2,),
+            "n_queries": (2,),
+            "pad_len": 0,
+        }
+    return types.SimpleNamespace(prefix_lm_layout=layout)
+
+
+class TestInit(unittest.TestCase):
+    def test_head_dim_from_config(self):
+        core = PrefixLMTritonCore(_cfg(head_dim=8))
+        self.assertEqual(core.head_dim, 8)
+        self.assertAlmostEqual(core.softmax_scale, 1.0 / (8**0.5))
+
+    def test_head_dim_derived(self):
+        core = PrefixLMTritonCore(
+            _cfg(head_dim=None, hidden_size=32, num_attention_heads=4)
+        )
+        self.assertEqual(core.head_dim, 8)
+
+    def test_softmax_scale_override(self):
+        core = PrefixLMTritonCore(_cfg(head_dim=8), softmax_scale=0.5)
+        self.assertAlmostEqual(core.softmax_scale, 0.5)
+
+    def test_block_sizes_from_env(self):
+        with _env(HYPERBODY_TRITON_BLOCK_M="32", HYPERBODY_TRITON_BLOCK_N="16"):
+            core = PrefixLMTritonCore(_cfg(head_dim=8))
+            self.assertEqual(core.block_m, 32)
+            self.assertEqual(core.block_n, 16)
+
+    def test_context_parallel_rejected(self):
+        cp = types.SimpleNamespace(nranks=2)
+        pg = types.SimpleNamespace(cp=cp)
+        with self.assertRaises(RuntimeError):
+            PrefixLMTritonCore(_cfg(head_dim=8), pg_collection=pg)
+
+    def test_context_parallel_size_one_ok(self):
+        cp = types.SimpleNamespace(nranks=1)
+        pg = types.SimpleNamespace(cp=cp)
+        core = PrefixLMTritonCore(_cfg(head_dim=8), pg_collection=pg)
+        self.assertEqual(core.context_parallel_size, 1)
+
+
+class TestResolveLayout(unittest.TestCase):
+    def test_non_dict_raises(self):
+        core = PrefixLMTritonCore(_cfg(head_dim=8))
+        with self.assertRaises(RuntimeError):
+            core._resolve_layout(4, _psp(layout="not-a-dict"))
+
+    def test_none_params_raises(self):
+        core = PrefixLMTritonCore(_cfg(head_dim=8))
+        with self.assertRaises(RuntimeError):
+            core._resolve_layout(4, None)
+
+    def test_cache_miss_then_hit(self):
+        core = PrefixLMTritonCore(_cfg(head_dim=8))
+        sentinel = object()
+        with mock.patch.object(
+            core_mod, "layout_from_hyperbody_dict", return_value=sentinel
+        ) as builder:
+            first = core._resolve_layout(4, _psp())
+            second = core._resolve_layout(4, _psp())
+        self.assertIs(first, sentinel)
+        self.assertIs(second, sentinel)
+        # Second call must be served from the module cache, not rebuilt.
+        builder.assert_called_once()
+
+
+class TestForwardGuards(unittest.TestCase):
+    def setUp(self):
+        self.core = PrefixLMTritonCore(_cfg(head_dim=8))
+
+    def test_attention_bias_rejected(self):
+        q = paddle.randn([1, 4, 4, 8])
+        with self.assertRaises(ValueError):
+            self.core.forward(q, q, q, attention_bias=q)
+
+    def test_attention_mask_rejected(self):
+        q = paddle.randn([1, 4, 4, 8])
+        with self.assertRaises(ValueError):
+            self.core.forward(q, q, q, attention_mask=paddle.ones([1, 1, 4, 4]))
+
+    def test_row_indices_rejected(self):
+        q = paddle.randn([1, 4, 4, 8])
+        with self.assertRaises(ValueError):
+            self.core.forward(
+                q,
+                q,
+                q,
+                attn_mask_startend_row_indices=paddle.zeros([1, 1, 4, 4]),
+            )
+
+    def test_non_4d_rejected(self):
+        q = paddle.randn([4, 4, 8])
+        with self.assertRaises(ValueError):
+            self.core.forward(q, q, q)
+
+    def test_gqa_rejected(self):
+        q = paddle.randn([1, 4, 4, 8])  # 4 heads
+        k = paddle.randn([1, 4, 2, 8])  # 2 heads
+        with self.assertRaises(ValueError):
+            self.core.forward(q, k, k, packed_seq_params=_psp())
+
+
+class TestForwardHappyPath(unittest.TestCase):
+    def test_permute_reshape_around_kernel(self):
+        core = PrefixLMTritonCore(_cfg(head_dim=8))
+        b, s, n, d = 1, 4, 4, 8
+        q = paddle.randn([b, s, n, d])
+
+        def fake_kernel(qt, kt, vt, layout, scale, block_m, block_n):
+            # kernel operates on [B, N, S, D]; echo the shape back.
+            self.assertEqual(qt.shape, [b, n, s, d])
+            return paddle.zeros([b, n, s, d], dtype=qt.dtype)
+
+        with (
+            mock.patch.object(
+                core_mod, "triton_prefix_lm_attention", side_effect=fake_kernel
+            ),
+            mock.patch.object(
+                core_mod, "layout_from_hyperbody_dict", return_value=object()
+            ),
+        ):
+            out = core.forward(q, q, q, packed_seq_params=_psp())
+        # [B, N, S, D] -> [B, S, N*D]
+        self.assertEqual(out.shape, [b, s, n * d])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- TemplateReference: https://github.com/PaddlePaddle/Paddle/wiki/PULL-REQUEST-TEMPLATE--REFERENCE -->

### PR Category
<!-- One of [ User Experience | Execute Infrastructure | Operator Mechanism | Performance Optimization | Distributed Strategy | Parameter Server | Communication Library | Environment Adaptation ] -->
Execute Infrastructure

### PR Types
<!-- One of [ New features | Bug fixes | Improvements | Performance | BC Breaking | Deprecations | Docs | Devs | Not User Facing | Security | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

  新增 HyperBody 多模态编码器 **HyperEncoder** 到 PaddleFleet（组网 + packed prefix-LM 注意力）。除在 `TransformerConfig`
  增加两个**可选**配置字段外，其余均为新增文件，不改动任何既有算子/模型的计算路径。

  **新增内容**
  - `models/hyperencoder/`：主干 layer specs（12 层 MoE decoder，按 `moe_layer_freq` 逐层选 dense/MoE）、图/音模态塔（`PatchEmbed` / `ImageEncoderConv` / `AudioEncoderConv` /
  `MlpProjector`）、恒定 fp32 累加的 `HyperEncoderRMSNorm`，以及注意力后端选择 `attn_backend`。
  - `transformer/prefix_lm_mask.py`：prefix-LM 三区掩码的三种等价表示（dense / FlashMask 列稀疏 / 几何 layout）及其展开器（供单测交叉校验）。
  - `transformer/prefix_lm_triton_core.py` + `triton_ops/prefix_lm_{attention,kernels}.py`：packed prefix-LM 的 Triton core-attention（前向 + 确定性反向，无 atomic 累加），作为
  `core_attention` 的 drop-in。

  **配置字段**
  在 `TransformerConfig` 上新增两个**可选、带默认值**的字段（其他模型不读取、行为不变）：`hyperencoder_attn_backend`（dp/triton）、`hyperencoder_packed_decoder`（packed 须配
  triton）；在 HyperEncoder 配置的 `__post_init__` 统一校验并随 config 落盘。Triton 内核的 block / warps / stages / plan-cache
  为内核默认值（64/64、4/2、64），不作为配置开关暴露——原先分散的 `HYPERBODY_*` 环境变量读取全部移除。

  **测试**
  掩码三表示一致性、模态塔前/反向、RMSNorm 前/反向、layer specs、attn-backend 配置校验、Triton-core host 逻辑；并新增 GPU 上真实 Triton 前向/反向 vs fp32 dense 参照的数值
  parity（覆盖多 segment / padding / dtype(bf16,fp16) / block size）。新增代码覆盖率 ≥90%（`triton_ops/**` 按门禁 diff 规则排除）。

  ### 是否引起精度变化

  否。新增内容为独立文件；对 `TransformerConfig` 仅新增**带默认值的可选字段**，其他模型不读取、行为不变。默认配置（`dp` 后端、非
  packed）走标准注意力路径，不触及任何既有算子/模型的数值；精度对齐相关行为由开关门控、在本 PR 中默认关闭。