### PR TITLE
[Models] Add HyperBody decoder layer specs

### DIFF
--- a/src/paddlefleet/models/hyperbody_decoder/__init__.py
+++ b/src/paddlefleet/models/hyperbody_decoder/__init__.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HyperBody decoder 在 PaddleFleet 侧的部分：**只提供组件**。
+
+分工与参考实现 ``fleet_formers`` 的 hyperencoder 一致：
+
+| 侧 | 内容 |
+|---|---|
+| **PaddleFleet（本包）** | ``layer_specs.py`` —— 12 层 backbone 的 ``LayerSpec`` 列表 / block spec |
+| PaddleFormers ``transformers/hyperbody_decoder/`` | HF-style config → ``GPTConfig`` 的转换 + 组网装配 + 顶层 Model |
+
+几何常量与 ``GPTConfig`` 的装配**不在这里** —— 它们属于「HF-style config 到
+GPTConfig 的转换」这一职责，全部收在 formers 的 ``configuration.py`` /
+``modeling.py``。这与 hyperencoder 那边 ``build_hyperencoder_config`` 位于
+``PaddleFormers/paddleformers/transformers/hyperencoder/configuration.py``
+是同一个约定。
+"""
+
+from .layer_specs import (
+    get_hyperbody_decoder_block_spec,
+    get_hyperbody_decoder_layer_specs,
+)
+
+__all__ = [
+    "get_hyperbody_decoder_block_spec",
+    "get_hyperbody_decoder_layer_specs",
+]

--- a/src/paddlefleet/models/hyperbody_decoder/__init__.py
+++ b/src/paddlefleet/models/hyperbody_decoder/__init__.py
@@ -12,20 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""HyperBody decoder 在 PaddleFleet 侧的部分：**只提供组件**。
+"""The PaddleFleet side of the HyperBody decoder: **components only**.
 
-分工与参考实现 ``fleet_formers`` 的 hyperencoder 一致：
-
-| 侧 | 内容 |
+| Side | Contents |
 |---|---|
-| **PaddleFleet（本包）** | ``layer_specs.py`` —— 12 层 backbone 的 ``LayerSpec`` 列表 / block spec |
-| PaddleFormers ``transformers/hyperbody_decoder/`` | HF-style config → ``GPTConfig`` 的转换 + 组网装配 + 顶层 Model |
+| **PaddleFleet (this package)** | ``layer_specs.py`` -- the ``LayerSpec`` list / block spec for the backbone |
+| PaddleFormers ``transformers/hyperbody_decoder/`` | HF-style config -> ``GPTConfig`` conversion + model assembly + top-level Model |
 
-几何常量与 ``GPTConfig`` 的装配**不在这里** —— 它们属于「HF-style config 到
-GPTConfig 的转换」这一职责，全部收在 formers 的 ``configuration.py`` /
-``modeling.py``。这与 hyperencoder 那边 ``build_hyperencoder_config`` 位于
-``PaddleFormers/paddleformers/transformers/hyperencoder/configuration.py``
-是同一个约定。
+Geometry constants and ``GPTConfig`` assembly do **not** live here -- they belong to
+the "HF-style config to GPTConfig conversion" responsibility, which is entirely
+collected in the PaddleFormers ``configuration.py`` / ``modeling.py``.
 """
 
 from .layer_specs import (

--- a/src/paddlefleet/models/hyperbody_decoder/layer_specs.py
+++ b/src/paddlefleet/models/hyperbody_decoder/layer_specs.py
@@ -50,14 +50,18 @@ that into an explicit error instead of a silent mismatch.
 
 from __future__ import annotations
 
-from paddle.distributed.fleet.meta_parallel import LayerSpec
+from typing import TYPE_CHECKING
 
 from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from paddlefleet.transformer.enums import AttnMaskType
 from paddlefleet.transformer.transformer_block import (
     TransformerBlockSublayersSpec,
 )
-from paddlefleet.transformer.transformer_config import TransformerConfig
+
+if TYPE_CHECKING:
+    from paddle.distributed.fleet.meta_parallel import LayerSpec
+
+    from paddlefleet.transformer.transformer_config import TransformerConfig
 
 __all__ = [
     "get_hyperbody_decoder_layer_specs",

--- a/src/paddlefleet/models/hyperbody_decoder/layer_specs.py
+++ b/src/paddlefleet/models/hyperbody_decoder/layer_specs.py
@@ -12,55 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""HyperBody decoder 主干的 layer spec —— PaddleFleet 侧提供的**组件**。
+"""Layer specs for the HyperBody decoder backbone -- a **component** provided on the PaddleFleet side.
 
-## 分工
+## Split of responsibilities
 
-| 侧 | 职责 |
+| Side | Responsibility |
 |---|---|
-| **PaddleFleet（本文件）** | 提供 12 层 backbone 的 `LayerSpec` 列表与 block spec |
-| PaddleFormers `transformers/hyperbody_decoder/` | HF-style config → ``GPTConfig`` 的转换 + 组网装配 |
+| **PaddleFleet (this file)** | Provides the ``LayerSpec`` list and block spec for the backbone |
+| PaddleFormers `transformers/hyperbody_decoder/` | HF-style config -> ``GPTConfig`` conversion + model assembly |
 
-这与参考实现 ``fleet_formers`` 的 hyperencoder 完全同形：那边 fleet 侧也只有
-``layer_specs.py`` + ``modality_encoders.py``（组件），config 装配与顶层 Model
-都在 formers 的 ``transformers/hyperencoder/``。
+Geometry constants and ``GPTConfig`` assembly do not live here; they belong to the
+"HF-style config to GPTConfig conversion" responsibility on the PaddleFormers side.
 
-## 与 hyperencoder 共享的 backbone
+## Backbone shape
 
-decoder 与 encoder 是**同一族 DeepSeekV2-Lite MoE 主干**：12 层 / hidden 1280 /
-MHA 10×128 / dense FFN 6848（只 layer 0）/ 64 experts top-6 / moe FFN 896 /
-2 shared experts / RMSNorm 1e-6 / RoPE base 10000。所以本文件的骨架直接复用
-``models/hyperencoder/layer_specs.py``：同样的 :func:`_is_moe_layer`（只认逐层
-list）、同样的「逐层调 ``get_gpt_layer_local_spec``」循环。
+The HyperBody decoder is a DeepSeekV2-Lite MoE backbone: hidden 1280 / MHA 10x128 /
+dense FFN 6848 (layer 0 only) / 64 experts top-6 / moe FFN 896 / 2 shared experts /
+RMSNorm 1e-6 / RoPE base 10000. Each layer is built by looping over
+``get_gpt_layer_local_spec``. :func:`_is_moe_layer` decides per-layer whether the
+MLP is dense or MoE by reading the per-layer ``moe_layer_freq`` list.
 
-**两处刻意不复用**，因为它们是 encoder 的双向 prefix-LM 专属机制，decoder 不占：
+The attention mask type is ``AttnMaskType.causal`` -- this is a standard causal LM,
+so ``DotProductAttention``'s SDPA branch forcing ``is_causal=True`` is exactly right.
+The per-layer norms use whatever ``get_gpt_layer_local_spec`` gives for
+``normalization="RMSNorm"``.
 
-1. ``input_layernorm`` / ``post_attention_layernorm`` **不换成**
-   ``HyperEncoderRMSNorm``。那是 encoder 为「恒定 fp32 norm」做的替换
-   （源侧 ``native_hyperbody_modality_submodules.py:356-357`` 的
-   ``_SequenceParallelRMSNorm``）；decoder 的源侧是未改动的 mcore ``GPTModel``，
-   norm 就用 ``get_gpt_layer_local_spec`` 按 ``normalization="RMSNorm"`` 给的那个。
-2. ``attn_mask_type`` 用 **``causal``** 而不是 encoder 的 ``no_mask``。decoder 是
-   标准因果 LM；encoder 传 ``no_mask`` 是因为它自己喂完整的 dense prefix-LM 掩码，
-   不能让框架再叠一层因果（见 hyperencoder/layer_specs.py 的模块 docstring）。
-   同理 decoder **不需要** ``_attn_implementation="eager"`` 那道断言 ——
-   ``DotProductAttention`` 的 SDPA 分支强制 ``is_causal=True`` 对我们正好是对的。
+## Why the spec construction is collected here
 
-## 为什么 decoder 也要有这个文件
-
-源侧 ``_build_model_specs``（``megatron_mimo_training_hyperbody.py:154-192``）只传
-``ModuleSpec(module=GPTModel, params={config, vocab_size, max_sequence_length,
-position_embedding_type})``，连 ``transformer_layer_spec`` 都没给 —— 所以
-``paddlefleet.gpt_builders.gpt_builder`` 的通用路径（它内部会调
-``get_gpt_decoder_layers_spec``）在**行为上**本来就够用。
-
-但把 spec 的构造显式收在这里有两个实际好处：
-
-* ``moe_layer_freq`` 传 int 时 ``get_gpt_decoder_layers_spec``
-  （``gpt_layer_specs.py:803-807``）会按 ``i % N`` 生成 pattern，而 Megatron 侧是
-  另一套取模语义 —— 静默错位。:func:`_is_moe_layer` 直接**拒绝** int，让它变成
-  显式报错（这条与 hyperencoder 那份逐字一致）。
-* backbone 的构造点是 encoder / decoder 的公共面，放在一处才能保证两边同步演进。
+The generic path in ``paddlefleet.gpt_builders.gpt_builder`` (which internally calls
+``get_gpt_decoder_layers_spec``) would already work behaviorally. Collecting the spec
+construction explicitly here gives one practical benefit: when ``moe_layer_freq`` is
+passed as an int, ``get_gpt_decoder_layers_spec`` (``gpt_layer_specs.py:803-807``)
+generates the dense/MoE pattern via ``i % N``, which is not the intended per-layer
+semantics for this model. :func:`_is_moe_layer` **rejects** ints outright, turning
+that into an explicit error instead of a silent mismatch.
 """
 
 from __future__ import annotations
@@ -69,7 +54,9 @@ from paddle.distributed.fleet.meta_parallel import LayerSpec
 
 from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from paddlefleet.transformer.enums import AttnMaskType
-from paddlefleet.transformer.transformer_block import TransformerBlockSublayersSpec
+from paddlefleet.transformer.transformer_block import (
+    TransformerBlockSublayersSpec,
+)
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
 __all__ = [
@@ -79,42 +66,45 @@ __all__ = [
 
 
 def _is_moe_layer(config: TransformerConfig, layer_idx: int) -> bool:
-    """第 i 层是不是 MoE 层。
+    """Whether layer ``i`` is a MoE layer.
 
-    源侧 ``moe_layer_freq = [0] + [1]*11``（``megatron_mimo_training_hyperbody.py:100``）
-    是**逐层的 0/1 列表**，判据就是取列表第 i 项。
+    ``moe_layer_freq`` is a **per-layer 0/1 list** (``[0] + [1]*(L-1)``), so the
+    criterion is simply taking element ``i`` of the list.
 
-    ⚠️ 与 hyperencoder 那份同样**拒绝 int**：传 int 时 Paddle 走
-    ``i % N``（``gpt_layer_specs.py:803-807``），Megatron 走另一套语义，必然错位。
+    WARNING: this **rejects int**. Passing an int would make Paddle take the
+    ``i % N`` path (``gpt_layer_specs.py:803-807``), which is not the intended
+    per-layer semantics for this model -- an inevitable mismatch.
     """
     freq = config.moe_layer_freq
     if isinstance(freq, (list, tuple)):
         if len(freq) != config.num_hidden_layers:
             raise ValueError(
-                f"moe_layer_freq 长度 {len(freq)} != num_hidden_layers "
+                f"moe_layer_freq length {len(freq)} != num_hidden_layers "
                 f"{config.num_hidden_layers}"
             )
         return bool(freq[layer_idx])
     raise TypeError(
-        f"HyperBody decoder 要求 moe_layer_freq 是逐层的 list，得到 {type(freq).__name__}。"
-        "传 int 会走 `i % N` 的语义（与 Megatron 侧不同），必然错位。"
+        f"HyperBody decoder requires moe_layer_freq to be a per-layer list, got {type(freq).__name__}. "
+        "Passing an int would take the `i % N` semantics, an inevitable mismatch."
     )
 
 
-def get_hyperbody_decoder_layer_specs(config: TransformerConfig) -> list[LayerSpec]:
-    """产出 ``num_hidden_layers`` 层的 :class:`LayerSpec` 列表。
+def get_hyperbody_decoder_layer_specs(
+    config: TransformerConfig,
+) -> list[LayerSpec]:
+    """Produce a :class:`LayerSpec` list of ``num_hidden_layers`` layers.
 
-    layer 0 是 dense FFN（``intermediate_size``），其余是 MoE
-    （``n_routed_experts`` × ``moe_intermediate_size`` + shared experts）。
+    Layer 0 is a dense FFN (``intermediate_size``); the rest are MoE
+    (``n_routed_experts`` x ``moe_intermediate_size`` + shared experts).
 
-    ``moe_expert_fusion`` 只对 MoE 层生效 —— dense 层传 ``False``，否则
-    ``get_mlp_layer_spec_for_backend`` 会去建 grouped GEMM 的 3-D 权重
-    （对齐 ``get_gpt_decoder_layers_spec`` 的做法）。
+    ``moe_expert_fusion`` only applies to MoE layers -- dense layers pass ``False``,
+    otherwise ``get_mlp_layer_spec_for_backend`` would build the 3-D grouped-GEMM
+    weights.
     """
     if config.multi_latent_attention:
         raise ValueError(
-            "HyperBody decoder 是纯 MHA（源侧 num_query_groups == num_attention_heads == 10，"
-            "且 _make_language_config 没设任何 MLA 字段）。multi_latent_attention 必须为 False。"
+            "HyperBody decoder is pure MHA (num_query_groups == num_attention_heads). "
+            "multi_latent_attention must be False."
         )
 
     specs: list[LayerSpec] = []
@@ -128,7 +118,7 @@ def get_hyperbody_decoder_layer_specs(config: TransformerConfig) -> list[LayerSp
                 moe_expert_fusion=config.moe_expert_fusion if is_moe else False,
                 use_qk_norm=config.use_qk_norm,
                 normalization=config.normalization,
-                # 标准因果 LM。与 encoder 的 no_mask 相反，见模块 docstring。
+                # Standard causal LM.
                 attn_mask_type=AttnMaskType.causal,
             )
         )
@@ -138,14 +128,15 @@ def get_hyperbody_decoder_layer_specs(config: TransformerConfig) -> list[LayerSp
 def get_hyperbody_decoder_block_spec(
     config: TransformerConfig,
 ) -> TransformerBlockSublayersSpec:
-    """产出整个 block 的 spec（N 层 + 最终 norm）。
+    """Produce the spec for the whole block (N layers + final norm).
 
-    ``layer_norm=None`` 表示沿用 ``TransformerBlock`` 按 ``config.normalization``
-    自己建的那一个 —— decoder 不像 encoder 需要换成自写的 fp32 norm。
+    ``layer_norm=None`` means we keep the one that ``TransformerBlock`` builds itself
+    according to ``config.normalization``.
 
-    走 ``paddleformers-cli`` 的 pipeline 路径时用不到这个函数（那条路要的是裸的
-    ``list[LayerSpec]``，见 ``get_hyperbody_decoder_layer_specs``）；它是给不走
-    ``PipelineLayer`` 的单卡脚本/单测直接建 ``TransformerBlock`` 用的。
+    This function is not used on the ``paddleformers-cli`` pipeline path (that path
+    wants the bare ``list[LayerSpec]``, see ``get_hyperbody_decoder_layer_specs``);
+    it is for single-card scripts / unit tests that build a ``TransformerBlock``
+    directly without going through ``PipelineLayer``.
     """
     return TransformerBlockSublayersSpec(
         layer_specs=get_hyperbody_decoder_layer_specs(config),

--- a/src/paddlefleet/models/hyperbody_decoder/layer_specs.py
+++ b/src/paddlefleet/models/hyperbody_decoder/layer_specs.py
@@ -55,6 +55,7 @@ from typing import TYPE_CHECKING
 from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from paddlefleet.transformer.enums import AttnMaskType
 from paddlefleet.transformer.transformer_block import (
+    LayerNormImpl,
     TransformerBlockSublayersSpec,
 )
 
@@ -86,7 +87,17 @@ def _is_moe_layer(config: TransformerConfig, layer_idx: int) -> bool:
                 f"moe_layer_freq length {len(freq)} != num_hidden_layers "
                 f"{config.num_hidden_layers}"
             )
-        return bool(freq[layer_idx])
+        flag = freq[layer_idx]
+        # Only 0/1 is a valid per-layer flag. Any other truthy value (2, -1,
+        # a string, ...) would be silently coerced to a MoE layer by bool(),
+        # producing a different model structure. get_gpt_decoder_layers_spec
+        # rejects the same non-0/1 patterns (gpt_layer_specs.py:825-826).
+        if flag not in (0, 1):
+            raise ValueError(
+                f"moe_layer_freq[{layer_idx}] = {flag!r} is not a 0/1 flag; "
+                "moe_layer_freq must be a per-layer 0/1 list."
+            )
+        return bool(flag)
     raise TypeError(
         f"HyperBody decoder requires moe_layer_freq to be a per-layer list, got {type(freq).__name__}. "
         "Passing an int would take the `i % N` semantics, an inevitable mismatch."
@@ -109,6 +120,19 @@ def get_hyperbody_decoder_layer_specs(
         raise ValueError(
             "HyperBody decoder is pure MHA (num_query_groups == num_attention_heads). "
             "multi_latent_attention must be False."
+        )
+    # get_gpt_layer_local_spec would otherwise switch to the DSV4 hybrid
+    # attention path (gpt_layer_specs.py:637-645), which is not pure MHA.
+    if getattr(config, "experimental_attention_variant", None) is not None:
+        raise ValueError(
+            "HyperBody decoder is pure MHA; experimental_attention_variant "
+            f"must be None, got {config.experimental_attention_variant!r}."
+        )
+    # use_vha_attention would route self_attention to SelfAttentionVHA
+    # (gpt_layer_specs.py:234-262), again not pure MHA.
+    if getattr(config, "use_vha_attention", False):
+        raise ValueError(
+            "HyperBody decoder is pure MHA; use_vha_attention must be False."
         )
 
     specs: list[LayerSpec] = []
@@ -134,15 +158,20 @@ def get_hyperbody_decoder_block_spec(
 ) -> TransformerBlockSublayersSpec:
     """Produce the spec for the whole block (N layers + final norm).
 
-    ``layer_norm=None`` means we keep the one that ``TransformerBlock`` builds itself
-    according to ``config.normalization``.
+    ``layer_norm`` is the stock ``LayerNormImpl`` (``WrappedPaddleNorm``), which
+    resolves to RMSNorm / LayerNorm per ``config.normalization`` -- the same
+    default ``_get_block_sublayers_spec`` applies when a bare ``LayerSpec`` is
+    handed to ``TransformerBlock``. This is required: ``TransformerBlock`` only
+    builds the final norm when ``layer_norm`` is truthy, so a ``None`` here
+    would silently drop the final norm (transformer_block.py:170-182).
 
-    This function is not used on the ``paddleformers-cli`` pipeline path (that path
-    wants the bare ``list[LayerSpec]``, see ``get_hyperbody_decoder_layer_specs``);
-    it is for single-card scripts / unit tests that build a ``TransformerBlock``
-    directly without going through ``PipelineLayer``.
+    This function is not used on the ``paddleformers-cli`` pipeline path (that
+    path wants the bare ``list[LayerSpec]``, see
+    ``get_hyperbody_decoder_layer_specs``); it is for single-card scripts /
+    unit tests that build a ``TransformerBlock`` directly without going through
+    ``PipelineLayer``.
     """
     return TransformerBlockSublayersSpec(
         layer_specs=get_hyperbody_decoder_layer_specs(config),
-        layer_norm=None,
+        layer_norm=LayerNormImpl,
     )

--- a/src/paddlefleet/models/hyperbody_decoder/layer_specs.py
+++ b/src/paddlefleet/models/hyperbody_decoder/layer_specs.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HyperBody decoder 主干的 layer spec —— PaddleFleet 侧提供的**组件**。
+
+## 分工
+
+| 侧 | 职责 |
+|---|---|
+| **PaddleFleet（本文件）** | 提供 12 层 backbone 的 `LayerSpec` 列表与 block spec |
+| PaddleFormers `transformers/hyperbody_decoder/` | HF-style config → ``GPTConfig`` 的转换 + 组网装配 |
+
+这与参考实现 ``fleet_formers`` 的 hyperencoder 完全同形：那边 fleet 侧也只有
+``layer_specs.py`` + ``modality_encoders.py``（组件），config 装配与顶层 Model
+都在 formers 的 ``transformers/hyperencoder/``。
+
+## 与 hyperencoder 共享的 backbone
+
+decoder 与 encoder 是**同一族 DeepSeekV2-Lite MoE 主干**：12 层 / hidden 1280 /
+MHA 10×128 / dense FFN 6848（只 layer 0）/ 64 experts top-6 / moe FFN 896 /
+2 shared experts / RMSNorm 1e-6 / RoPE base 10000。所以本文件的骨架直接复用
+``models/hyperencoder/layer_specs.py``：同样的 :func:`_is_moe_layer`（只认逐层
+list）、同样的「逐层调 ``get_gpt_layer_local_spec``」循环。
+
+**两处刻意不复用**，因为它们是 encoder 的双向 prefix-LM 专属机制，decoder 不占：
+
+1. ``input_layernorm`` / ``post_attention_layernorm`` **不换成**
+   ``HyperEncoderRMSNorm``。那是 encoder 为「恒定 fp32 norm」做的替换
+   （源侧 ``native_hyperbody_modality_submodules.py:356-357`` 的
+   ``_SequenceParallelRMSNorm``）；decoder 的源侧是未改动的 mcore ``GPTModel``，
+   norm 就用 ``get_gpt_layer_local_spec`` 按 ``normalization="RMSNorm"`` 给的那个。
+2. ``attn_mask_type`` 用 **``causal``** 而不是 encoder 的 ``no_mask``。decoder 是
+   标准因果 LM；encoder 传 ``no_mask`` 是因为它自己喂完整的 dense prefix-LM 掩码，
+   不能让框架再叠一层因果（见 hyperencoder/layer_specs.py 的模块 docstring）。
+   同理 decoder **不需要** ``_attn_implementation="eager"`` 那道断言 ——
+   ``DotProductAttention`` 的 SDPA 分支强制 ``is_causal=True`` 对我们正好是对的。
+
+## 为什么 decoder 也要有这个文件
+
+源侧 ``_build_model_specs``（``megatron_mimo_training_hyperbody.py:154-192``）只传
+``ModuleSpec(module=GPTModel, params={config, vocab_size, max_sequence_length,
+position_embedding_type})``，连 ``transformer_layer_spec`` 都没给 —— 所以
+``paddlefleet.gpt_builders.gpt_builder`` 的通用路径（它内部会调
+``get_gpt_decoder_layers_spec``）在**行为上**本来就够用。
+
+但把 spec 的构造显式收在这里有两个实际好处：
+
+* ``moe_layer_freq`` 传 int 时 ``get_gpt_decoder_layers_spec``
+  （``gpt_layer_specs.py:803-807``）会按 ``i % N`` 生成 pattern，而 Megatron 侧是
+  另一套取模语义 —— 静默错位。:func:`_is_moe_layer` 直接**拒绝** int，让它变成
+  显式报错（这条与 hyperencoder 那份逐字一致）。
+* backbone 的构造点是 encoder / decoder 的公共面，放在一处才能保证两边同步演进。
+"""
+
+from __future__ import annotations
+
+from paddle.distributed.fleet.meta_parallel import LayerSpec
+
+from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
+from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.transformer_block import TransformerBlockSublayersSpec
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+__all__ = [
+    "get_hyperbody_decoder_layer_specs",
+    "get_hyperbody_decoder_block_spec",
+]
+
+
+def _is_moe_layer(config: TransformerConfig, layer_idx: int) -> bool:
+    """第 i 层是不是 MoE 层。
+
+    源侧 ``moe_layer_freq = [0] + [1]*11``（``megatron_mimo_training_hyperbody.py:100``）
+    是**逐层的 0/1 列表**，判据就是取列表第 i 项。
+
+    ⚠️ 与 hyperencoder 那份同样**拒绝 int**：传 int 时 Paddle 走
+    ``i % N``（``gpt_layer_specs.py:803-807``），Megatron 走另一套语义，必然错位。
+    """
+    freq = config.moe_layer_freq
+    if isinstance(freq, (list, tuple)):
+        if len(freq) != config.num_hidden_layers:
+            raise ValueError(
+                f"moe_layer_freq 长度 {len(freq)} != num_hidden_layers "
+                f"{config.num_hidden_layers}"
+            )
+        return bool(freq[layer_idx])
+    raise TypeError(
+        f"HyperBody decoder 要求 moe_layer_freq 是逐层的 list，得到 {type(freq).__name__}。"
+        "传 int 会走 `i % N` 的语义（与 Megatron 侧不同），必然错位。"
+    )
+
+
+def get_hyperbody_decoder_layer_specs(config: TransformerConfig) -> list[LayerSpec]:
+    """产出 ``num_hidden_layers`` 层的 :class:`LayerSpec` 列表。
+
+    layer 0 是 dense FFN（``intermediate_size``），其余是 MoE
+    （``n_routed_experts`` × ``moe_intermediate_size`` + shared experts）。
+
+    ``moe_expert_fusion`` 只对 MoE 层生效 —— dense 层传 ``False``，否则
+    ``get_mlp_layer_spec_for_backend`` 会去建 grouped GEMM 的 3-D 权重
+    （对齐 ``get_gpt_decoder_layers_spec`` 的做法）。
+    """
+    if config.multi_latent_attention:
+        raise ValueError(
+            "HyperBody decoder 是纯 MHA（源侧 num_query_groups == num_attention_heads == 10，"
+            "且 _make_language_config 没设任何 MLA 字段）。multi_latent_attention 必须为 False。"
+        )
+
+    specs: list[LayerSpec] = []
+    for i in range(config.num_hidden_layers):
+        is_moe = _is_moe_layer(config, i)
+        specs.append(
+            get_gpt_layer_local_spec(
+                config=config,
+                layer_number=i + config.num_empty_layers_add_in_head,
+                num_experts=config.n_routed_experts if is_moe else None,
+                moe_expert_fusion=config.moe_expert_fusion if is_moe else False,
+                use_qk_norm=config.use_qk_norm,
+                normalization=config.normalization,
+                # 标准因果 LM。与 encoder 的 no_mask 相反，见模块 docstring。
+                attn_mask_type=AttnMaskType.causal,
+            )
+        )
+    return specs
+
+
+def get_hyperbody_decoder_block_spec(
+    config: TransformerConfig,
+) -> TransformerBlockSublayersSpec:
+    """产出整个 block 的 spec（N 层 + 最终 norm）。
+
+    ``layer_norm=None`` 表示沿用 ``TransformerBlock`` 按 ``config.normalization``
+    自己建的那一个 —— decoder 不像 encoder 需要换成自写的 fp32 norm。
+
+    走 ``paddleformers-cli`` 的 pipeline 路径时用不到这个函数（那条路要的是裸的
+    ``list[LayerSpec]``，见 ``get_hyperbody_decoder_layer_specs``）；它是给不走
+    ``PipelineLayer`` 的单卡脚本/单测直接建 ``TransformerBlock`` 用的。
+    """
+    return TransformerBlockSublayersSpec(
+        layer_specs=get_hyperbody_decoder_layer_specs(config),
+        layer_norm=None,
+    )

--- a/tests/single_card_tests/test_hyperbody_decoder_layer_specs.py
+++ b/tests/single_card_tests/test_hyperbody_decoder_layer_specs.py
@@ -27,6 +27,7 @@ from paddlefleet.models.hyperbody_decoder.layer_specs import (
     get_hyperbody_decoder_layer_specs,
 )
 from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.transformer_block import LayerNormImpl
 from paddlefleet.transformer.transformer_config import TransformerConfig
 
 
@@ -78,10 +79,12 @@ class TestHyperBodyDecoderLayerSpecs(unittest.TestCase):
                 AttnMaskType.causal,
             )
 
-    def test_block_spec_final_norm_is_none(self):
+    def test_block_spec_final_norm_is_stock_norm(self):
+        # layer_norm must be the stock LayerNormImpl -- a None would make
+        # TransformerBlock silently drop the final norm.
         config = _make_config()
         block = get_hyperbody_decoder_block_spec(config)
-        self.assertIsNone(block.layer_norm)
+        self.assertIs(block.layer_norm, LayerNormImpl)
         self.assertEqual(len(block.layer_specs), config.num_hidden_layers)
 
     def test_int_moe_layer_freq_rejected(self):
@@ -99,6 +102,29 @@ class TestHyperBodyDecoderLayerSpecs(unittest.TestCase):
     def test_multi_latent_attention_rejected(self):
         # HyperBody decoder is pure MHA; MLA must be refused early.
         config = _make_config(multi_latent_attention=True)
+        with self.assertRaises(ValueError):
+            get_hyperbody_decoder_layer_specs(config)
+
+    def test_non_binary_moe_layer_freq_rejected(self):
+        # A non-0/1 entry would be silently coerced to a MoE layer by bool();
+        # it must be rejected instead.
+        config = _make_config(moe_layer_freq=[0, 2, 1, 1])
+        with self.assertRaises(ValueError):
+            _is_moe_layer(config, 1)
+
+    def test_dsv4_hybrid_attention_variant_rejected(self):
+        # experimental_attention_variant="dsv4_hybrid" would route to the DSV4
+        # hybrid attention path, not pure MHA -> must be refused early.
+        config = _make_config()
+        config.experimental_attention_variant = "dsv4_hybrid"
+        with self.assertRaises(ValueError):
+            get_hyperbody_decoder_layer_specs(config)
+
+    def test_vha_attention_rejected(self):
+        # use_vha_attention=True would route self_attention to SelfAttentionVHA,
+        # not pure MHA -> must be refused early.
+        config = _make_config()
+        config.use_vha_attention = True
         with self.assertRaises(ValueError):
             get_hyperbody_decoder_layer_specs(config)
 

--- a/tests/single_card_tests/test_hyperbody_decoder_layer_specs.py
+++ b/tests/single_card_tests/test_hyperbody_decoder_layer_specs.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structural unit tests for the HyperBody decoder layer specs.
+
+These only inspect the ``LayerSpec`` structure produced by
+``get_hyperbody_decoder_layer_specs`` / ``get_hyperbody_decoder_block_spec``,
+so they run on a single card without any distributed / RNG initialization.
+"""
+
+import unittest
+
+from paddlefleet.models.hyperbody_decoder.layer_specs import (
+    _is_moe_layer,
+    get_hyperbody_decoder_block_spec,
+    get_hyperbody_decoder_layer_specs,
+)
+from paddlefleet.transformer.enums import AttnMaskType
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+
+def _make_config(**overrides) -> TransformerConfig:
+    """A tiny DeepSeekV2-Lite-shaped config: layer 0 dense, rest MoE."""
+    kwargs = dict(
+        num_hidden_layers=4,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        intermediate_size=128,
+        moe_layer_freq=[0, 1, 1, 1],
+        n_routed_experts=4,
+        moe_intermediate_size=64,
+        num_experts_per_tok=2,
+        n_shared_experts=1,
+        normalization="RMSNorm",
+    )
+    kwargs.update(overrides)
+    return TransformerConfig(**kwargs)
+
+
+class TestHyperBodyDecoderLayerSpecs(unittest.TestCase):
+    def test_spec_count_matches_num_layers(self):
+        config = _make_config()
+        specs = get_hyperbody_decoder_layer_specs(config)
+        self.assertEqual(len(specs), config.num_hidden_layers)
+
+    def test_layer0_dense_rest_moe(self):
+        config = _make_config()
+        specs = get_hyperbody_decoder_layer_specs(config)
+        mlp_classes = [s.sublayers_spec.mlp.layer.__name__ for s in specs]
+        self.assertEqual(mlp_classes[0], "MLP")
+        self.assertTrue(all(name == "MoELayer" for name in mlp_classes[1:]))
+
+    def test_is_moe_layer_reads_list(self):
+        config = _make_config()
+        flags = [_is_moe_layer(config, i) for i in range(config.num_hidden_layers)]
+        self.assertEqual(flags, [False, True, True, True])
+
+    def test_all_layers_causal(self):
+        config = _make_config()
+        specs = get_hyperbody_decoder_layer_specs(config)
+        for s in specs:
+            self.assertEqual(
+                s.sublayers_spec.self_attn.extra_kwargs["attn_mask_type"],
+                AttnMaskType.causal,
+            )
+
+    def test_block_spec_final_norm_is_none(self):
+        config = _make_config()
+        block = get_hyperbody_decoder_block_spec(config)
+        self.assertIsNone(block.layer_norm)
+        self.assertEqual(len(block.layer_specs), config.num_hidden_layers)
+
+    def test_int_moe_layer_freq_rejected(self):
+        # Passing an int would silently take the `i % N` path (Paddle) which
+        # disagrees with Megatron's per-layer list semantics -> must raise.
+        config = _make_config(moe_layer_freq=2)
+        with self.assertRaises(TypeError):
+            _is_moe_layer(config, 0)
+
+    def test_length_mismatch_rejected(self):
+        config = _make_config(moe_layer_freq=[0, 1])
+        with self.assertRaises(ValueError):
+            _is_moe_layer(config, 0)
+
+    def test_multi_latent_attention_rejected(self):
+        # HyperBody decoder is pure MHA; MLA must be refused early.
+        config = _make_config(multi_latent_attention=True)
+        with self.assertRaises(ValueError):
+            get_hyperbody_decoder_layer_specs(config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/test_hyperbody_decoder_layer_specs.py
+++ b/tests/single_card_tests/test_hyperbody_decoder_layer_specs.py
@@ -32,19 +32,19 @@ from paddlefleet.transformer.transformer_config import TransformerConfig
 
 def _make_config(**overrides) -> TransformerConfig:
     """A tiny DeepSeekV2-Lite-shaped config: layer 0 dense, rest MoE."""
-    kwargs = dict(
-        num_hidden_layers=4,
-        hidden_size=64,
-        num_attention_heads=4,
-        num_key_value_heads=4,
-        intermediate_size=128,
-        moe_layer_freq=[0, 1, 1, 1],
-        n_routed_experts=4,
-        moe_intermediate_size=64,
-        num_experts_per_tok=2,
-        n_shared_experts=1,
-        normalization="RMSNorm",
-    )
+    kwargs = {
+        "num_hidden_layers": 4,
+        "hidden_size": 64,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 4,
+        "intermediate_size": 128,
+        "moe_layer_freq": [0, 1, 1, 1],
+        "n_routed_experts": 4,
+        "moe_intermediate_size": 64,
+        "num_experts_per_tok": 2,
+        "n_shared_experts": 1,
+        "normalization": "RMSNorm",
+    }
     kwargs.update(overrides)
     return TransformerConfig(**kwargs)
 
@@ -64,7 +64,9 @@ class TestHyperBodyDecoderLayerSpecs(unittest.TestCase):
 
     def test_is_moe_layer_reads_list(self):
         config = _make_config()
-        flags = [_is_moe_layer(config, i) for i in range(config.num_hidden_layers)]
+        flags = [
+            _is_moe_layer(config, i) for i in range(config.num_hidden_layers)
+        ]
         self.assertEqual(flags, [False, True, True, True])
 
     def test_all_layers_causal(self):


### PR DESCRIPTION
### PR Category
Execute Infrastructure

### PR Types
New features

### Description
Adds the HyperBody decoder backbone **components** to PaddleFleet: a
`models/hyperbody_decoder/` package exposing `get_hyperbody_decoder_layer_specs`
and `get_hyperbody_decoder_block_spec`.

The decoder is a DeepSeekV2-Lite MoE backbone: 12 layers / hidden 1280 /
MHA 10x128 / dense FFN on layer 0 / 64 experts top-6 / 2 shared experts /
RMSNorm / RoPE base 10000. Each layer is built by looping over
`get_gpt_layer_local_spec`, and `_is_moe_layer` reads the per-layer
`moe_layer_freq` list to decide dense vs MoE.

A few deliberate choices:

- norms use the stock `get_gpt_layer_local_spec` RMSNorm (no fp32 override);
- every layer uses `attn_mask_type=causal` (standard causal LM);
- `_is_moe_layer` rejects an `int` `moe_layer_freq` (an int would take Paddle's
  `i % N` semantics, not the intended per-layer list), and MLA is refused early
  since the decoder is pure MHA.

This PR is purely additive — no existing file is touched.

### Tests
`tests/single_card_tests/test_hyperbody_decoder_layer_specs.py` (8 cases,
launcher-free): spec count, dense-layer-0 / MoE-rest split, all-causal masks,
`layer_norm=None` block spec, and the int / length-mismatch / MLA rejections.
