### PR TITLE
[MTP] add mtp_shared_weights and mtp_depth_sampling on top of echo mtp

### DIFF
--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -946,6 +946,11 @@ class LanguageLoss(FleetLayer):
 
             logs = get_global_training_logs()
             if logs is not None and hasattr(logs, "update"):
+                if hasattr(logs, "pop"):
+                    for _d in range(
+                        len(mtp_loss), self.config.num_nextn_predict_layers
+                    ):
+                        logs.pop(f"mtp_{_d + 1}_loss", None)
                 for i, loss_val in enumerate(mtp_loss):
                     logs.update(**{f"mtp_{i + 1}_loss": loss_val.detach()})
 

--- a/src/paddlefleet/models/common/language_loss/language_loss.py
+++ b/src/paddlefleet/models/common/language_loss/language_loss.py
@@ -633,6 +633,12 @@ class LanguageLoss(FleetLayer):
                     lm_loss = self._forward(logits[0], lm_labels)
 
                 for depth in range(self.config.num_nextn_predict_layers):
+                    # MTP depth sampling: the LM head emits None for depths that were
+                    # not computed this step; skip them so mtp_loss holds only the K
+                    # computed depths (the `/ num_mtp` reduction below then averages
+                    # over K). No effect when sampling is off — logits are never None.
+                    if mtp_logits[depth] is None:
+                        continue
                     logits_cur_depth = mtp_logits[depth]
                     if _mtp_is_megatron:
                         # Under use_erndata=True labels_ori is [B, L]
@@ -942,6 +948,15 @@ class LanguageLoss(FleetLayer):
             if logs is not None and hasattr(logs, "update"):
                 for i, loss_val in enumerate(mtp_loss):
                     logs.update(**{f"mtp_{i + 1}_loss": loss_val.detach()})
+
+            # MTP depth sampling: mtp_loss holds only the computed prefix
+            # (depths 0..len-1). Drop stale tracker entries for the sampled-out deeper
+            # depths so the trainer does not re-log a stale value on those steps —
+            # per-depth curves stay sparse-but-correct instead of flat.
+            for _d in range(
+                len(mtp_loss), self.config.num_nextn_predict_layers
+            ):
+                LanguageLoss.mtp_loss_tracker.pop(f"mtp_{_d + 1}_loss", None)
 
             def add_loss(main_loss, loss):
                 if _use_accuracy_compatible_kernel():

--- a/src/paddlefleet/models/gpt/gpt_model.py
+++ b/src/paddlefleet/models/gpt/gpt_model.py
@@ -286,11 +286,7 @@ class GPTModel(PipelineLayer):
           [MTP-SHARED-WEIGHTS-SKIP]      stage has < 2 MTP layers (nothing to share)
           [MTP-SHARED-WEIGHTS-WARN]      partial / shape-mismatched alias
         """
-        mtp_layers = [
-            layer
-            for layer in self.run_function
-            if isinstance(layer, MultiTokenPredictionLayer)
-        ]
+        mtp_layers = self._get_all_mtp_layers()
 
         if len(mtp_layers) < 2:
             warnings.warn(

--- a/src/paddlefleet/models/gpt/gpt_model.py
+++ b/src/paddlefleet/models/gpt/gpt_model.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -249,6 +250,110 @@ class GPTModel(PipelineLayer):
 
         # Tie GPTMTPLMHead weight to GPTMainLMHead weight on the same stage.
         self._tie_mtp_lm_head_weight()
+        # MTP cross-depth weight sharing: alias every MTP depth (1..D-1) onto the
+        # first MTP layer (depth 0) on this PP rank. When mtp_shared_last_layer is
+        # also on, the transformer_layer body is already shared through paddle's
+        # SharedLayerDesc machinery, so only the fusion modules are aliased here.
+        if getattr(self.config, "mtp_shared_weights", False):
+            self._alias_mtp_shared_weights()
+
+    def _alias_mtp_shared_weights(self):
+        """Share ONE MultiTokenPredictionLayer's parameters across all MTP depths on
+        this PP rank: alias depths 1..D-1 onto depth 0 (the first MTP layer).
+
+        This is parameter-object aliasing (Parameter identity is shared, NOT module
+        reference replacement), so the LayerDesc tree is preserved and checkpoint save
+        via AOA still emits per-MTP keys. Loading semantics: all depths point at the
+        same Parameter, so whichever depth's keys are loaded last wins.
+
+        Interaction with ``mtp_shared_last_layer``:
+          - False: alias everything, i.e. the internal ``transformer_layer`` body plus
+            the per-depth fusion modules (enorm / hnorm / eh_proj / norm).
+          - True: every MTP depth registers the same SharedLayerDesc key
+            ("mtp_reuse_transformer"), so paddle already points all depths' body
+            parameters at the backbone-last layer and also tracks those Parameter
+            objects in ``PipelineLayer.shared_comm`` for the cross-stage gradient
+            allreduce. Re-pointing them here would leave that bookkeeping referring to
+            Parameter objects the modules no longer use, so ``transformer_layer.*`` is
+            deliberately skipped and only the fusion modules are aliased.
+
+        Cross-stage sharing is NOT supported (parameter aliasing cannot bridge PP
+        stages); on a rank with fewer than two MTP layers this is a no-op with a clear
+        warning so operators can grep the log.
+
+        Grep tags:
+          [MTP-SHARED-WEIGHTS-CONFIRM]   alias succeeded for one MTP depth
+          [MTP-SHARED-WEIGHTS-SKIP]      stage has < 2 MTP layers (nothing to share)
+          [MTP-SHARED-WEIGHTS-WARN]      partial / shape-mismatched alias
+        """
+        mtp_layers = [
+            layer
+            for layer in self.run_function
+            if isinstance(layer, MultiTokenPredictionLayer)
+        ]
+
+        if len(mtp_layers) < 2:
+            warnings.warn(
+                "[MTP-SHARED-WEIGHTS-SKIP] not applied on this PP rank: "
+                f"num_mtp_layers={len(mtp_layers)} (<2, nothing to share). "
+                "If pipeline_model_parallel_size>1 and MTP depths are on different "
+                "stages, parameter-level aliasing cannot bridge stages — use "
+                "SharedLayerDesc instead."
+            )
+            return
+
+        # Parameters already shared by SharedLayerDesc must not be re-pointed here.
+        body_owned_by_shared_layer = getattr(
+            self.config, "mtp_shared_last_layer", False
+        )
+
+        src = mtp_layers[0]
+        src_params = dict(src.named_parameters())
+
+        for mtp in mtp_layers[1:]:
+            dst_named = list(mtp.named_parameters())
+            aliased = 0
+            skipped_body = 0
+            shape_mismatch = 0
+            missing = 0
+            for dotted_name, dst_param in dst_named:
+                if body_owned_by_shared_layer and dotted_name.startswith(
+                    "transformer_layer."
+                ):
+                    skipped_body += 1
+                    continue
+                src_param = src_params.get(dotted_name)
+                if src_param is None:
+                    missing += 1
+                    continue
+                if tuple(src_param.shape) != tuple(dst_param.shape):
+                    shape_mismatch += 1
+                    continue
+                # Walk to the parent submodule and overwrite the entry in its
+                # _parameters dict so the Parameter object identity is shared.
+                parts = dotted_name.split(".")
+                owner = mtp
+                for p in parts[:-1]:
+                    owner = getattr(owner, p)
+                attr_name = parts[-1]
+                if attr_name in owner._parameters:
+                    owner._parameters[attr_name] = src_param
+                else:
+                    setattr(owner, attr_name, src_param)
+                aliased += 1
+
+            total = len(dst_named)
+            tag = "[MTP-SHARED-WEIGHTS-CONFIRM]"
+            if missing or shape_mismatch:
+                tag = "[MTP-SHARED-WEIGHTS-WARN]"
+            warnings.warn(
+                f"{tag} mtp_layer_number={mtp.layer_number} "
+                f"aliased={aliased}/{total} params to MTP depth-0 "
+                f"(missing={missing}, shape_mismatch={shape_mismatch}, "
+                f"skipped_shared_body={skipped_body}). All MTP depths are built from "
+                "the same spec, so a clean run reports aliased+skipped_shared_body"
+                "==total with missing=shape_mismatch=0."
+            )
 
     def _get_weight_only_params(self):
         """Get all parameters marked with is_weight_only_mtp flag."""

--- a/src/paddlefleet/models/gpt/lm_head.py
+++ b/src/paddlefleet/models/gpt/lm_head.py
@@ -343,8 +343,20 @@ class GPTLMHead(ColumnParallelLinear):
                 self.config.num_nextn_predict_layers + 1,
             )
             logits = [self._forward(tensor_list[0])]
+            # MTP depth sampling: depths >= K were skipped by the MTP layers this
+            # step, so their slice of hidden_states carries no MTP computation. Skip
+            # the vocab projection for them and keep a None placeholder so the list
+            # length stays num_nextn_predict_layers + 1 and the loss can detect the
+            # skipped depths. K flows in dict_args (recompute / pp / grad-accum safe).
+            sampled_depth = dict_args.get(
+                "mtp_sampled_depth", self.config.num_nextn_predict_layers
+            )
+            sampling_on = bool(getattr(self.config, "mtp_depth_sampling", None))
             for i in range(self.config.num_nextn_predict_layers):
-                logits.append(self._forward(tensor_list[i + 1]))
+                if sampling_on and i >= sampled_depth:
+                    logits.append(None)
+                else:
+                    logits.append(self._forward(tensor_list[i + 1]))
             return logits
         else:
             return self._forward(hidden_states)

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -19,6 +19,7 @@ from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+import numpy as np
 import paddle
 from paddle import Tensor, nn
 from paddle.distributed.fleet.meta_parallel import (
@@ -1349,6 +1350,31 @@ class MultiTokenPredictionLayer(FleetLayer):
 
         return outputs
 
+    def _sample_mtp_depth(self):
+        """Sample how many MTP depths K to actually run this step (prefix 1..K).
+
+        Driven by config.mtp_depth_sampling, a list P(K=k) of length
+        D=num_nextn_predict_layers. Every rank draws (so the numpy stream advances
+        identically everywhere) and the value is then overwritten with global rank
+        0's via broadcast, because all ranks must run the exact same set of depths
+        for MoE expert-parallel all-to-all to stay consistent. A broadcast failure
+        is deliberately NOT swallowed: falling back to a per-rank sample would
+        desync the depths and resurface later as an all-to-all mismatch or hang.
+        Returns D when sampling is disabled.
+        """
+        d = self.config.num_nextn_predict_layers
+        ratio = getattr(self.config, "mtp_depth_sampling", None)
+        if not ratio:
+            return d
+        probs = np.asarray(ratio, dtype="float64")
+        probs = probs / probs.sum()
+        k = int(np.random.choice(len(probs), p=probs)) + 1
+        if paddle.distributed.is_initialized():
+            t = paddle.to_tensor([k], dtype="int32")
+            paddle.distributed.broadcast(t, src=0)
+            k = int(t.item())
+        return max(1, min(k, d))
+
     def forward(self, dict_args: dict):
         # Dispatch by config.use_erndata. Under erndata the data pipeline
         # emits no mtp_startend_row_indices_all / mtp_hidden_inputs_mask_all
@@ -1369,6 +1395,30 @@ class MultiTokenPredictionLayer(FleetLayer):
             assert dict_args["packed_seq_params"] is None, (
                 "multi token prediction + sequence packing is not yet supported."
             )
+
+        # === MTP depth sampling (prefix-length sampling) ===
+        # Sample K once per micro-batch in the depth-0 layer and carry it in
+        # dict_args so it flows WITH the data. This is robust to
+        # gradient_accumulation_steps>1, pipeline_parallel and recompute: there is no
+        # shared/config state an interleaved micro-batch could overwrite, and the
+        # recompute of a layer replays the same saved dict_args. Depths >= K return
+        # early, skipping their transformer_layer forward; the LM head then emits None
+        # logits for them and the loss drops those entries.
+        if (
+            getattr(self.config, "mtp_depth_sampling", None)
+            and not self.config.enable_mtp_magic_send
+        ):
+            d = self.config.num_nextn_predict_layers
+            if self.layer_number == 0:
+                k = self._sample_mtp_depth()
+                dict_args["mtp_sampled_depth"] = k
+                # observability only, never read by the logic
+                self._last_sampled_depth = k
+            k = dict_args.get("mtp_sampled_depth", d)
+            if self.layer_number >= k:
+                # Skip this depth entirely: leave hidden_states_concat unchanged
+                # (K stays in dict_args for downstream MTP layers + the LM head).
+                return dict_args
 
         # === MTP input arrives outside hidden_states ===
         # hidden_states is the pure backbone output in both cases. The shifted MTP

--- a/src/paddlefleet/transformer/multi_token_prediction.py
+++ b/src/paddlefleet/transformer/multi_token_prediction.py
@@ -1803,7 +1803,13 @@ class MultiTokenPredictionLayer(FleetLayer):
             )
 
         if self.config.train_mtp_only:
-            for i in range(self.config.num_nextn_predict_layers):
+            sampled_depth = dict_args.get(
+                "mtp_sampled_depth", self.config.num_nextn_predict_layers
+            )
+            num_depths = min(
+                self.config.num_nextn_predict_layers, sampled_depth
+            )
+            for i in range(num_depths):
                 tensor_list = paddle.split(
                     hidden_states_concat,
                     self.config.num_nextn_predict_layers + 1,

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -189,6 +189,41 @@ class TransformerConfig(ModelParallelConfig):
     mtp_shared_last_layer: bool = False
     """When True, MTP layers share the last backbone TransformerLayer parameters."""
 
+    mtp_shared_weights: bool = False
+    """When True, all MTP depths share a single MultiTokenPredictionLayer's parameters
+    by aliasing depths 1..D-1 onto depth 0 (parameter-object aliasing, so the LayerDesc
+    tree is preserved and AOA still emits per-MTP checkpoint keys).
+
+    Composes with mtp_shared_last_layer:
+    - mtp_shared_last_layer=False: the whole MTP layer is shared across depths, i.e.
+      the internal transformer_layer body AND the per-depth fusion modules
+      (enorm / hnorm / eh_proj / norm).
+    - mtp_shared_last_layer=True: the transformer_layer body is already shared by
+      paddle's SharedLayerDesc machinery (all depths use the same "mtp_reuse_transformer"
+      key), so aliasing is restricted to the fusion modules and deliberately leaves
+      the SharedLayerDesc-managed body parameters untouched.
+
+    Cross-PP-stage sharing is NOT supported (parameter aliasing cannot bridge stages);
+    a rank holding fewer than two MTP layers logs a skip warning and does nothing.
+    No effect when num_nextn_predict_layers <= 1."""
+
+    mtp_depth_sampling: list | None = None
+    """Per-step random sampling of how many MTP depths to actually run, to keep MTP
+    compute close to num_nextn_predict_layers=1 while still training deeper depths
+    occasionally.
+    - None: disabled — always run all num_nextn_predict_layers depths (default).
+    - list[float] of length D=num_nextn_predict_layers: a probability distribution
+      P(K=k), k=1..D (must sum to 1). Each step samples a prefix length K and runs
+      only MTP depths 1..K; depths >K are skipped (no transformer_layer forward, no
+      vocab projection, no loss). The loss averages over the K computed depths, so
+      depth j's effective weight is w_j = E[1{K>=j}/K] and sum_j w_j == 1. K is
+      sampled once per micro-batch and broadcast from global rank 0 so that MoE
+      expert-parallel all-to-all stays consistent across ranks.
+    Requires pipeline_model_parallel_size == 1 (rejected otherwise in __post_init__):
+    MTP layers only land on the last pipeline stage, so the rank-0 broadcast would be
+    entered by a subset of the world group. Validated at single card; not yet validated
+    at expert_model_parallel_size>1."""
+
     separate_mtp_headloss: bool = False
     """Separate MTP LMHead & Loss calculate for pipeline balance."""
 
@@ -2167,6 +2202,68 @@ class TransformerConfig(ModelParallelConfig):
                     "mtp_load_weight_only=True. GPTEmbedding does not build the "
                     "shifted MTP embeddings in that mode, so separate_mtp_input "
                     "would silently do nothing."
+                )
+
+        if self.mtp_depth_sampling is not None:
+            # Raise, not assert: ``python -O`` strips assertions, and every check
+            # below guards a path that would otherwise fail silently (sampling
+            # accepted but never applied) or much later inside the loss.
+            for _flag in (
+                "enable_mtp_magic_send",
+                "separate_mtp_headloss",
+                "mtp_distillation_loss",
+                "use_erndata",
+            ):
+                if getattr(self, _flag, False):
+                    raise ValueError(
+                        f"mtp_depth_sampling={self.mtp_depth_sampling} requires "
+                        f"{_flag}=False, got {_flag}=True. Reasons per flag: "
+                        "enable_mtp_magic_send / separate_mtp_headloss route MTP "
+                        "logits through a different LM head that emits no None "
+                        "placeholders; mtp_distillation_loss iterates every entry "
+                        "of mtp_logits and would dereference those placeholders; "
+                        "use_erndata dispatches MultiTokenPredictionLayer.forward "
+                        "to _forward_megatron_style before the sampling hook, so "
+                        "depths would silently not be skipped."
+                    )
+            _d = self.num_nextn_predict_layers
+            if (
+                not isinstance(self.mtp_depth_sampling, (list, tuple))
+                or len(self.mtp_depth_sampling) != _d
+            ):
+                raise ValueError(
+                    "mtp_depth_sampling must be a list/tuple of length "
+                    f"num_nextn_predict_layers={_d} holding P(K=k) for k=1..{_d}, "
+                    f"got {self.mtp_depth_sampling!r} of length "
+                    f"{len(self.mtp_depth_sampling) if isinstance(self.mtp_depth_sampling, (list, tuple)) else 'n/a'}"
+                )
+            if any(p < 0.0 for p in self.mtp_depth_sampling):
+                raise ValueError(
+                    "mtp_depth_sampling entries are probabilities and must all be "
+                    f">= 0, got {self.mtp_depth_sampling}"
+                )
+            _s = float(sum(self.mtp_depth_sampling))
+            if abs(_s - 1.0) >= 1e-3:
+                raise ValueError(
+                    "mtp_depth_sampling must sum to 1.0 (it is the distribution "
+                    f"P(K=k)), got sum={_s} for {self.mtp_depth_sampling}"
+                )
+            if self.pipeline_model_parallel_size > 1:
+                raise ValueError(
+                    "mtp_depth_sampling requires pipeline_model_parallel_size == 1, "
+                    f"got pipeline_model_parallel_size="
+                    f"{self.pipeline_model_parallel_size}. Two independent reasons, "
+                    "both fatal rather than degraded: (1) K is broadcast from global "
+                    "rank 0 over the default (world) group inside "
+                    "MultiTokenPredictionLayer._sample_mtp_depth, but MTP layers are "
+                    "appended after the backbone and therefore only land on the last "
+                    "pipeline stage, so only those ranks reach the collective and the "
+                    "remaining ranks never join it -> hang; (2) K rides in dict_args "
+                    "as a plain int, and paddle's stage-boundary "
+                    "convert_tensor_dict_to_tuple() assigns `.key` on every dict "
+                    "value, which fails on a non-tensor. Supporting PP needs a "
+                    "dedicated communication group for the ranks that hold MTP plus "
+                    "a tensor-typed carrier; neither is implemented yet."
                 )
 
         if self.enable_mtp_magic_send:

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 import functools
 import logging
 import math
-from numbers import Real
 from dataclasses import dataclass
+from numbers import Real
 from typing import TYPE_CHECKING, Literal
 
 import paddle.nn.functional as F

--- a/src/paddlefleet/transformer/transformer_config.py
+++ b/src/paddlefleet/transformer/transformer_config.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import functools
 import logging
 import math
+from numbers import Real
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
@@ -2236,6 +2237,16 @@ class TransformerConfig(ModelParallelConfig):
                     f"num_nextn_predict_layers={_d} holding P(K=k) for k=1..{_d}, "
                     f"got {self.mtp_depth_sampling!r} of length "
                     f"{len(self.mtp_depth_sampling) if isinstance(self.mtp_depth_sampling, (list, tuple)) else 'n/a'}"
+                )
+            if any(
+                isinstance(p, bool)
+                or not isinstance(p, Real)
+                or not math.isfinite(float(p))
+                for p in self.mtp_depth_sampling
+            ):
+                raise ValueError(
+                    "mtp_depth_sampling entries must be finite real numbers, "
+                    f"got {self.mtp_depth_sampling}"
                 )
             if any(p < 0.0 for p in self.mtp_depth_sampling):
                 raise ValueError(

--- a/tests/single_card_tests/model/test_gpt_model_mtp_shared_weights.py
+++ b/tests/single_card_tests/model/test_gpt_model_mtp_shared_weights.py
@@ -293,7 +293,9 @@ class TestMTPDepthSampling(unittest.TestCase):
     def setUpClass(cls):
         cls.strategy = _init_fleet()
 
-    def _cfg(self, mtp_depth_sampling, num_nextn=3):
+    def _cfg(
+        self, mtp_depth_sampling, num_nextn=3, train_mtp_only=False
+    ):
         return GPTConfig(
             num_hidden_layers=2,
             hidden_size=512,
@@ -324,6 +326,7 @@ class TestMTPDepthSampling(unittest.TestCase):
             num_nextn_predict_layers=num_nextn,
             use_dense_mtp=False,
             mtp_depth_sampling=mtp_depth_sampling,
+            train_mtp_only=train_mtp_only,
         )
 
     def _mtp0(self, model):
@@ -373,6 +376,21 @@ class TestMTPDepthSampling(unittest.TestCase):
         loss = _run_step(model, cfg, self.strategy)
         assert loss is not None and not paddle.isnan(loss).any(), "loss NaN"
         assert getattr(mtp0, "_last_sampled_depth", None) == 3
+
+    def test_forward_backward_train_mtp_only_k1(self):
+        """train_mtp_only must honor the sampled prefix length."""
+        cfg = self._cfg([1.0, 0.0, 0.0], train_mtp_only=True)
+        model = gpt_builder(cfg, num_stages=1)
+        mtp0 = self._mtp0(model)
+        loss = _run_step(model, cfg, self.strategy)
+        assert loss is not None and not paddle.isnan(loss).any(), "loss NaN"
+        assert getattr(mtp0, "_last_sampled_depth", None) == 1
+
+    def test_sampling_rejects_non_finite_probability(self):
+        """NaN and infinity must fail during config validation."""
+        for probs in ([float("nan"), 0.0, 1.0], [float("inf"), 0.0, 0.0]):
+            with self.assertRaises(ValueError):
+                self._cfg(probs)
 
     def test_null_baseline_runs(self):
         """mtp_depth_sampling=None (default) trains with no skip path at all."""

--- a/tests/single_card_tests/model/test_gpt_model_mtp_shared_weights.py
+++ b/tests/single_card_tests/model/test_gpt_model_mtp_shared_weights.py
@@ -1,0 +1,423 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-card tests for mtp_shared_weights and mtp_depth_sampling."""
+
+import functools
+import inspect
+import random
+import unittest
+
+import numpy as np
+import paddle
+from paddle.distributed import fleet
+from paddle.distributed.fleet.meta_parallel import (
+    NoPipelineParallel,
+    SharedLayerDesc,
+)
+
+import paddlefleet.parallel_state as ps
+from paddlefleet.gpt_builders import gpt_builder
+from paddlefleet.models.gpt import GPTConfig
+from paddlefleet.transformer.multi_token_prediction import (
+    MultiTokenPredictionLayer,
+)
+from paddlefleet.transformer.transformer_layer import TransformerLayer
+
+# mtp_shared_last_layer needs a paddle whose SharedLayerDesc understands
+# shared_submodule_weight_only (the flag paddlefleet passes for the MTP body).
+# Older paddle builds treat it as a layer kwarg and then choke on the
+# named_parameters() generator returned by transformer_layer_weights.
+PADDLE_SUPPORTS_SHARED_SUBMODULE = (
+    "shared_submodule_weight_only"
+    in inspect.signature(SharedLayerDesc.__init__).parameters
+)
+
+
+def _init_fleet():
+    seed = 46
+    random.seed(seed)
+    np.random.seed(seed)
+    paddle.seed(seed)
+    strategy = fleet.DistributedStrategy()
+    strategy.hybrid_configs = {
+        "dp_degree": 1,
+        "mp_degree": 1,
+        "pp_degree": 1,
+        "sharding_degree": 1,
+        "sep_degree": 1,
+        "cp_degree": 1,
+        "ep_degree": 1,
+        "moe_sharding_degree": 1,
+        "order": [
+            "sharding",
+            "moe_sharding",
+            "pp",
+            "sep",
+            "cp",
+            "dp",
+            "ep",
+            "mp",
+        ],
+    }
+    try:
+        fleet.init(is_collective=True, strategy=strategy)
+    except Exception:
+        # Another test class in the same process may already have done this.
+        pass
+    hcg = fleet.get_hybrid_communicate_group()
+    try:
+        ps.initialize_model_parallel(hcg)
+    except Exception:
+        pass
+    return strategy
+
+
+def _mtp_layers(model):
+    return [
+        layer
+        for layer in model.run_function
+        if isinstance(layer, MultiTokenPredictionLayer)
+    ]
+
+
+def _decoder_layers(model):
+    return [
+        layer
+        for layer in model.run_function
+        if isinstance(layer, TransformerLayer)
+    ]
+
+
+def _run_step(model, config, strategy):
+    seq = config.max_sequence_length
+    data = list(range(seq))
+    input_ids = paddle.to_tensor(data, dtype=paddle.int64).repeat((1, 1))
+    position_ids = paddle.to_tensor(data, dtype=paddle.int64).repeat((1, 1))
+    labels = paddle.to_tensor(
+        list(range(1, seq + 1)), dtype=paddle.int64
+    ).repeat((1, 1))
+    pipe = NoPipelineParallel(model, strategy)
+    return pipe.forward_backward_pipeline(
+        (
+            {"input_ids": [input_ids], "position_ids": [position_ids]},
+            [labels],
+        )
+    )
+
+
+class TestMTPSharedWeights(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.strategy = _init_fleet()
+
+    def _base_kwargs(self, num_nextn=2):
+        return {
+            "num_hidden_layers": 2,
+            "hidden_size": 512,
+            "vocab_size": 100,
+            "max_sequence_length": 64,
+            "num_attention_heads": 4,
+            "moe_expert_fusion": False,
+            "intermediate_size": 1024,
+            "normalization": "RMSNorm",
+            "hidden_dropout_prob": 0.0,
+            "attention_dropout": 0.0,
+            "n_routed_experts": 8,
+            "moe_intermediate_size": 1024,
+            "moe_token_dispatcher_type": "alltoall",
+            "n_shared_experts": 1,
+            "use_bias": False,
+            "rotary_percent": 1.0,
+            "rotary_base": 10000,
+            "rope_scaling": 1.0,
+            "init_method": functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            "output_layer_init_method": functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            "tie_word_embeddings": True,
+            "use_qk_norm": True,
+            "num_nextn_predict_layers": num_nextn,
+        }
+
+    def test_off_by_default(self):
+        """Without mtp_shared_weights every MTP depth keeps its own parameters."""
+        config = GPTConfig(**self._base_kwargs())
+        model = gpt_builder(config, num_stages=1)
+        mtp = _mtp_layers(model)
+        assert len(mtp) == 2, f"expected 2 MTP layers, got {len(mtp)}"
+        d0 = dict(mtp[0].named_parameters())
+        shared = [n for n, p in mtp[1].named_parameters() if d0.get(n) is p]
+        assert not shared, (
+            f"depths must stay independent when the flag is off, shared={shared[:5]}"
+        )
+
+    def test_shared_last_layer_false_shares_everything(self):
+        """mtp_shared_weights alone: depth 1 shares depth 0's FULL parameter set,
+        i.e. the transformer_layer body plus enorm/hnorm/eh_proj/norm."""
+        config = GPTConfig(
+            **self._base_kwargs(),
+            mtp_shared_weights=True,
+        )
+        model = gpt_builder(config, num_stages=1)
+        mtp = _mtp_layers(model)
+        assert len(mtp) == 2
+
+        d0 = dict(mtp[0].named_parameters())
+        assert d0, "MTP layer should expose parameters"
+        not_shared = [
+            name
+            for name, p in mtp[1].named_parameters()
+            if d0.get(name) is not p
+        ]
+        assert not not_shared, (
+            f"depth-1 must share ALL depth-0 params, not_shared={not_shared[:8]}"
+        )
+
+        # The body is included, and so are the fusion modules.
+        body = [n for n in d0 if n.startswith("transformer_layer.")]
+        assert body, "expected transformer_layer.* params on the MTP layer"
+        d1 = dict(mtp[1].named_parameters())
+        for fusion in ("enorm.weight", "hnorm.weight", "eh_proj.weight"):
+            assert fusion in d0, f"expected fusion param {fusion}"
+            assert d0[fusion] is d1.get(fusion), (
+                f"fusion {fusion} not shared across depths"
+            )
+
+    def test_shared_last_layer_true_skips_body_aliases_fusion(self):
+        """The mtp_shared_last_layer=True branch in isolation.
+
+        When the body is owned by paddle's SharedLayerDesc bookkeeping,
+        _alias_mtp_shared_weights must leave transformer_layer.* alone and still
+        share the fusion modules. Built here with independent depths and the flag
+        flipped afterwards, so depth-0 and depth-1 body params are DISTINCT objects
+        and a skip is therefore observable (an unguarded alias would re-point them).
+        """
+        config = GPTConfig(**self._base_kwargs())
+        model = gpt_builder(config, num_stages=1)
+        mtp = _mtp_layers(model)
+        assert len(mtp) == 2
+
+        body_before = {
+            name: p
+            for name, p in mtp[1].named_parameters()
+            if name.startswith("transformer_layer.")
+        }
+        assert body_before, "expected transformer_layer.* params"
+
+        model.config.mtp_shared_last_layer = True
+        try:
+            model._alias_mtp_shared_weights()
+        finally:
+            model.config.mtp_shared_last_layer = False
+
+        d0 = dict(mtp[0].named_parameters())
+        d1 = dict(mtp[1].named_parameters())
+
+        re_pointed = [n for n, p in body_before.items() if d1.get(n) is not p]
+        assert not re_pointed, (
+            "SharedLayerDesc-owned body params must not be re-pointed, "
+            f"re_pointed={re_pointed[:5]}"
+        )
+        fusion = [n for n in d0 if not n.startswith("transformer_layer.")]
+        assert fusion, "expected fusion params outside transformer_layer.*"
+        not_shared = [n for n in fusion if d0[n] is not d1.get(n)]
+        assert not not_shared, (
+            f"fusion modules must still be shared, not_shared={not_shared[:5]}"
+        )
+
+    @unittest.skipUnless(
+        PADDLE_SUPPORTS_SHARED_SUBMODULE,
+        "installed paddle's SharedLayerDesc lacks shared_submodule_weight_only",
+    )
+    def test_with_shared_last_layer_end_to_end(self):
+        """mtp_shared_weights + mtp_shared_last_layer: every depth's body shares
+        storage with the backbone-last layer, fusion modules shared across depths."""
+        config = GPTConfig(
+            **self._base_kwargs(),
+            mtp_shared_last_layer=True,
+            mtp_shared_weights=True,
+        )
+        model = gpt_builder(config, num_stages=1)
+        mtp = _mtp_layers(model)
+        decoder = _decoder_layers(model)
+        assert len(mtp) == 2
+        assert decoder, "model should have decoder layers"
+
+        backbone = dict(decoder[-1].transformer_layer_weights)
+        for depth, layer in enumerate(mtp):
+            for name, param in layer.transformer_layer_weights:
+                assert name in backbone, f"depth-{depth} param {name} missing"
+                assert param.data_ptr() == backbone[name].data_ptr(), (
+                    f"depth-{depth} body param {name} does not share storage "
+                    "with the backbone-last layer"
+                )
+
+        d0 = dict(mtp[0].named_parameters())
+        d1 = dict(mtp[1].named_parameters())
+        fusion = [n for n in d0 if not n.startswith("transformer_layer.")]
+        assert fusion, "expected fusion params"
+        not_shared = [n for n in fusion if d0[n] is not d1.get(n)]
+        assert not not_shared, (
+            f"fusion modules not shared across depths, not_shared={not_shared[:5]}"
+        )
+
+    def test_forward_backward_with_shared_weights(self):
+        """Sharing must not break the training step."""
+        config = GPTConfig(
+            **self._base_kwargs(),
+            mtp_shared_weights=True,
+        )
+        model = gpt_builder(config, num_stages=1)
+        loss = _run_step(model, config, self.strategy)
+        assert loss is not None, "no loss returned"
+        assert not paddle.isnan(loss).any(), "loss is NaN"
+        assert not paddle.isinf(loss).any(), "loss is Inf"
+
+
+class TestMTPDepthSampling(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.strategy = _init_fleet()
+
+    def _cfg(self, mtp_depth_sampling, num_nextn=3):
+        return GPTConfig(
+            num_hidden_layers=2,
+            hidden_size=512,
+            vocab_size=100,
+            max_sequence_length=64,
+            num_attention_heads=4,
+            moe_expert_fusion=False,
+            intermediate_size=1024,
+            normalization="RMSNorm",
+            hidden_dropout_prob=0.0,
+            attention_dropout=0.0,
+            n_routed_experts=8,
+            moe_intermediate_size=1024,
+            moe_token_dispatcher_type="alltoall",
+            n_shared_experts=1,
+            use_bias=False,
+            rotary_percent=1.0,
+            rotary_base=10000,
+            rope_scaling=1.0,
+            init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            output_layer_init_method=functools.partial(
+                paddle.nn.init.xavier_uniform_, gain=1.0
+            ),
+            tie_word_embeddings=True,
+            use_qk_norm=True,
+            num_nextn_predict_layers=num_nextn,
+            use_dense_mtp=False,
+            mtp_depth_sampling=mtp_depth_sampling,
+        )
+
+    def _mtp0(self, model):
+        layers = _mtp_layers(model)
+        return layers[0] if layers else None
+
+    def test_sampler_fixed_k1(self):
+        """P(K=1)=1 -> always sample K=1."""
+        cfg = self._cfg([1.0, 0.0, 0.0])
+        mtp0 = self._mtp0(gpt_builder(cfg, num_stages=1))
+        ks = [mtp0._sample_mtp_depth() for _ in range(50)]
+        assert set(ks) == {1}, f"expected all K==1, got {sorted(set(ks))}"
+
+    def test_sampler_fixed_kd(self):
+        """P(K=D)=1 -> always sample K=D (runs every depth)."""
+        cfg = self._cfg([0.0, 0.0, 1.0])
+        mtp0 = self._mtp0(gpt_builder(cfg, num_stages=1))
+        ks = [mtp0._sample_mtp_depth() for _ in range(50)]
+        assert set(ks) == {3}, f"expected all K==3, got {sorted(set(ks))}"
+
+    def test_sampler_distribution(self):
+        """Mixed distribution -> K stays in support and E[K] < D."""
+        cfg = self._cfg([0.5, 0.5, 0.0])
+        mtp0 = self._mtp0(gpt_builder(cfg, num_stages=1))
+        ks = [mtp0._sample_mtp_depth() for _ in range(400)]
+        assert set(ks) <= {1, 2}, f"K out of support: {sorted(set(ks))}"
+        assert 1 in ks and 2 in ks, f"both should appear: {sorted(set(ks))}"
+        assert sum(ks) / len(ks) < 3, "E[K] must be < D=3"
+
+    def test_forward_backward_k1(self):
+        """K=1: step runs, loss finite, depth-0 records the sampled K."""
+        cfg = self._cfg([1.0, 0.0, 0.0])
+        model = gpt_builder(cfg, num_stages=1)
+        mtp0 = self._mtp0(model)
+        loss = _run_step(model, cfg, self.strategy)
+        assert loss is not None and not paddle.isnan(loss).any(), "loss NaN"
+        assert not paddle.isinf(loss).any(), "loss Inf"
+        assert getattr(mtp0, "_last_sampled_depth", None) == 1, (
+            f"expected K==1, got {getattr(mtp0, '_last_sampled_depth', None)}"
+        )
+
+    def test_forward_backward_full(self):
+        """K=D behaves like running all depths; loss finite."""
+        cfg = self._cfg([0.0, 0.0, 1.0])
+        model = gpt_builder(cfg, num_stages=1)
+        mtp0 = self._mtp0(model)
+        loss = _run_step(model, cfg, self.strategy)
+        assert loss is not None and not paddle.isnan(loss).any(), "loss NaN"
+        assert getattr(mtp0, "_last_sampled_depth", None) == 3
+
+    def test_null_baseline_runs(self):
+        """mtp_depth_sampling=None (default) trains with no skip path at all."""
+        cfg = self._cfg(None)
+        model = gpt_builder(cfg, num_stages=1)
+        mtp0 = self._mtp0(model)
+        loss = _run_step(model, cfg, self.strategy)
+        assert loss is not None and not paddle.isnan(loss).any(), "loss NaN"
+        assert not hasattr(mtp0, "_last_sampled_depth"), (
+            "sampling state must not be set when the feature is disabled"
+        )
+        assert not hasattr(cfg, "_mtp_sampled_depth"), (
+            "no config-level sampling state should exist"
+        )
+
+    def test_lm_head_emits_none_for_skipped_depths(self):
+        """The LM head must place None at every sampled-out depth and keep the
+        list length at D+1, which is how the loss detects the skipped depths."""
+        cfg = self._cfg([1.0, 0.0, 0.0])
+        model = gpt_builder(cfg, num_stages=1)
+        captured = {}
+
+        for layer in model.run_function:
+            if type(layer).__name__ == "GPTLMHead":
+                original = layer.forward
+
+                def spy(dict_args, _orig=original):
+                    out = _orig(dict_args)
+                    captured["logits"] = out
+                    return out
+
+                layer.forward = spy
+                break
+
+        _run_step(model, cfg, self.strategy)
+        logits = captured.get("logits")
+        assert logits is not None, "LM head was not exercised"
+        assert len(logits) == cfg.num_nextn_predict_layers + 1, (
+            f"expected D+1 entries, got {len(logits)}"
+        )
+        assert logits[1] is not None, "depth 0 must be computed at K=1"
+        assert logits[2] is None and logits[3] is None, (
+            "depths >= K must be None placeholders"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/single_card_tests/test_transformer_config.py
+++ b/tests/single_card_tests/test_transformer_config.py
@@ -707,6 +707,16 @@ class TestMTPDepthSamplingValidation(unittest.TestCase):
                 mtp_depth_sampling=[1.5, -0.5],
             )
 
+    def test_non_finite_probability_rejected(self):
+        for probs in ([float("nan"), 0.0], [float("inf"), 0.0]):
+            with self.assertRaisesRegex(
+                ValueError, r"must be finite real numbers"
+            ):
+                TransformerConfig(
+                    num_nextn_predict_layers=2,
+                    mtp_depth_sampling=probs,
+                )
+
     def test_conflicting_flag_rejected(self):
         with self.assertRaisesRegex(
             ValueError, r"requires mtp_distillation_loss=False"

--- a/tests/single_card_tests/test_transformer_config.py
+++ b/tests/single_card_tests/test_transformer_config.py
@@ -656,5 +656,117 @@ class TestFlashAttnFa3Backend(unittest.TestCase):
             self.facade.set_fa3_backend("cute")
 
 
+class TestMTPDepthSamplingValidation(unittest.TestCase):
+    """__post_init__ validation for mtp_depth_sampling / mtp_shared_weights."""
+
+    def test_defaults_are_off(self):
+        config = TransformerConfig(num_nextn_predict_layers=3)
+        self.assertIsNone(config.mtp_depth_sampling)
+        self.assertFalse(config.mtp_shared_weights)
+
+    def test_valid_distribution_accepted(self):
+        config = TransformerConfig(
+            num_nextn_predict_layers=3,
+            mtp_depth_sampling=[0.6, 0.3, 0.1],
+            mtp_shared_weights=True,
+        )
+        self.assertEqual(config.mtp_depth_sampling, [0.6, 0.3, 0.1])
+        self.assertTrue(config.mtp_shared_weights)
+
+    def test_length_must_match_num_nextn_predict_layers(self):
+        with self.assertRaisesRegex(
+            ValueError, r"num_nextn_predict_layers=3"
+        ) as context:
+            TransformerConfig(
+                num_nextn_predict_layers=3,
+                mtp_depth_sampling=[0.5, 0.5],
+            )
+        self.assertIn("[0.5, 0.5]", str(context.exception))
+
+    def test_non_list_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError, r"mtp_depth_sampling must be a list/tuple"
+        ):
+            TransformerConfig(
+                num_nextn_predict_layers=1,
+                mtp_depth_sampling=1.0,
+            )
+
+    def test_must_sum_to_one(self):
+        with self.assertRaisesRegex(ValueError, r"must sum to 1.0") as context:
+            TransformerConfig(
+                num_nextn_predict_layers=2,
+                mtp_depth_sampling=[0.5, 0.9],
+            )
+        self.assertIn("sum=1.4", str(context.exception))
+
+    def test_negative_probability_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"must all be >= 0"):
+            TransformerConfig(
+                num_nextn_predict_layers=2,
+                mtp_depth_sampling=[1.5, -0.5],
+            )
+
+    def test_conflicting_flag_rejected(self):
+        with self.assertRaisesRegex(
+            ValueError, r"requires mtp_distillation_loss=False"
+        ):
+            TransformerConfig(
+                num_nextn_predict_layers=2,
+                mtp_depth_sampling=[0.5, 0.5],
+                mtp_distillation_loss=True,
+            )
+
+    def test_pipeline_parallel_rejected(self):
+        """PP>1 must be refused, not warned: only the last stage holds the MTP
+        layers, so the rank-0 broadcast would be entered by a subset of the
+        world group and the remaining ranks would never join it."""
+        with self.assertRaisesRegex(
+            ValueError,
+            r"mtp_depth_sampling requires pipeline_model_parallel_size == 1",
+        ) as context:
+            TransformerConfig(
+                num_nextn_predict_layers=2,
+                mtp_depth_sampling=[0.5, 0.5],
+                pipeline_model_parallel_size=2,
+            )
+        self.assertIn("hang", str(context.exception))
+
+    def test_pipeline_parallel_allowed_when_sampling_off(self):
+        """The rejection is scoped to mtp_depth_sampling; PP stays usable."""
+        config = TransformerConfig(
+            num_nextn_predict_layers=2,
+            pipeline_model_parallel_size=2,
+            mtp_shared_weights=True,
+        )
+        self.assertIsNone(config.mtp_depth_sampling)
+        self.assertEqual(config.pipeline_model_parallel_size, 2)
+
+    def test_validation_survives_python_optimize(self):
+        """`python -O` strips assert, so the checks must raise ValueError."""
+        code = """
+from paddlefleet.transformer.transformer_config import TransformerConfig
+
+try:
+    TransformerConfig(num_nextn_predict_layers=2, mtp_depth_sampling=[0.5, 0.9])
+except ValueError as exc:
+    if "must sum to 1.0" not in str(exc):
+        raise RuntimeError(f"incomplete validation error: {exc}")
+else:
+    raise RuntimeError("mtp_depth_sampling summing to 1.4 was accepted")
+"""
+        result = subprocess.run(
+            [sys.executable, "-O", "-c", code],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR Category
Distributed Strategy

### PR Types
New features

### Description
Ported from the local echo-mtp branch onto the upstream "echo mtp" PR (33cadc3d), which is the only upstream commit this work targets.

mtp_shared_weights: share ONE MultiTokenPredictionLayer's parameters across all MTP depths by aliasing depths 1..D-1 onto depth 0. Composes with mtp_shared_last_layer:
  - False: aliases the transformer_layer body AND the per-depth fusion modules (enorm/hnorm/eh_proj/norm).
  - True: the body is already shared by paddle's SharedLayerDesc (all depths register the same "mtp_reuse_transformer" key), and those Parameter objects are tracked in PipelineLayer.shared_comm for the cross-stage gradient allreduce, so transformer_layer.* is skipped and only the fusion modules are aliased. Cross-PP-stage sharing is unsupported (aliasing cannot bridge stages); a rank with <2 MTP layers logs [MTP-SHARED-WEIGHTS-SKIP] and no-ops.

mtp_depth_sampling: per-step prefix-length sampling of MTP depths. Given P(K=k) of length D, sample K once per micro-batch in the depth-0 layer, broadcast from global rank 0 (keeps MoE expert-parallel all-to-all consistent) and carry it in dict_args so grad-accum / pp / recompute cannot corrupt it. Depths >= K skip the transformer_layer forward, the LM head emits None for them, and the loss drops those entries so the reduction averages over the K computed depths. Stale per-depth tracker entries are popped so sampled-out depths are not re-logged. Asserted incompatible with enable_mtp_magic_send / separate_mtp_headloss / mtp_distillation_loss.

Both default off.

Add two opt-in MTP training features on top of echo mtp:

- `mtp_shared_weights`: parameter-object aliasing so all MTP depths share one MultiTokenPredictionLayer (composes with `mtp_shared_last_layer`; cross-PP-stage sharing is rejected).
- `mtp_depth_sampling`: per-micro-batch prefix-length sampling of MTP depths from P(K=k), broadcast from global rank 0, so deeper depths are still trained occasionally at near-`num_nextn_predict_layers=1` compute cost. Incompatible combinations are rejected in config validation; NaN/inf/non-real/negative probabilities and non-normalized distributions raise `ValueError`.

Both flags default to off; existing configs are unchanged. Covered by `tests/single_card_tests/model/test_gpt_model_mtp_shared_weights.py` and `tests/single_card_tests/test_transformer_config.py`.

### 是否引起精度变化
否（两个开关默认关闭；开启 `mtp_depth_sampling` 属于有意的采样训练策略，loss 对 K 个已计算深度归一化，E[权重] 之和为 1）